### PR TITLE
2021-04-03 trace_equivalency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["mathematics", "science"]
 bitflags = "1.2"
 
 [features]
-default = ["clause_elimination", "clause_reduction", "clause_vivification", "LR_rewarding", "Luby_stabilization", "reason_side_rewarding", "rephase", "trace_equivalency"]
+default = ["clause_elimination", "clause_reduction", "clause_vivification", "LR_rewarding", "Luby_stabilization", "reason_side_rewarding", "rephase"]
 best_phases_tracking = []
 boundary_check = []
 clause_elimination = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["mathematics", "science"]
 bitflags = "1.2"
 
 [features]
-default = ["clause_elimination", "clause_reduction", "clause_vivification", "LR_rewarding", "Luby_stabilization", "reason_side_rewarding", "rephase"]
+default = ["clause_elimination", "clause_reduction", "clause_vivification", "LR_rewarding", "Luby_stabilization", "reason_side_rewarding", "rephase", "trace_equivalency"]
 best_phases_tracking = []
 boundary_check = []
 clause_elimination = []
@@ -32,8 +32,10 @@ no_IO = []
 reason_side_rewarding = []
 rephase = ["best_phases_tracking"]
 strategy_adaptation = []
+support_user_assumption = []
 trace_analysis = []
 trace_elimination = []
+trace_equivalency = []
 
 [profile.release]
 lto = "fat"

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,6 @@
-## 0.7.1, 2021-03-28
+## 0.7.1, 2021-0X-XX
 
+- NOW WORKING ON fixing a bug which has been rarely emitted by eliminator.
 - activate feature 'clause vivification'
 - activate feature 'rephase', which selects the best phases and its variants
 - delete features 'var-boosting' and 'best_phases_reuse'

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,11 @@
-## 0.7.1, 2021-0X-XX
+## 0.7.1, 2021-04-XX
 
-- NOW WORKING ON fixing a bug which has been rarely emitted by eliminator.
+- fix a bug which has been rarely emitted by eliminator.
+   - Splrs-0.7.0 shows that ans_aes_equiv_encry_3_rounds.debugged-sc2012.cnf
+     is satisfiable. But it's not.
+   - `AssignIF::propagate` skipped clause-level satisfiability checking,
+     if its watch's `blocker` held an eliminated var, which was never falsified.
+   - `ClauseDB::strengthen_by_elimination` didn't turn `LEARNT` off when a clause became a binclause.
 - activate feature 'clause vivification'
 - activate feature 'rephase', which selects the best phases and its variants
 - delete features 'var-boosting' and 'best_phases_reuse'

--- a/README.md
+++ b/README.md
@@ -144,16 +144,10 @@ unif-k3-r4.25-v360-c1530-S1028159446-096.cnf       360,1530 |time:   124.06
 s UNSATISFIABLE: cnfs/unif-k3-r4.25-v360-c1530-S1028159446-096.cnf
 ```
 
-2. Trim comments from the output
+2. Convert the drat file to a grat file.
 
 ```plain
-$ egrep -v '^[cs]' < proof.out > proof.drat
-```
-
-3. Convert the drat file to a grat file.
-
-```plain
-$ gratgen cnfs/unif-k3-r4.25-v360-c1530-S1028159446-096.cnf proof.drat -o proof.grat
+$ gratgen cnfs/unif-k3-r4.25-v360-c1530-S1028159446-096.cnf proof.out -o proof.grat
 c sizeof(cdb_t) = 4
 c sizeof(cdb_t*) = 8
 c Using RAT run heuristics
@@ -188,7 +182,7 @@ c Item list:       54569664
 c Pivots store:    8388608
 ```
 
-4. Verify it with `gratchk`
+3. Verify it with `gratchk`
 
 ```plain
 $ gratchk unsat cnfs/unif-k3-r4.25-v360-c1530-S1028159446-096.cnf proof.grat

--- a/src/assign/heap.rs
+++ b/src/assign/heap.rs
@@ -227,8 +227,8 @@ impl VarIdHeap {
     fn check(&self, s: &str) {
         let h = &mut self.heap.clone()[1..];
         let d = &mut self.idxs.clone()[1..];
-        h.sort_unstable();
-        d.sort_unstable();
+        h.sort();
+        d.sort();
         for i in 0..h.len() {
             if h[i] != i + 1 {
                 panic!("heap {} {} {:?}", i, h[i], h);

--- a/src/assign/mod.rs
+++ b/src/assign/mod.rs
@@ -67,6 +67,10 @@ pub trait AssignIF:
     fn satisfies(&self, c: &[Lit]) -> bool;
     /// return `true` is the clause is the reason of the assignment.
     fn locked(&self, c: &Clause, cid: ClauseId) -> bool;
+    /// dump the status as a CNF
+    fn dump_cnf<C>(&mut self, cdb: &C, fname: &str)
+    where
+        C: ClauseDBIF;
 }
 
 /// Reasons of assignments, two kinds

--- a/src/assign/mod.rs
+++ b/src/assign/mod.rs
@@ -208,9 +208,10 @@ pub mod property {
         NumUnassertedVar,
         NumUnassignedVar,
         NumUnreachableVar,
+        RootLevel,
     }
 
-    pub const USIZES: [Tusize; 11] = [
+    pub const USIZES: [Tusize; 12] = [
         Tusize::NumConflict,
         Tusize::NumDecision,
         Tusize::NumPropagation,
@@ -222,6 +223,7 @@ pub mod property {
         Tusize::NumUnassertedVar,
         Tusize::NumUnassignedVar,
         Tusize::NumUnreachableVar,
+        Tusize::RootLevel,
     ];
 
     impl PropertyDereference<Tusize, usize> for AssignStack {
@@ -243,6 +245,7 @@ pub mod property {
                     self.num_vars - self.num_eliminated_vars - self.trail.len()
                 }
                 Tusize::NumUnreachableVar => self.num_vars - self.num_best_assign,
+                Tusize::RootLevel => self.root_level as usize,
             }
         }
     }

--- a/src/assign/propagate.rs
+++ b/src/assign/propagate.rs
@@ -277,7 +277,9 @@ impl PropagateIF for AssignStack {
                 'next_clause: while n < source.len() {
                     let mut w = source.get_unchecked_mut(n);
                     n += 1;
+                    debug_assert!(!self.var[w.blocker.vi()].is(Flag::ELIMINATED));
                     if let Some(true) = lit_assign!(self, w.blocker) {
+                        // In this path, we use only `AssignStack::assign`.
                         continue 'next_clause;
                     }
                     // debug_assert!(!cdb[w.c].is(Flag::DEAD));
@@ -397,6 +399,7 @@ impl PropagateIF for AssignStack {
                     if cdb[w.c].is(Flag::DEAD) {
                         continue 'next_clause;
                     }
+                    debug_assert!(!self.var[w.blocker.vi()].is(Flag::ELIMINATED));
                     if let Some(true) = lit_assign!(self, w.blocker) {
                         continue 'next_clause;
                     }

--- a/src/assign/propagate.rs
+++ b/src/assign/propagate.rs
@@ -88,9 +88,10 @@ impl PropagateIF for AssignStack {
     fn assign_at_root_level(&mut self, l: Lit) -> MaybeInconsistent {
         let vi = l.vi();
         debug_assert!(vi < self.var.len());
-        self.level[vi] = 0;
         debug_assert!(!self.var[vi].is(Flag::ELIMINATED));
         debug_assert_eq!(self.root_level, self.decision_level());
+        debug_assert!(self.trail_lim.is_empty());
+        self.level[vi] = self.root_level;
         match var_assign!(self, vi) {
             None => {
                 set_assign!(self, l);

--- a/src/assign/propagate.rs
+++ b/src/assign/propagate.rs
@@ -495,9 +495,9 @@ impl AssignStack {
             }
         }
         self.build_best_at = self.num_propagation;
-	#[cfg(feature = "rephase")]
-	{
-	    self.phase_age = 0;
-	}
+        #[cfg(feature = "rephase")]
+        {
+            self.phase_age = 0;
+        }
     }
 }

--- a/src/assign/propagate.rs
+++ b/src/assign/propagate.rs
@@ -302,8 +302,6 @@ impl PropagateIF for AssignStack {
                     //
                     //## Search an un-falsified literal
                     //
-                    #[cfg(feature = "boundary_check")]
-                    assert!(*search_from < lits.len());
                     let len = lits.len();
                     // Gathering good literals at the beginning of lits.
                     for k in (*search_from..len).chain(2..*search_from) {
@@ -423,8 +421,6 @@ impl PropagateIF for AssignStack {
                     //
                     //## Search an un-falsified literal
                     //
-                    #[cfg(feature = "boundary_check")]
-                    assert!(*search_from < lits.len());
                     let len = lits.len();
                     // Gathering good literals at the beginning of lits.
                     for k in (*search_from..len).chain((2..*search_from).rev()) {

--- a/src/assign/propagate.rs
+++ b/src/assign/propagate.rs
@@ -488,7 +488,7 @@ impl AssignStack {
     /// save the current assignments as the best phases
     fn save_best_phases(&mut self) {
         #[cfg(feature = "best_phases_tracking")]
-        for l in self.trail.iter().skip(self.len_upto(0)) {
+        for l in self.trail.iter().skip(self.len_upto(self.root_level)) {
             let vi = l.vi();
             if let Some(b) = self.assign[vi] {
                 self.best_phases.insert(vi, (b, self.reason[vi]));

--- a/src/assign/select.rs
+++ b/src/assign/select.rs
@@ -93,8 +93,7 @@ impl VarSelectIF for AssignStack {
                 2 | 3 | 5 => RephasingTarget::BestPhases,
                 4 => RephasingTarget::Inverted,
                 6 => RephasingTarget::Shift,
-                x if x % 3 == 0 => RephasingTarget::BestPhases,
-                x if x % 3 == 1 => RephasingTarget::Inverted,
+                x if x % 3 == 2 => RephasingTarget::BestPhases,
                 _ => RephasingTarget::Clear,
             }
         };

--- a/src/assign/select.rs
+++ b/src/assign/select.rs
@@ -65,7 +65,7 @@ pub enum RephasingTarget {
 
 #[cfg(feature = "rephase")]
 impl std::fmt::Display for RephasingTarget {
-    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(formatter, "{:?}", self)
     }
 }

--- a/src/assign/stack.rs
+++ b/src/assign/stack.rs
@@ -362,6 +362,11 @@ impl AssignIF for AssignStack {
 
 #[cfg(feature = "boundary_check")]
 impl AssignStack {
+    // return the list of
+    // 1. literal in Clause of cid
+    // 2. its level
+    // 3. it is not assigned,  assigned by decision, or asserted.
+    // 4. value
     pub fn dump<'a, V: IntoIterator<Item = &'a Lit, IntoIter = Iter<'a, Lit>>>(
         &mut self,
         v: V,

--- a/src/assign/stack.rs
+++ b/src/assign/stack.rs
@@ -181,7 +181,9 @@ impl AssignIF for AssignStack {
         self.trail.len()
     }
     fn len_upto(&self, n: DecisionLevel) -> usize {
-        self.trail_lim[n as usize]
+        self.trail_lim
+            .get(n as usize)
+            .map_or(self.trail.len(), |n| *n)
     }
     fn stack_is_empty(&self) -> bool {
         self.trail.is_empty()
@@ -350,7 +352,7 @@ impl AssignIF for AssignStack {
                 buf.write_all(b"0\n").unwrap();
             }
             buf.write_all(b"c from trail\n").unwrap();
-            for x in &self.trail {
+            for x in self.trail.iter().take(self.len_upto(0)) {
                 buf.write_all(format!("{} 0\n", i32::from(*x)).as_bytes())
                     .unwrap();
             }

--- a/src/assign/var.rs
+++ b/src/assign/var.rs
@@ -142,6 +142,7 @@ impl AssignStack {
     pub fn make_var_eliminated(&mut self, vi: VarId) {
         if !self.var[vi].is(Flag::ELIMINATED) {
             self.var[vi].turn_on(Flag::ELIMINATED);
+            self.var[vi].timestamp = self.ordinal;
             self.set_activity(vi, 0.0);
             self.remove_from_heap(vi);
             self.num_eliminated_vars += 1;

--- a/src/assign/var.rs
+++ b/src/assign/var.rs
@@ -146,6 +146,24 @@ impl AssignStack {
             self.set_activity(vi, 0.0);
             self.remove_from_heap(vi);
             self.num_eliminated_vars += 1;
+            #[cfg(feature = "trace_elimination")]
+            {
+                let lv = self.level[vi];
+                if self.root_level == self.level[vi] && self.assign[vi].is_some() {
+                    panic!("v:{}, dl:{}", self.var[vi], self.decision_level());
+                }
+                if !(self.root_level < self.level[vi] || self.assign[vi].is_none()) {
+                    panic!(
+                        "v:{}, lvl:{} => {}, dl:{}, assign:{:?} ",
+                        self.var[vi],
+                        lv,
+                        self.level[vi],
+                        self.decision_level(),
+                        self.assign[vi],
+                    );
+                }
+                assert!(self.root_level < self.level[vi] || self.assign[vi].is_none());
+            }
         } else {
             #[cfg(feature = "boundary_check")]
             panic!("double elimination");

--- a/src/bin/splr.rs
+++ b/src/bin/splr.rs
@@ -81,7 +81,7 @@ fn main() {
     }
     let mut s = Solver::build(&config).expect("failed to load");
     let res = s.solve();
-    save_result(&s, &res, &cnf_file, ans_file);
+    save_result(&mut s, &res, &cnf_file, ans_file);
     std::process::exit(match res {
         Ok(Certificate::SAT(_)) => 10,
         Ok(Certificate::UNSAT) => 20,
@@ -90,7 +90,7 @@ fn main() {
 }
 
 fn save_result<S: AsRef<str> + std::fmt::Display>(
-    s: &Solver,
+    s: &mut Solver,
     res: &SolverResult,
     input: S,
     output: Option<PathBuf>,
@@ -157,8 +157,9 @@ fn save_result<S: AsRef<str> + std::fmt::Display>(
                 _ => (),
             }
             if s.state.config.use_certification {
-                let proof_file: PathBuf = s.state.config.io_odir.join(&s.state.config.io_pfile);
-                save_proof(&s, &input, &proof_file);
+                // let proof_file: PathBuf = s.state.config.io_odir.join(&s.state.config.io_pfile);
+                // save_proof(&s, &input, &proof_file);
+                s.save_certification();
                 println!(
                     " Certificate|file: {}",
                     s.state.config.io_pfile.to_string_lossy()
@@ -215,6 +216,7 @@ fn save_result<S: AsRef<str> + std::fmt::Display>(
     }
 }
 
+#[allow(dead_code)]
 fn save_proof<S: AsRef<str> + std::fmt::Display>(s: &Solver, input: S, output: &PathBuf) {
     let mut buf = match File::create(output) {
         Ok(out) => BufWriter::new(out),

--- a/src/bin/splr.rs
+++ b/src/bin/splr.rs
@@ -3,7 +3,8 @@ use {
     splr::{
         assign,
         cdb::{self, CertifiedRecord},
-        config, processor,
+        config::{self, CERTIFICATION_DEFAULT_FILENAME},
+        processor,
         solver::*,
         state::{self, LogF64Id, LogUsizeId},
         Config, EmaIF, PropertyDereference, PropertyReference, SolverError, VERSION,
@@ -60,7 +61,9 @@ fn main() {
         )))),
         _ => Some(config.io_odir.join(&config.io_rfile)),
     };
-    if config.io_pfile.to_string_lossy() != "proof.out" && !config.use_certification {
+    if config.io_pfile.to_string_lossy() != CERTIFICATION_DEFAULT_FILENAME
+        && !config.use_certification
+    {
         println!("Abort: You set a proof filename with '--proof' explicitly, but didn't set '--certify'. It doesn't look good.");
         return;
     }

--- a/src/cdb/db.rs
+++ b/src/cdb/db.rs
@@ -1,7 +1,5 @@
-#[cfg(feature = "strategy_adaptation")]
-use crate::state::SearchStrategy;
 use {
-    super::{CertifiedRecord, Clause, ClauseDB, ClauseDBIF, ClauseId, WatchDBIF},
+    super::{property, CertifiedRecord, Clause, ClauseDB, ClauseDBIF, ClauseId, WatchDBIF},
     crate::{assign::AssignIF, solver::SolverEvent, types::*},
     std::{
         ops::{Index, IndexMut, Range, RangeFrom},
@@ -175,9 +173,9 @@ impl Instantiate for ClauseDB {
                 // decision level must be 0 if `state.strategy.1` == `state[Stat::Conflict]`
                 match strategy {
                     (_, n) if n != num_conflict => (),
-                    (SearchStrategy::Initial, _) => (),
-                    (SearchStrategy::Generic, _) => (),
-                    (SearchStrategy::LowDecisions, _) => {
+                    (crate::state::SearchStrategy::Initial, _) => (),
+                    (crate::state::SearchStrategy::Generic, _) => (),
+                    (crate::state::SearchStrategy::LowDecisions, _) => {
                         self.co_lbd_bound = 4;
                         self.reduction_coeff =
                             (num_conflict as f64 / self.next_reduction as f64 + 1.0) as usize;
@@ -188,15 +186,15 @@ impl Instantiate for ClauseDB {
                         // This call requires 'decision level == 0'.
                         self.make_permanent(true);
                     }
-                    (SearchStrategy::HighSuccessive, _) => {
+                    (crate::state::SearchStrategy::HighSuccessive, _) => {
                         self.co_lbd_bound = 3;
                         self.first_reduction = 30000;
                         self.use_chan_seok = true;
                         // This call requires 'decision level == 0'.
                         self.make_permanent(false);
                     }
-                    (SearchStrategy::LowSuccessive, _) => (),
-                    (SearchStrategy::ManyGlues, _) => (),
+                    (crate::state::SearchStrategy::LowSuccessive, _) => (),
+                    (crate::state::SearchStrategy::ManyGlues, _) => (),
                 }
             }
             SolverEvent::NewVar => {

--- a/src/cdb/db.rs
+++ b/src/cdb/db.rs
@@ -259,10 +259,10 @@ impl ClauseDBIF for ClauseDB {
         //
         let (recycles, wss) = bin_watcher.split_at_mut(2);
         let recycled = &mut recycles[1];
-        for (i, ws) in &mut wss.iter_mut().enumerate() {
-            if !touched[i + 2] {
-                continue;
-            }
+        for ws in &mut wss.iter_mut() {
+            // if !touched[i + 2] {
+            //     continue;
+            // }
             let mut n = 0;
             while n < ws.len() {
                 let cid = ws[n].c;
@@ -290,15 +290,16 @@ impl ClauseDBIF for ClauseDB {
                 ws.detach(n);
             }
         }
+        let nrb = recycles.len();
         //
         //## normal clauses
         //
         let (recycles, wss) = watcher.split_at_mut(2);
         let recycled = &mut recycles[1];
         for (i, ws) in &mut wss.iter_mut().enumerate() {
-            if !touched[i + 2] {
-                continue;
-            }
+            // if !touched[i + 2] {
+            //     continue;
+            // }
             touched[i + 2] = false;
             let mut n = 0;
             while n < ws.len() {

--- a/src/cdb/db.rs
+++ b/src/cdb/db.rs
@@ -822,11 +822,11 @@ impl ClauseDBIF for ClauseDB {
                 if lits.len() == 2 {
                     bin_watcher[!q].register(w1);
                     bin_watcher[!r].register(w2);
+                    self.num_bi_clause += 1;
                     if c.is(Flag::LEARNT) {
                         c.turn_off(Flag::LEARNT);
                         c.rank = 1;
                         self.num_learnt -= 1;
-                        self.num_bi_clause += 1;
                         self.num_bi_learnt += 1;
                     }
                 } else {

--- a/src/cdb/mod.rs
+++ b/src/cdb/mod.rs
@@ -83,8 +83,6 @@ pub trait ClauseDBIF:
     fn mark_clause_as_used<A>(&mut self, asg: &mut A, cid: ClauseId) -> bool
     where
         A: AssignIF;
-    /// return the number of alive clauses in the database.
-    fn count(&self) -> usize;
     /// return the number of clauses which satisfy given flags and aren't DEAD.
     fn countf(&self, mask: Flag) -> usize;
     /// record a clause to unsat certification.
@@ -273,7 +271,12 @@ pub mod property {
         #[inline]
         fn derefer(&self, k: Tusize) -> usize {
             match k {
-                Tusize::NumClause => self.num_clause,
+                Tusize::NumClause => {
+                    // let n = self.clause.iter().skip(1).filter(|c| !c.is(Flag::DEAD)).count();
+                    // assert_eq!(n, self.num_clause);
+                    // n
+                    self.num_clause
+                }
                 Tusize::NumBiClause => self.num_bi_clause,
                 Tusize::NumBiLearnt => self.num_bi_learnt,
                 Tusize::NumLBD2 => self.num_lbd2,

--- a/src/cdb/mod.rs
+++ b/src/cdb/mod.rs
@@ -38,12 +38,16 @@ pub trait ClauseDBIF:
     fn iter(&self) -> Iter<'_, Clause>;
     /// return a mutable iterator.
     fn iter_mut(&mut self) -> IterMut<'_, Clause>;
+    /// return a watcher list for binclauses
+    fn bin_watcher_list(&self, l: Lit) -> &Vec<Watch>;
     /// return the list of bin_watch lists
     fn bin_watcher_lists(&self) -> &[Vec<Watch>];
-    /// return a watcher list
-    fn watcher_list(&self, l: Lit) -> &[Watch];
-    /// return the list of watch lists
+    /// return a mutable watcher list
+    fn watcher_list_mut(&mut self, l: Lit) -> &mut Vec<Watch>;
+    /// return the mutable list of watch lists
     fn watcher_lists_mut(&mut self) -> &mut [Vec<Watch>];
+    /// detach the two watches of the clause
+    fn detach_watches(&mut self, cid: ClauseId) -> (Watch, Watch);
     /// un-register a clause `cid` from clause database and make the clause dead.
     fn detach(&mut self, cid: ClauseId);
     /// check a condition to reduce.
@@ -100,10 +104,10 @@ pub trait ClauseDBIF:
     /// Otherwise returns a clause which is not satisfiable under a given assignment.
     /// Clauses with an unassigned literal are treated as falsified in `strict` mode.
     fn validate(&self, model: &[Option<bool>], strict: bool) -> Option<ClauseId>;
-    /// removes Lit `p` from Clause *self*. This is an O(n) function!
+    /// removes an eliminated Lit `p` from a clause. This is an O(n) function!
     /// This returns `true` if the clause became a unit clause.
     /// And this is called only from `Eliminator::strengthen_clause`.
-    fn strengthen(&mut self, cid: ClauseId, p: Lit) -> bool;
+    fn strengthen_by_elimination(&mut self, cid: ClauseId, p: Lit) -> bool;
     /// minimize a clause.
     fn minimize_with_biclauses<A>(&mut self, asg: &A, vec: &mut Vec<Lit>)
     where

--- a/src/cdb/mod.rs
+++ b/src/cdb/mod.rs
@@ -4,6 +4,8 @@ mod cid;
 mod clause;
 /// methods on `ClauseDB`
 mod db;
+/// methods for UNSAT certification
+mod unsat_certificate;
 /// methods on `Watch` and `WatchDB`
 mod watch;
 
@@ -11,6 +13,7 @@ pub use self::{
     cid::ClauseIdIF,
     clause::ClauseIF,
     property::*,
+    unsat_certificate::CertificationDumper,
     watch::{Watch, WatchDBIF},
 };
 
@@ -93,6 +96,8 @@ pub trait ClauseDBIF:
     fn certificate_add(&mut self, vec: &[Lit]);
     /// record a deleted clause to unsat certification.
     fn certificate_delete(&mut self, vec: &[Lit]);
+    /// save the certification record to a file.
+    fn certificate_save(&mut self);
     /// flag positive and negative literals of a var as dirty
     fn touch_var(&mut self, vi: VarId);
     /// check the number of clauses
@@ -180,6 +185,7 @@ pub struct ClauseDB {
     pub watcher: Vec<Vec<Watch>>,
     /// clause history to make certification
     pub certified: DRAT,
+    certification_store: CertificationDumper,
     /// a number of clauses to emit out-of-memory exception
     soft_limit: usize,
     /// flag for Chan Seok heuristics; this value is exported with `Export:mode`

--- a/src/cdb/unsat_certificate.rs
+++ b/src/cdb/unsat_certificate.rs
@@ -1,0 +1,100 @@
+#[cfg(not(feature = "no_IO"))]
+use std::{
+    fs::File,
+    io::{BufWriter, Write},
+    path::PathBuf,
+};
+
+use crate::types::*;
+
+#[derive(Debug)]
+pub struct CertificationDumper {
+    target: Option<PathBuf>,
+    buffer: Option<BufWriter<File>>,
+}
+
+impl Clone for CertificationDumper {
+    fn clone(&self) -> Self {
+        Self::default()
+    }
+}
+
+impl Default for CertificationDumper {
+    fn default() -> Self {
+        CertificationDumper {
+            buffer: None,
+            target: None,
+        }
+    }
+}
+
+impl Instantiate for CertificationDumper {
+    fn instantiate(config: &Config, _cnf: &CNFDescription) -> Self {
+        #[cfg(not(feature = "no_IO"))]
+        if config.use_certification {
+            let cert: PathBuf = config.io_odir.join(&config.io_pfile);
+            if let Ok(out) = File::create(&cert) {
+                return CertificationDumper {
+                    buffer: Some(BufWriter::new(out)),
+                    target: Some(cert),
+                };
+            }
+        }
+        CertificationDumper::default()
+    }
+}
+
+impl CertificationDumper {
+    #[cfg(feature = "no_IO")]
+    pub fn push_add(&mut self, _vec: &[Lit]) {}
+    #[cfg(not(feature = "no_IO"))]
+    pub fn push_add(&mut self, vec: &[Lit]) {
+        if let Some(ref mut buf) = self.buffer {
+            for l in vec {
+                if buf
+                    .write_all(format!("{} ", i32::from(*l)).as_bytes())
+                    .is_err()
+                {
+                    self.buffer = None;
+                    return;
+                }
+            }
+            if buf.write_all(b"0\n").is_err() {
+                self.buffer = None;
+            }
+        }
+    }
+    #[cfg(feature = "no_IO")]
+    pub fn push_delete(&mut self, _vec: &[Lit]) {}
+    #[cfg(not(feature = "no_IO"))]
+    pub fn push_delete(&mut self, vec: &[Lit]) {
+        if let Some(ref mut buf) = self.buffer {
+            if buf.write_all(b"d ").is_err() {
+                self.buffer = None;
+                return;
+            }
+            for l in vec {
+                if buf
+                    .write_all(format!("{} ", i32::from(*l)).as_bytes())
+                    .is_err()
+                {
+                    self.buffer = None;
+                    return;
+                }
+            }
+            if buf.write_all(b"0\n").is_err() {
+                self.buffer = None;
+            }
+        }
+    }
+    #[cfg(feature = "no_IO")]
+    pub fn close(&mut self) {}
+    #[cfg(not(feature = "no_IO"))]
+    pub fn close(&mut self) {
+        if let Some(ref mut buf) = self.buffer {
+            let _ = buf.write_all(b"0\n");
+            self.buffer = None;
+            self.target = None;
+        }
+    }
+}

--- a/src/cdb/watch.rs
+++ b/src/cdb/watch.rs
@@ -1,6 +1,10 @@
 use {super::ClauseId, crate::types::*};
 
 /// API for 'watcher list' like [`register`](`crate::cdb::WatchDBIF::register`), [`detach`](`crate::cdb::WatchDBIF::detach`), [`update_blocker`](`crate::cdb::WatchDBIF::update_blocker`) and so on.
+///
+///## WATCHING LITERAL LIST MANAGEMENT RULES:
+///  - Watching literals are lits[0] and lits[1] anytime anywhere.
+///  - Watching literals must not be eliminated vars.
 pub trait WatchDBIF {
     /// make a new 'watch', and add it to this watcher list.
     fn register(&mut self, w: Watch);

--- a/src/cdb/watch.rs
+++ b/src/cdb/watch.rs
@@ -50,8 +50,9 @@ impl WatchDBIF for Vec<Watch> {
         for w in &mut self[..] {
             if w.c == cid {
                 w.blocker = l;
-                return;
+                return Ok(());
             }
         }
+        Err(SolverError::Inconsistent)
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,8 @@
 /// Crate `config` provides solver's configuration and CLI.
 use {crate::types::DecisionLevel, std::path::PathBuf};
 
+pub const CERTIFICATION_DEFAULT_FILENAME: &str = "proof.drat";
+
 /// Configuration built from command line options
 #[derive(Clone, Debug)]
 pub struct Config {
@@ -125,7 +127,7 @@ impl Default for Config {
             splr_interface: false,
             cnf_file: PathBuf::new(),
             io_odir: PathBuf::from("."),
-            io_pfile: PathBuf::from("proof.out"),
+            io_pfile: PathBuf::from(CERTIFICATION_DEFAULT_FILENAME),
             io_rfile: PathBuf::new(),
             no_color: false,
             quiet_mode: false,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![doc(html_root_url = "https://docs.rs/splr/0.7.0")]
+#![allow(clippy::upper_case_acronyms)]
 /*!
 # A modern CDCL SAT solver in Rust
 

--- a/src/processor/eliminate.rs
+++ b/src/processor/eliminate.rs
@@ -67,8 +67,12 @@ where
                             " - eliminate_var {}: found assign {} from {}{} and {}{}",
                             vi, lit, p, cdb[*p], n, cdb[*n],
                         );
+                        match asg.assigned(lit) {
+                            Some(true) => (),
+                            Some(false) => return Err(SolverError::Inconsistent),
+                            None => asg.assign_at_root_level(lit)?,
+                        }
                         cdb.certificate_add(&*vec);
-                        asg.assign_at_root_level(lit)?;
                     }
                     2 => {
                         if !cdb.registered_bin_clause((*vec)[0], (*vec)[1]) {
@@ -79,12 +83,12 @@ where
                                 true,
                             );
                             elim.add_cid_occur(asg, cid, &mut cdb[cid], true);
+                            #[cfg(feature = "trace_elimination")]
+                            println!(
+                                " - eliminate_var {}: X {} from {} and {}",
+                                vi, cdb[cid], cdb[*p], cdb[*n],
+                            );
                         }
-                        #[cfg(feature = "trace_elimination")]
-                        println!(
-                            " - eliminate_var {}: X {} from {} and {}",
-                            vi, cdb[cid], cdb[*p], cdb[*n],
-                        );
                     }
                     _ => {
                         let cid = cdb.new_clause(

--- a/src/processor/eliminator.rs
+++ b/src/processor/eliminator.rs
@@ -382,7 +382,10 @@ impl Eliminator {
                 return Ok(());
             }
             let best = if cid.is_lifted_lit() {
-                Lit::from(cid).vi()
+                let vi = Lit::from(cid).vi();
+                debug_assert!(!asg.var(vi).is(Flag::DEAD));
+                debug_assert!(!asg.var(vi).is(Flag::ELIMINATED));
+                vi
             } else {
                 let mut tmp = cdb.derefer(cdb::property::Tusize::NumClause);
                 let c = &mut cdb[cid];

--- a/src/processor/eliminator.rs
+++ b/src/processor/eliminator.rs
@@ -384,7 +384,7 @@ impl Eliminator {
             let best = if cid.is_lifted_lit() {
                 Lit::from(cid).vi()
             } else {
-                let mut tmp = cdb.count();
+                let mut tmp = cdb.derefer(cdb::property::Tusize::NumClause);
                 let c = &mut cdb[cid];
                 c.turn_off(Flag::ENQUEUED);
                 let lits = &c.lits;
@@ -496,7 +496,7 @@ impl Eliminator {
         }
         let mut timedout: usize = {
             let nv = asg.derefer(assign::property::Tusize::NumUnassertedVar) as f64;
-            let nc = cdb.count() as f64;
+            let nc = cdb.derefer(cdb::property::Tusize::NumClause) as f64;
             (6.0 * nv.log(1.5) * nc) as usize
         };
         while self.bwdsub_assigns < asg.stack_len()

--- a/src/processor/heap.rs
+++ b/src/processor/heap.rs
@@ -272,8 +272,8 @@ impl VarOccHeap {
     fn check(&self, s: &str) {
         let h = &mut self.heap.clone()[1..];
         let d = &mut self.idxs.clone()[1..];
-        h.sort_unstable();
-        d.sort_unstable();
+        h.sort();
+        d.sort();
         for i in 0..h.len() {
             if h[i] != i + 1 {
                 panic!("heap {} {} {:?}", i, h[i], h);

--- a/src/processor/subsume.rs
+++ b/src/processor/subsume.rs
@@ -16,7 +16,7 @@ impl Eliminator {
         A: AssignIF,
         C: ClauseDBIF,
     {
-        match subsume(cdb, cid, did) {
+        match have_subsuming_lit(cdb, cid, did) {
             Some(NULL_LIT) => {
                 #[cfg(feature = "trace_elimination")]
                 println!(
@@ -44,7 +44,7 @@ impl Eliminator {
 }
 
 /// returns a literal if these clauses can be merged by the literal.
-fn subsume<C>(cdb: &mut C, cid: ClauseId, other: ClauseId) -> Option<Lit>
+fn have_subsuming_lit<C>(cdb: &mut C, cid: ClauseId, other: ClauseId) -> Option<Lit>
 where
     C: ClauseDBIF,
 {

--- a/src/processor/subsume.rs
+++ b/src/processor/subsume.rs
@@ -96,7 +96,7 @@ where
     debug_assert!(1 < cdb[cid].len());
     cdb.touch_var(l.vi());
     debug_assert!(!cid.is_none());
-    if cdb.strengthen(cid, l) {
+    if cdb.strengthen_by_elimination(cid, l) {
         // Vaporize the binary clause
         debug_assert!(2 == cdb[cid].len());
         let c0 = cdb[cid][0];

--- a/src/solver/build.rs
+++ b/src/solver/build.rs
@@ -13,7 +13,7 @@ use {
 #[cfg(not(feature = "no_IO"))]
 use std::{
     fs::File,
-    io::{BufRead, BufReader},
+    io::{BufRead, BufReader, Write},
 };
 
 /// API for SAT solver creation and modification.
@@ -94,6 +94,7 @@ pub trait SatSolverIF: Instantiate {
     /// assert_eq!(s.solve(), Ok(Certificate::SAT(vec![1, 2, 3, 4, 5, -6, 7, 8, -9])));
     /// ```
     fn add_var(&mut self) -> usize;
+    #[cfg(not(feature = "no_IO"))]
     /// make a solver and load a CNF into it.
     ///
     /// # Errors
@@ -101,10 +102,10 @@ pub trait SatSolverIF: Instantiate {
     /// * `SolverError::IOError` if it failed to load a CNF file.
     /// * `SolverError::Inconsistent` if the CNF is conflicting.
     /// * `SolverError::OutOfRange` if any literal used in the CNF is out of range for var index.
-    #[cfg(not(feature = "no_IO"))]
     fn build(config: &Config) -> Result<Solver, SolverError>;
     /// reinitialize a solver for incremental solving. **Requires 'incremental_solver' feature**
     fn reset(&mut self);
+    #[cfg(not(feature = "no_IO"))]
     /// dump the current status as a CNF
     fn dump_cnf(&self, fname: &str);
 }
@@ -245,6 +246,7 @@ impl SatSolverIF for Solver {
             cdb.new_clause(asg, &mut vec, false, false);
         }
     }
+    #[cfg(not(feature = "no_IO"))]
     fn dump_cnf(&self, fname: &str) {
         let nv = self.asg.derefer(crate::assign::property::Tusize::NumVar);
         for vi in 1..nv {

--- a/src/solver/build.rs
+++ b/src/solver/build.rs
@@ -314,7 +314,7 @@ impl Solver {
         if lits.iter().any(|l| asg.assigned(*l).is_some()) {
             cdb.certificate_add(lits);
         }
-        lits.sort_unstable();
+        lits.sort();
         let mut j = 0;
         let mut l_ = NULL_LIT; // last literal; [x, x.negate()] means tautology.
         for i in 0..lits.len() {

--- a/src/solver/build.rs
+++ b/src/solver/build.rs
@@ -106,6 +106,9 @@ pub trait SatSolverIF: Instantiate {
     /// reinitialize a solver for incremental solving. **Requires 'incremental_solver' feature**
     fn reset(&mut self);
     #[cfg(not(feature = "no_IO"))]
+    /// dump an UNSAT certification file
+    fn save_certification(&mut self);
+    #[cfg(not(feature = "no_IO"))]
     /// dump the current status as a CNF
     fn dump_cnf(&self, fname: &str);
 }
@@ -245,6 +248,11 @@ impl SatSolverIF for Solver {
         while let Some(mut vec) = tmp.pop() {
             cdb.new_clause(asg, &mut vec, false, false);
         }
+    }
+    #[cfg(not(feature = "no_IO"))]
+    /// dump an UNSAT certification file
+    fn save_certification(&mut self) {
+        self.cdb.certificate_save();
     }
     #[cfg(not(feature = "no_IO"))]
     fn dump_cnf(&self, fname: &str) {

--- a/src/solver/conflict.rs
+++ b/src/solver/conflict.rs
@@ -331,9 +331,8 @@ fn conflict_analyze(
                 let c = &cdb[cid];
 
                 #[cfg(feature = "boundary_check")]
-                assert!(
-                    0 < c.len(),
-                    format!(
+                if c.len() == 0 {
+                    panic!(
                         "Level {} I-graph reaches {}:{} for {}:{}",
                         asg.decision_level(),
                         cid,
@@ -341,7 +340,7 @@ fn conflict_analyze(
                         p,
                         asg.var(p.vi())
                     )
-                );
+                }
 
                 #[cfg(feature = "trace_analysis")]
                 println!("- handle {}", cid);
@@ -403,10 +402,9 @@ fn conflict_analyze(
             let vi = asg.stack(ti).vi();
 
             #[cfg(feature = "boundary_check")]
-            assert!(
-                vi < asg.level_ref().len(),
-                format!("ti:{}, lit:{}, len:{}", ti, asg.stack(ti), asg.stack_len())
-            );
+            if asg.level_ref().len() <= vi {
+                panic!("ti:{}, lit:{}, len:{}", ti, asg.stack(ti), asg.stack_len());
+            }
 
             let lvl = asg.level(vi);
             let v = asg.var(vi);
@@ -416,17 +414,16 @@ fn conflict_analyze(
             println!("- skip {} because it isn't flagged", asg.stack(ti));
 
             #[cfg(feature = "boundary_check")]
-            assert!(
-                0 < ti,
-                format!(
+            if 0 == ti {
+                panic!(
                     "p:{}, path_cnt:{}, lv:{}, learnt:{:?}\nconflict:{:?}",
                     p,
                     path_cnt,
                     dl,
                     asg.dump(&*learnt),
                     asg.dump(&cdb[conflicting_clause].lits),
-                ),
-            );
+                );
+            }
 
             ti -= 1;
         }

--- a/src/solver/conflict.rs
+++ b/src/solver/conflict.rs
@@ -98,10 +98,12 @@ pub fn handle_conflict(
                             let l = c.lits[i];
                             if l == decision {
                                 c.lits.swap(0, i);
-                                let mut w =
-                                    cdb.watcher_lists_mut()[usize::from(!l0)].detach_with(ci);
-                                w.blocker = l0;
-                                cdb.watcher_lists_mut()[usize::from(!decision)].register(w);
+
+                                let w = cdb.watcher_list_mut(!l0).detach_with(ci).unwrap();
+                                debug_assert_ne!(l0.vi(), decision.vi());
+                                debug_assert!(!asg.var(l0.vi()).is(Flag::ELIMINATED));
+                                debug_assert_ne!(w.blocker, l0);
+                                cdb.watcher_list_mut(!decision).register(w);
                                 break;
                             }
                         }

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -264,26 +264,6 @@ fn search(
                         }
                     }
                     asg.handle(SolverEvent::NewStabilizationStage(block_level));
-                    if last_core != num_unreachable || 0 == num_unreachable {
-                        state.log(
-                            asg.num_conflict,
-                            format!(
-                                "#cycle:{:>5}, core:{:>9}, level:{:>9},/cpr:{:>9.2}",
-                                num_cycle,
-                                num_unreachable,
-                                block_level,
-                                asg.refer(assign::property::TEma::PropagationPerConflict)
-                                    .get(),
-                            ),
-                        );
-                        last_core = num_unreachable;
-                    } else if let Some(p) = state.elapsed() {
-                        if 1.0 <= p {
-                            return Err(SolverError::TimeOut);
-                        }
-                    } else {
-                        return Err(SolverError::UndescribedError);
-                    }
                     if cdb.reduce(asg, asg.num_conflict) {
                         #[cfg(feature = "trace_equivalency")]
                         if false {
@@ -314,6 +294,26 @@ fn search(
                                 return Ok(false);
                             }
                         }
+                    }
+                    if last_core != num_unreachable || 0 == num_unreachable {
+                        state.log(
+                            asg.num_conflict,
+                            format!(
+                                "#cycle:{:>5}, core:{:>9}, level:{:>9},/cpr:{:>9.2}",
+                                num_cycle,
+                                num_unreachable,
+                                block_level,
+                                asg.refer(assign::property::TEma::PropagationPerConflict)
+                                    .get(),
+                            ),
+                        );
+                        last_core = num_unreachable;
+                    } else if let Some(p) = state.elapsed() {
+                        if 1.0 <= p {
+                            return Err(SolverError::TimeOut);
+                        }
+                    } else {
+                        return Err(SolverError::UndescribedError);
                     }
                     if next_progress < asg.num_conflict {
                         state.progress(asg, cdb, elim, rst);

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -285,9 +285,22 @@ fn search(
                         return Err(SolverError::UndescribedError);
                     }
                     if cdb.reduce(asg, asg.num_conflict) {
+                        #[cfg(feature = "trace_equivalency")]
+                        if false {
+                            state.progress(asg, cdb, elim, rst);
+                            cdb.check_consistency(asg, "before simplify");
+                        }
                         if state.config.c_ip_int <= elim.to_simplify as usize {
                             elim.activate();
                             elim.simplify(asg, cdb, rst, state)?;
+                            #[cfg(feature = "trace_equivalency")]
+                            if false {
+                                state.progress(asg, cdb, elim, rst);
+                                cdb.check_consistency(
+                                    asg,
+                                    &format!("simplify nc:{}", asg.num_conflict),
+                                );
+                            }
                         } else {
                             #[cfg(feature = "clause_vivification")]
                             if vivify(asg, cdb, elim, state).is_err() {

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -219,7 +219,7 @@ fn search(
     #[cfg(feature = "Luby_restart")]
     rst.update(ProgressUpdate::Luby);
 
-    while 0 < asg.derefer(assign::property::Tusize::NumUnassignedVar) {
+    while 0 < asg.derefer(assign::property::Tusize::NumUnassignedVar) || asg.remains() {
         if !asg.remains() {
             let lit = asg.select_decision_literal();
             asg.assign_by_decision(lit);

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -134,7 +134,9 @@ impl SolveIF for Solver {
                 }
                 let act = 1.0 / (asg.num_vars as f64).powf(0.25);
                 for vi in elim.sorted_iterator() {
-                    asg.set_activity(*vi, act);
+                    if !asg.var(*vi).is(Flag::ELIMINATED) {
+                        asg.set_activity(*vi, act);
+                    }
                 }
                 asg.rebuild_order();
             }

--- a/src/solver/vivify.rs
+++ b/src/solver/vivify.rs
@@ -46,7 +46,7 @@ pub fn vivify(
     if clauses.is_empty() {
         return Ok(());
     }
-    clauses.sort_unstable();
+    clauses.sort();
     let num_target = clauses.len();
     state[Stat::Vivification] += 1;
     let dl = asg.decision_level();

--- a/src/solver/vivify.rs
+++ b/src/solver/vivify.rs
@@ -67,6 +67,7 @@ pub fn vivify(
         if c.is(Flag::DEAD) {
             continue;
         }
+        assert!(!c.is(Flag::ELIMINATED));
         let is_learnt = c.is(Flag::LEARNT);
         c.vivified();
         let clits = c.lits.clone();
@@ -168,11 +169,10 @@ pub fn vivify(
                 return Err(SolverError::Inconsistent);
             }
             0 => {
-                if !cdb[cs.to()].is(Flag::DEAD) {
-                    cdb.detach(cs.to());
-                    cdb.garbage_collect();
-                    num_purge += 1;
-                }
+                assert!(!cdb[cs.to()].is(Flag::DEAD));
+                cdb.detach(cs.to());
+                cdb.garbage_collect();
+                num_purge += 1;
             }
             1 => {
                 let l0 = copied[0];

--- a/src/solver/vivify.rs
+++ b/src/solver/vivify.rs
@@ -145,7 +145,6 @@ pub fn vivify(
                         debug_assert!(cdb[cj].is(Flag::VIV_ASSUMED));
                         cdb.detach(cj);
                         debug_assert!(!asg.locked(&cdb[cj], cj));
-                        cdb.garbage_collect();
                         debug_assert!(cdb[cj].is(Flag::DEAD));
                     }
                     if !cc.is_none() {
@@ -171,7 +170,6 @@ pub fn vivify(
             0 => {
                 assert!(!cdb[cs.to()].is(Flag::DEAD));
                 cdb.detach(cs.to());
-                cdb.garbage_collect();
                 num_purge += 1;
             }
             1 => {

--- a/src/solver/vivify.rs
+++ b/src/solver/vivify.rs
@@ -67,7 +67,7 @@ pub fn vivify(
         if c.is(Flag::DEAD) {
             continue;
         }
-        assert!(!c.is(Flag::ELIMINATED));
+        debug_assert!(!c.is(Flag::ELIMINATED));
         let is_learnt = c.is(Flag::LEARNT);
         c.vivified();
         let clits = c.lits.clone();
@@ -168,7 +168,7 @@ pub fn vivify(
                 return Err(SolverError::Inconsistent);
             }
             0 => {
-                assert!(!cdb[cs.to()].is(Flag::DEAD));
+                debug_assert!(!cdb[cs.to()].is(Flag::DEAD));
                 cdb.detach(cs.to());
                 num_purge += 1;
             }

--- a/src/state.rs
+++ b/src/state.rs
@@ -171,7 +171,8 @@ pub struct State {
     pub b_lvl: Ema,
     /// EMA of conflicting levels
     pub c_lvl: Ema,
-    /// hold conflicting literals for UNSAT problems
+    #[cfg(feature = "support_user_assumption")]
+    /// hold conflicting user-defined *assumed* literals for UNSAT problems
     pub conflicts: Vec<Lit>,
     /// chronoBT threshold
     pub chrono_bt_threshold: DecisionLevel,
@@ -207,6 +208,7 @@ impl Default for State {
 
             b_lvl: Ema::new(5_000),
             c_lvl: Ema::new(5_000),
+            #[cfg(feature = "support_user_assumption")]
             conflicts: Vec::new(),
             chrono_bt_threshold: 100,
             last_asg: 0,

--- a/src/types.rs
+++ b/src/types.rs
@@ -709,13 +709,10 @@ impl<T> Delete<T> for Vec<T> {
     where
         F: FnMut(&T) -> bool,
     {
-        let mut i = 0;
-        while i != self.len() {
-            if filter(&mut self[i]) {
-                self.swap_remove(i); // self.remove(i) for stable deletion
-                break;
-            } else {
-                i += 1;
+        for (i, x) in self.iter().enumerate() {
+            if filter(x) {
+                self.swap_remove(i);
+                return;
             }
         }
     }

--- a/tests/verify-certificates.rs
+++ b/tests/verify-certificates.rs
@@ -44,11 +44,12 @@ fn main() {
                     //     exit 1;
                     // fi
                     if !out.exists() {
-                        panic!(format!(
+                        println!(
                             " FAIL TO CERTIFICATE: {} => {}",
                             cnf.file_name().unwrap().to_string_lossy(),
                             out.to_string_lossy(),
-                        ));
+                        );
+                        panic!("abort");
                     }
                     // egrep -v '^[cs]' < ${target}.out > ${target}.drat
                     Command::new("egrep")
@@ -80,11 +81,12 @@ fn main() {
                     if grat.exists() {
                         print!(" => {}", grat.to_string_lossy());
                     } else {
-                        panic!(format!(
+                        println!(
                             " FAIL TO CONVERT: {} => {}",
                             cnf.file_name().unwrap().to_string_lossy(),
                             grat.to_string_lossy(),
-                        ));
+                        );
+                        panic!("abort");
                     }
                     let mut pass = false;
                     if let Ok(out) = Command::new("gratchk")
@@ -103,11 +105,12 @@ fn main() {
                         }
                     }
                     if !pass {
-                        panic!(format!(
+                        println!(
                             " FAIL TO CERTIFICATE: {} => {}",
                             cnf.file_name().unwrap().to_string_lossy(),
                             grat.to_string_lossy(),
-                        ));
+                        );
+                        panic!("abort");
                     }
                 }
             }


### PR DESCRIPTION
- [x] add feature 'trace_equivalency'
- [x] revise AssignStack::dump_cnf
- [x] export AssignStack::root_level via derefer
- [x]  extend the definition of `AssignIF::len_upto(0)`
- [x] add feature 'support_user_assumptions'
- [x] change the definition of ClauseDB::num_clause and drop ClauseDBIF::count by making it dereferable
- [x] revise the termination condition of the search loop
- [x] `WatchDBIF::detach_with` and `update_blocker` return errors if failed to find targets
- [x] (db.rs) import SearchStrategy implicitly only under feature 'strategy_adaptation'
- [x] rename `subsume` to `have_subsuming_lit`
- [x] add `SatSolverIF::dump_cnf` if without feature 'no_IO'
- [x] (ClauseDBIF::strengthen) revise the logic to update watch list to fix the equivalency bug 💥 
- [x] all eliminated vars have appropriate timestamps and zero rewards
- [x] (reduce_db) count dead clauses
- [x] (CluaseDB) add `has_consistent_watcher` and `check_consistency` for debugging
- [x] (assign_at_root_level) set the level to self.root_level instead of `0`
- [x] (search) place a template for feature 'trace_equivalency'
- [x]  [RESOLVED]`ClauseDB::strengthen_by_elimination`, renamed from `strengthen`, updates various data correctly
- [x] (reduce_db) revise to use `ClauseDB::lbd_of_dp_ema` instead of the number of dead clauses
- [x] (vivify) call `cdb.garbage_collect` only once in each path
- [x] (select_rephasing_target) use only `RephasingTarget::BestPhases` after the incipient turbulence period
- [x] (ClauseDB) add `CertificationDumper` to dump clauses in real time
- [x] count clauses correctly

----
- [x] ~~TEMPORARILY check non-dirty watch lists  in `garbage_collect`~~
- [x] ~~TEMPORARILY (vivify) add more assertions~~

### TODO
- [x] ~~stop updating a watch list in `handle_conflict`~~
https://github.com/shnarazk/splr/blob/6bf1f40f38aed65f8d66b2bc8b3a9d6c8d9602ec/src/cdb/watch.rs#L5-L7