### PR TITLE
20210606 watch cache optimization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "splr"
-version = "0.10.0-beta1"
+version = "0.10.0-RC1"
 dependencies = [
  "bitflags",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "splr"
-version = "0.10.0-beta1"
+version = "0.10.0-RC1"
 authors = ["Narazaki Shuji <shujinarazaki@protonmail.com>"]
 description = "A modern CDCL SAT solver in Rust"
 edition = "2018"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,14 @@ bitflags = "1.2"
 
 [features]
 default = [
+           # DEBUG "boundary_check",
            "bi_clause_completion",
            "clause_elimination",
            "clause_reduction",
            "clause_vivification",
            "LR_rewarding",
            "Luby_stabilization",
+           # DEBUG "maintain_watch_cache",
            "reason_side_rewarding",
            "rephase",
            "unsafe_access"

--- a/src/assign/mod.rs
+++ b/src/assign/mod.rs
@@ -76,18 +76,24 @@ pub trait AssignIF:
 /// Reasons of assignments, two kinds
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub enum AssignReason {
-    /// One of not assigned, assigned by decision, or asserted.
-    None,
+    /// asserted
+    Asserted(usize),
+    /// Assigned by decision
+    Decision(DecisionLevel),
     /// Assigned by a clause. If it is binary, the reason literal is stored in the 2nd.
     Implication(ClauseId, Lit),
+    /// One of not assigned, assigned by decision, or asserted.
+    None,
 }
 
 impl fmt::Display for AssignReason {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            AssignReason::None => write!(f, "Decision|NoAssign"),
+            AssignReason::Asserted(t) => write!(f, "Asserted at {}", t),
+            AssignReason::Decision(lvl) => write!(f, "Decided at level {}", lvl),
             AssignReason::Implication(cid, NULL_LIT) => write!(f, "Implicated by {}", cid),
             AssignReason::Implication(cid, _) => write!(f, "Implicated by B{}", cid),
+            AssignReason::None => write!(f, "Not assigned"),
         }
     }
 }

--- a/src/assign/mod.rs
+++ b/src/assign/mod.rs
@@ -91,8 +91,8 @@ impl fmt::Display for AssignReason {
         match self {
             AssignReason::Asserted(t) => write!(f, "Asserted at {}", t),
             AssignReason::Decision(lvl) => write!(f, "Decided at level {}", lvl),
-            AssignReason::Implication(cid, NULL_LIT) => write!(f, "Implicated by {}", cid),
-            AssignReason::Implication(cid, _) => write!(f, "Implicated by B{}", cid),
+            AssignReason::Implication(cid, NULL_LIT) => write!(f, "Implied by {}", cid),
+            AssignReason::Implication(cid, _) => write!(f, "Implied by B{}", cid),
             AssignReason::None => write!(f, "Not assigned"),
         }
     }

--- a/src/assign/propagate.rs
+++ b/src/assign/propagate.rs
@@ -17,7 +17,7 @@ pub trait PropagateIF {
     ///
     /// ## Warning
     /// Callers must assure the consistency after this assignment.
-    fn assign_by_implication(&mut self, l: Lit, reason: AssignReason, lv: DecisionLevel);
+    fn assign_by_implication(&mut self, l: Lit, lv: DecisionLevel, cid: ClauseId, by: Option<Lit>);
     /// unsafe assume (assign by decision); doesn't emit an exception.
     /// ## Caveat
     /// Callers have to assure the consistency after this assignment.
@@ -123,16 +123,19 @@ impl PropagateIF for AssignStack {
                 Ok(())
             }
             Some(x) if x == bool::from(l) => {
+                #[cfg(feature = "boundary_check")]
+                panic!("double assginment(assertion)");
+                #[cfg(not(feature = "boundary_check"))]
                 // Vivification tries to assign a var by propagation then can assert it.
                 // To make sure the var is asserted, we need to nullify its reason.
-                self.reason[vi] = AssignReason::None;
+                // || self.reason[vi] = AssignReason::None;
                 // self.make_var_asserted(vi);
                 Ok(())
             }
             _ => Err(SolverError::RootLevelConflict(Some(ClauseId::from(l)))),
         }
     }
-    fn assign_by_implication(&mut self, l: Lit, reason: AssignReason, lv: DecisionLevel) {
+    fn assign_by_implication(&mut self, l: Lit, lv: DecisionLevel, cid: ClauseId, by: Option<Lit>) {
         debug_assert!(usize::from(l) != 0, "Null literal is about to be enqueued");
         debug_assert!(l.vi() < self.var.len());
         // The following doesn't hold anymore by using chronoBT.
@@ -142,15 +145,24 @@ impl PropagateIF for AssignStack {
         debug_assert!(
             var_assign!(self, vi) == Some(bool::from(l)) || var_assign!(self, vi).is_none()
         );
+        debug_assert_eq!(self.assign[vi], None);
+        debug_assert_eq!(self.reason[vi], AssignReason::None);
+        debug_assert!(self.trail.iter().all(|rl| *rl != l));
         set_assign!(self, l);
         self.level[vi] = lv;
-        self.reason[vi] = reason;
+        self.reason[vi] = AssignReason::Implication(cid, by.unwrap_or(NULL_LIT));
         self.reward_at_assign(vi);
         debug_assert!(!self.trail.contains(&l));
         debug_assert!(!self.trail.contains(&!l));
         self.trail.push(l);
         if self.root_level == lv {
             self.make_var_asserted(vi);
+        }
+
+        #[cfg(feature = "boundary_check")]
+        {
+            self.var[vi].propagated_at = self.num_conflict;
+            self.var[vi].state = VarState::Assigned(self.num_conflict);
         }
     }
     fn assign_by_decision(&mut self, l: Lit) {
@@ -169,6 +181,8 @@ impl PropagateIF for AssignStack {
         self.level[vi] = dl;
         let v = &mut self.var[vi];
         debug_assert!(!v.is(Flag::ELIMINATED));
+        debug_assert_eq!(self.assign[vi], None);
+        debug_assert_eq!(self.reason[vi], AssignReason::None);
         set_assign!(self, l);
         self.reason[vi] = AssignReason::Decision(self.decision_level());
         self.reward_at_assign(vi);
@@ -186,8 +200,7 @@ impl PropagateIF for AssignStack {
         }
         // We assume that backtrack is never happened in level zero.
         let lim = self.trail_lim[lv as usize];
-        let mut ooo_propagated: Vec<Lit> = Vec::new();
-        let mut ooo_unpropagated: Vec<Lit> = Vec::new();
+        let mut unpropagated: Vec<Lit> = Vec::new();
         for i in lim..self.trail.len() {
             let l = self.trail[i];
             debug_assert!(
@@ -208,26 +221,30 @@ impl PropagateIF for AssignStack {
                     self.decision_level(),
             );
             if self.level[vi] <= lv {
-                if i < self.q_head {
-                    ooo_propagated.push(l);
-                } else {
-                    ooo_unpropagated.push(l);
-                }
+                unpropagated.push(l);
                 continue;
             }
             let v = &mut self.var[vi];
             #[cfg(feature = "debug_propagation")]
             v.turn_off(Flag::PROPAGATED);
             v.set(Flag::PHASE, var_assign!(self, vi).unwrap());
+
+            #[cfg(feature = "boundary_check")]
+            {
+                v.propagated_at = self.num_conflict;
+                v.state = VarState::Unassigned(self.num_conflict);
+            }
+
             unset_assign!(self, vi);
             self.reason[vi] = AssignReason::None;
             self.reward_at_unassign(vi);
             self.insert_heap(vi);
         }
         self.trail.truncate(lim);
-        self.trail.append(&mut ooo_propagated);
-        self.q_head = self.trail.len();
-        self.trail.append(&mut ooo_unpropagated);
+        // moved below -- self.q_head = self.trail.len();
+        // see https://github.com/shnarazk/splr/issues/117
+        self.q_head = self.trail.len().min(self.q_head);
+        self.trail.append(&mut unpropagated);
         debug_assert!(self
             .trail
             .iter()
@@ -254,7 +271,7 @@ impl PropagateIF for AssignStack {
         for i in lim..self.trail.len() {
             let l = self.trail[i];
             let vi = l.vi();
-            assert!(self.root_level < self.level[vi]);
+            debug_assert!(self.root_level < self.level[vi]);
             let v = &mut self.var[vi];
             v.set(Flag::PHASE, var_assign!(self, vi).unwrap());
             unset_assign!(self, vi);
@@ -283,34 +300,53 @@ impl PropagateIF for AssignStack {
             assert!(!self.var[p.vi()].is(Flag::PROPAGATED));
             #[cfg(feature = "debug_propagation")]
             self.var[p.vi()].turn_on(Flag::PROPAGATED);
-            let sweeping = Lit::from(usize::from(*p));
+            let propagating = Lit::from(usize::from(*p));
             let false_lit = !*p;
 
+            #[cfg(feature = "boundary_check")]
+            {
+                self.var[p.vi()].propagated_at = self.num_conflict;
+                self.var[p.vi()].state = VarState::Propagated(self.num_conflict);
+            }
             // we have to drop `p` here to use self as a mutable reference again later.
+
             //
             //## binary loop
             //
-            let bi_clause = cdb.bi_clause_map(*p);
-            for (&blocker, &cid) in bi_clause.iter() {
-                assert!(!cdb[cid].is_dead());
-                assert!(!self.var[blocker.vi()].is(Flag::ELIMINATED));
+            // Note: bi_clause_map contains clauses themselves,
+            // while the key of watch_cache is watching literals.
+            // Therefore keys to access appropriate targets have the opposite phases.
+            //
+            for (&blocker, &cid) in cdb.bi_clause_map(false_lit).iter() {
+                debug_assert!(!cdb[cid].is_dead());
+                debug_assert!(!self.var[blocker.vi()].is(Flag::ELIMINATED));
                 debug_assert_ne!(blocker, false_lit);
+
                 #[cfg(feature = "boundary_check")]
                 debug_assert_eq!(cdb[cid].len(), 2);
+
                 match lit_assign!(self, blocker) {
                     Some(true) => (),
                     Some(false) => {
                         self.dpc_ema.update(self.num_decision);
                         self.ppc_ema.update(self.num_propagation);
                         self.num_conflict += 1;
+
+                        #[cfg(feature = "boundary_check")]
+                        {
+                            cdb[cid].moved_at = Propagate::EmitConflict(self.num_conflict, blocker);
+                        }
+
                         return Some(cid);
                     }
                     None => {
-                        assert!(!cdb[cid].is_dead());
+                        debug_assert!(!cdb[cid].is_dead());
+                        debug_assert!(cdb[cid].lit0() == false_lit || cdb[cid].lit1() == false_lit);
                         self.assign_by_implication(
                             blocker,
-                            AssignReason::Implication(cid, false_lit),
-                            self.level[false_lit.vi()],
+                            self.level[propagating.vi()],
+                            cid,
+                            Some(propagating),
                         );
                     }
                 }
@@ -318,7 +354,7 @@ impl PropagateIF for AssignStack {
             //
             //## normal clause loop
             //
-            let mut source = cdb.watch_cache_iter(sweeping);
+            let mut source = cdb.watch_cache_iter(propagating);
             #[cfg(feature = "hashed_watch_cache")]
             let mut watches = source.iter();
             'next_clause: while let Some((cid, mut cached)) = {
@@ -330,24 +366,36 @@ impl PropagateIF for AssignStack {
                 {
                     source
                         .next()
-                        .map(|index| cdb.fetch_watch_cache_entry(sweeping, index))
+                        .map(|index| cdb.fetch_watch_cache_entry(propagating, index))
                 }
             } {
-                assert!(
+                debug_assert!(
                     !cdb[cid].is_dead(),
                     "dead clause in propagation: {:?}",
                     cdb.is_garbage_collected(cid),
                 );
-                assert!(!self.var[cached.vi()].is(Flag::ELIMINATED));
+                debug_assert!(!self.var[cached.vi()].is(Flag::ELIMINATED));
+                #[cfg(feature = "maintain_watch_cache")]
+                debug_assert!(
+                    cached == cdb[cid].lit0() || cached == cdb[cid].lit1(),
+                    "mismatch watch literal and its cache {}: l0 {}  l1 {}, timestamp: {:?}",
+                    cached,
+                    cdb[cid].lit0(),
+                    cdb[cid].lit1(),
+                    cdb[cid].timestamp(),
+                );
                 // FIXME: assert!(!self.var[wc.1.vi()].is(Flag::ELIMINATED));
                 // assert_ne!(other_watch.vi(), false_lit.vi());
                 // assert!(other_watch == cdb[cid].lit0() || other_watch == cdb[cid].lit1());
                 let mut other_watch_value = lit_assign!(self, cached);
-                if let Some(true) = other_watch_value {
-                    debug_assert!(!self.var[cached.vi()].is(Flag::ELIMINATED));
+                let mut updated_cache: Option<Lit> = None;
+                if Some(true) == other_watch_value {
+                    #[cfg(feature = "maintain_watch_cache")]
+                    debug_assert!(cdb[cid].lit0() == cached || cdb[cid].lit1() == cached);
+
                     // In this path, we use only `AssignStack::assign`.
                     // assert!(w.blocker == cdb[w.c].lits[0] || w.blocker == cdb[w.c].lits[1]);
-                    cdb.transform_by_restoring_watch_cache(sweeping, &mut source, None);
+                    cdb.transform_by_restoring_watch_cache(propagating, &mut source, None);
                     continue 'next_clause;
                 }
                 {
@@ -363,17 +411,24 @@ impl PropagateIF for AssignStack {
                     if cached != other {
                         cached = other;
                         other_watch_value = lit_assign!(self, other);
-                        if let Some(true) = other_watch_value {
-                            debug_assert!(!self.var[cached.vi()].is(Flag::ELIMINATED));
+                        if Some(true) == other_watch_value {
+                            debug_assert!(!self.var[other.vi()].is(Flag::ELIMINATED));
                             // In this path, we use only `AssignStack::assign`.
                             // assert!(w.blocker == cdb[w.c].lits[0] || w.blocker == cdb[w.c].lits[1]);
                             cdb.transform_by_restoring_watch_cache(
-                                sweeping,
+                                propagating,
                                 &mut source,
                                 Some(other),
                             );
+
+                            #[cfg(feature = "boundary_check")]
+                            {
+                                cdb[cid].moved_at = Propagate::CacheSatisfied(self.num_conflict);
+                            }
+
                             continue 'next_clause;
                         }
+                        updated_cache = Some(other);
                     }
                     let c = &cdb[cid];
                     debug_assert!(lit0 == false_lit || lit1 == false_lit);
@@ -390,9 +445,24 @@ impl PropagateIF for AssignStack {
                         .chain(c.iter().enumerate().skip(2).take(start - 2))
                     {
                         if lit_assign!(self, *lk) != Some(false) {
-                            cdb.detach_watch_cache(sweeping, &mut source);
+                            let new_watch = !*lk;
+                            cdb.detach_watch_cache(propagating, &mut source);
                             cdb.transform_by_updating_watch(cid, false_watch_pos, k, true);
                             cdb[cid].search_from = k + 1;
+                            debug_assert!(
+                                self.assigned(!new_watch) == Some(true)
+                                    || self.assigned(!new_watch) == None
+                            );
+
+                            #[cfg(feature = "boundary_check")]
+                            {
+                                cdb[cid].moved_at = Propagate::FindNewWatch(
+                                    self.num_conflict,
+                                    propagating,
+                                    new_watch,
+                                );
+                            }
+
                             continue 'next_clause;
                         }
                     }
@@ -400,17 +470,22 @@ impl PropagateIF for AssignStack {
                         cdb.swap_watch(cid);
                     }
                 }
-                // cdb.reregister_watch_cache(sweeping, Some(wc_proxy));
-                cdb.transform_by_restoring_watch_cache(sweeping, &mut source, None);
+                // cdb.reregister_watch_cache(propagating, Some(wc_proxy));
+                cdb.transform_by_restoring_watch_cache(propagating, &mut source, updated_cache);
                 if other_watch_value == Some(false) {
                     self.num_conflict += 1;
                     self.dpc_ema.update(self.num_decision);
                     self.ppc_ema.update(self.num_propagation);
 
                     #[cfg(feature = "hashed_watch_cache")]
-                    while cdb.reregister_watch_cache(sweeping, watches.next().deref_watch()) {}
+                    while cdb.reregister_watch_cache(propagating, watches.next().deref_watch()) {}
                     #[cfg(not(feature = "hashed_watch_cache"))]
-                    cdb.restore_detached_watch_cache(sweeping, source);
+                    cdb.restore_detached_watch_cache(propagating, source);
+
+                    #[cfg(feature = "boundary_check")]
+                    {
+                        cdb[cid].moved_at = Propagate::EmitConflict(self.num_conflict, cached);
+                    }
 
                     return Some(cid);
                 }
@@ -420,7 +495,16 @@ impl PropagateIF for AssignStack {
                     .map(|l| self.level[l.vi()])
                     .max()
                     .unwrap_or(self.root_level);
-                self.assign_by_implication(cached, AssignReason::Implication(cid, NULL_LIT), lv);
+                debug_assert_eq!(cdb[cid].lit0(), cached);
+                debug_assert_eq!(self.assigned(cached), None);
+                if other_watch_value.is_none() {
+                    self.assign_by_implication(cached, lv, cid, None);
+                }
+
+                #[cfg(feature = "boundary_check")]
+                {
+                    cdb[cid].moved_at = Propagate::BecameUnit(self.num_conflict, cached);
+                }
             }
         }
         let na = self.q_head + self.num_eliminated_vars + self.num_asserted_vars;
@@ -452,15 +536,21 @@ impl PropagateIF for AssignStack {
             assert!(!self.var[p.vi()].is(Flag::PROPAGATED));
             #[cfg(feature = "debug_propagation")]
             self.var[p.vi()].turn_on(Flag::PROPAGATED);
-            let sweeping = Lit::from(usize::from(*p));
+
+            #[cfg(feature = "boundary_check")]
+            {
+                self.var[p.vi()].propagated_at = self.num_conflict;
+                self.var[p.vi()].state = VarState::Propagated(self.num_conflict);
+            }
+
+            let propagating = Lit::from(usize::from(*p));
             let false_lit = !*p;
 
             // we have to drop `p` here to use self as a mutable reference again later.
             //
             //## binary loop
             //
-            let bi_clause = cdb.bi_clause_map(*p);
-            for (&blocker, &cid) in bi_clause.iter() {
+            for (&blocker, &cid) in cdb.bi_clause_map(false_lit).iter() {
                 assert!(!cdb[cid].is_dead());
                 debug_assert!(!self.var[blocker.vi()].is(Flag::ELIMINATED));
                 debug_assert_ne!(blocker, false_lit);
@@ -468,14 +558,14 @@ impl PropagateIF for AssignStack {
                 debug_assert_eq!(cdb[cid].len(), 2);
                 match lit_assign!(self, blocker) {
                     Some(true) => (),
-                    Some(false) => {
-                        return Some(cid);
-                    }
+                    Some(false) => return Some(cid),
                     None => {
+                        assert!(cdb[cid].lit0() == false_lit || cdb[cid].lit1() == false_lit);
                         self.assign_by_implication(
                             blocker,
-                            AssignReason::Implication(cid, false_lit),
                             self.level[false_lit.vi()],
+                            cid,
+                            Some(propagating),
                         );
                     }
                 }
@@ -483,7 +573,7 @@ impl PropagateIF for AssignStack {
             //
             //## normal clause loop
             //
-            let mut source = cdb.watch_cache_iter(sweeping);
+            let mut source = cdb.watch_cache_iter(propagating);
             #[cfg(feature = "hashed_watch_cache")]
             let mut watches = source.iter();
             'next_clause: while let Some((cid, mut cached)) = {
@@ -495,18 +585,24 @@ impl PropagateIF for AssignStack {
                 {
                     source
                         .next()
-                        .map(|index| cdb.fetch_watch_cache_entry(sweeping, index))
+                        .map(|index| cdb.fetch_watch_cache_entry(propagating, index))
                 }
             } {
                 if cdb[cid].is_dead() {
-                    source.restore_entry();
+                    cdb.transform_by_restoring_watch_cache(propagating, &mut source, None);
                     continue;
                 }
                 assert!(!self.var[cached.vi()].is(Flag::ELIMINATED));
                 let mut other_watch_value = lit_assign!(self, cached);
                 if let Some(true) = other_watch_value {
                     assert!(!self.var[cached.vi()].is(Flag::ELIMINATED));
-                    cdb.transform_by_restoring_watch_cache(sweeping, &mut source, None);
+                    cdb.transform_by_restoring_watch_cache(propagating, &mut source, None);
+
+                    #[cfg(feature = "boundary_check")]
+                    {
+                        cdb[cid].moved_at = Propagate::SandboxCacheSatisfied(self.num_conflict);
+                    }
+
                     continue 'next_clause;
                 }
                 {
@@ -522,18 +618,25 @@ impl PropagateIF for AssignStack {
                     if cached != other {
                         cached = other;
                         other_watch_value = lit_assign!(self, other);
-                        if let Some(true) = other_watch_value {
+                        if Some(true) == other_watch_value {
                             debug_assert!(!self.var[cached.vi()].is(Flag::ELIMINATED));
                             cdb.transform_by_restoring_watch_cache(
-                                sweeping,
+                                propagating,
                                 &mut source,
                                 Some(other),
                             );
+
+                            #[cfg(feature = "boundary_check")]
+                            {
+                                cdb[cid].moved_at =
+                                    Propagate::SandboxCacheSatisfied(self.num_conflict);
+                            }
+
                             continue 'next_clause;
                         }
                     }
                     let c = &cdb[cid];
-                    debug_assert!(lit0 == false_lit || lit1 == false_lit);
+                    assert!(lit0 == false_lit || lit1 == false_lit);
                     let start = c.search_from;
                     for (k, lk) in c
                         .iter()
@@ -542,9 +645,22 @@ impl PropagateIF for AssignStack {
                         .chain(c.iter().enumerate().skip(2).take(start - 2))
                     {
                         if lit_assign!(self, *lk) != Some(false) {
-                            cdb.detach_watch_cache(sweeping, &mut source);
+                            #[cfg(feature = "boundary_check")]
+                            let new_watch = !*lk;
+
+                            cdb.detach_watch_cache(propagating, &mut source);
                             cdb.transform_by_updating_watch(cid, false_watch_pos, k, true);
                             cdb[cid].search_from = k + 1;
+
+                            #[cfg(feature = "boundary_check")]
+                            {
+                                cdb[cid].moved_at = Propagate::SandboxFindNewWatch(
+                                    self.num_conflict,
+                                    false_lit,
+                                    new_watch,
+                                );
+                            }
+
                             continue 'next_clause;
                         }
                     }
@@ -552,12 +668,19 @@ impl PropagateIF for AssignStack {
                         cdb.swap_watch(cid);
                     }
                 }
-                cdb.transform_by_restoring_watch_cache(sweeping, &mut source, None);
+                cdb.transform_by_restoring_watch_cache(propagating, &mut source, None);
                 if other_watch_value == Some(false) {
                     #[cfg(feature = "hashed_watch_cache")]
-                    while cdb.reregister_watch_cache(sweeping, watches.next().deref_watch()) {}
+                    while cdb.reregister_watch_cache(propagating, watches.next().deref_watch()) {}
                     #[cfg(not(feature = "hashed_watch_cache"))]
-                    cdb.restore_detached_watch_cache(sweeping, source);
+                    cdb.restore_detached_watch_cache(propagating, source);
+
+                    #[cfg(feature = "boundary_check")]
+                    {
+                        cdb[cid].moved_at =
+                            Propagate::SandboxEmitConflict(self.num_conflict, propagating);
+                    }
+
                     return Some(cid);
                 }
                 let lv = cdb[cid]
@@ -566,8 +689,14 @@ impl PropagateIF for AssignStack {
                     .map(|l| self.level[l.vi()])
                     .max()
                     .unwrap_or(self.root_level);
-                assert!(!cdb[cid].is_dead());
-                self.assign_by_implication(cached, AssignReason::Implication(cid, NULL_LIT), lv);
+                assert_eq!(cdb[cid].lit0(), cached);
+                assert_eq!(self.assigned(cached), None);
+                self.assign_by_implication(cached, lv, cid, None);
+
+                #[cfg(feature = "boundary_check")]
+                {
+                    cdb[cid].moved_at = Propagate::SandboxBecameUnit(self.num_conflict);
+                }
             }
         }
         None
@@ -576,12 +705,21 @@ impl PropagateIF for AssignStack {
     where
         C: ClauseDBIF,
     {
-        if self.decision_level() == self.root_level && 7 < !self.trail.len() {
+        assert_eq!(self.decision_level(), self.root_level);
+        loop {
+            if self.remains() {
+                self.propagate(cdb)
+                    .map_or(Ok(()), |cc| Err(SolverError::RootLevelConflict(Some(cc))))?;
+            }
             self.propagate_at_root_level(cdb)
                 .map_or(Ok(()), |cc| Err(SolverError::RootLevelConflict(Some(cc))))?;
+            if self.remains() {
+                self.propagate(cdb)
+                    .map_or(Ok(()), |cc| Err(SolverError::RootLevelConflict(Some(cc))))?;
+            } else {
+                break;
+            }
         }
-        self.propagate(cdb)
-            .map_or(Ok(()), |cc| Err(SolverError::RootLevelConflict(Some(cc))))?;
         // wipe asserted literals from trail and increment the number of asserted vars.
         self.num_asserted_vars += self.trail.len();
         self.trail.clear();
@@ -617,11 +755,12 @@ impl AssignStack {
                     RefClause::EmptyClause => return Some(cid),
                     RefClause::RegisteredClause(_) => (),
                     RefClause::UnitClause(lit) => {
+                        assert!(self.assigned(lit).is_none());
                         cdb.certificate_add_assertion(lit);
                         if self.assign_at_root_level(lit).is_err() {
                             return Some(cid);
                         } else {
-                            assert!(!self.locked(lit, cid));
+                            assert!(!self.locked(&cdb[cid], cid));
                             cdb.remove_clause(cid);
                         }
                     }

--- a/src/assign/propagate.rs
+++ b/src/assign/propagate.rs
@@ -344,7 +344,7 @@ impl PropagateIF for AssignStack {
                 // assert!(other_watch == cdb[cid].lit0() || other_watch == cdb[cid].lit1());
                 let mut other_watch_value = lit_assign!(self, cached);
                 if let Some(true) = other_watch_value {
-                    assert!(!self.var[cached.vi()].is(Flag::ELIMINATED));
+                    debug_assert!(!self.var[cached.vi()].is(Flag::ELIMINATED));
                     // In this path, we use only `AssignStack::assign`.
                     // assert!(w.blocker == cdb[w.c].lits[0] || w.blocker == cdb[w.c].lits[1]);
                     cdb.transform_by_restoring_watch_cache(sweeping, &mut source, None);

--- a/src/assign/stack.rs
+++ b/src/assign/stack.rs
@@ -87,7 +87,7 @@ impl Instantiate for AssignStack {
         AssignStack {
             assign: vec![None; 1 + nv],
             level: vec![DecisionLevel::default(); nv + 1],
-            reason: vec![AssignReason::default(); nv + 1],
+            reason: vec![AssignReason::None; nv + 1],
             trail: Vec::with_capacity(nv),
             var_order: VarIdHeap::new(nv, nv),
 
@@ -122,7 +122,7 @@ impl Instantiate for AssignStack {
             SolverEvent::NewVar => {
                 self.assign.push(None);
                 self.level.push(DecisionLevel::default());
-                self.reason.push(AssignReason::default());
+                self.reason.push(AssignReason::None);
                 self.expand_heap();
                 self.num_vars += 1;
                 self.var.push(Var::from(self.num_vars));

--- a/src/assign/var.rs
+++ b/src/assign/var.rs
@@ -16,6 +16,11 @@ impl Default for Var {
             reward: 0.0,
             timestamp: 0,
             flags: Flag::empty(),
+
+            #[cfg(feature = "boundary_check")]
+            propagated_at: 0,
+            #[cfg(feature = "boundary_check")]
+            state: VarState::Unassigned(0),
         }
     }
 }

--- a/src/assign/var.rs
+++ b/src/assign/var.rs
@@ -158,7 +158,7 @@ impl VarManipulateIF for AssignStack {
 impl AssignStack {
     /// make a var asserted.
     pub fn make_var_asserted(&mut self, vi: VarId) {
-        self.reason[vi] = AssignReason::None;
+        self.reason[vi] = AssignReason::Asserted(self.num_conflict);
         self.var[vi].timestamp = self.ordinal;
         self.set_activity(vi, 0.0);
         self.remove_from_heap(vi);

--- a/src/cdb/clause.rs
+++ b/src/cdb/clause.rs
@@ -16,6 +16,11 @@ impl Default for Clause {
             reward: 0.0,
             timestamp: 0,
             flags: Flag::empty(),
+
+            #[cfg(feature = "boundary_check")]
+            birth: 0,
+            #[cfg(feature = "boundary_check")]
+            moved_at: Propagate::None,
         }
     }
 }
@@ -182,6 +187,11 @@ impl ClauseIF for Clause {
             self.turn_off(Flag::DERIVE20);
         }
     }
+
+    #[cfg(feature = "boundary_check")]
+    fn set_birth(&mut self, time: usize) {
+        self.birth = time;
+    }
 }
 
 impl FlagIF for Clause {
@@ -200,6 +210,19 @@ impl FlagIF for Clause {
 }
 
 impl fmt::Display for Clause {
+    #[cfg(feature = "boundary_check")]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let st = |flag, mes| if self.is(flag) { mes } else { "" };
+        write!(
+            f,
+            "{{{:?}b{}{}{}}}",
+            i32s(&self.lits),
+            self.birth,
+            st(Flag::LEARNT, ", learnt"),
+            st(Flag::ENQUEUED, ", enqueued"),
+        )
+    }
+    #[cfg(not(feature = "boundary_check"))]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let st = |flag, mes| if self.is(flag) { mes } else { "" };
         write!(

--- a/src/cdb/db.rs
+++ b/src/cdb/db.rs
@@ -903,6 +903,7 @@ impl ClauseDBIF for ClauseDB {
             debug_assert!(watch_cache[!c.lits[old]].get_watch(&cid).is_none());
         }
         //## Step:2
+        assert!(watch_cache[!c.lits[new]].iter().all(|e| e.0 != cid));
         watch_cache[!c.lits[new]].insert_watch(cid, c.lits[other]);
 
         #[cfg(feature = "maintain_watch_cache")]

--- a/src/cdb/db.rs
+++ b/src/cdb/db.rs
@@ -634,7 +634,7 @@ impl ClauseDBIF for ClauseDB {
             //
             if p == old_l0 || p == old_l1 {
                 watch_cache[!p].remove_watch(&cid);
-                watch_cache[!l1].update_or_insert_watch(cid, l0);
+                watch_cache[!l1].insert_watch(cid, l0);
                 // Here we assumed that there's no eliminated var in clause and *watch cache*.
                 // Fortunately the current implementation purges all eliminated vars completely.
             } else {
@@ -718,17 +718,17 @@ impl ClauseDBIF for ClauseDB {
             if l0 == old_l0 && l1 == old_l1 {
             } else if l0 == old_l0 {
                 watch_cache[!old_l1].remove_watch(&cid);
-                watch_cache[!l0].update_or_insert_watch(cid, l1);
-                watch_cache[!l1].update_or_insert_watch(cid, l0);
+                watch_cache[!l0].insert_watch(cid, l1);
+                watch_cache[!l1].insert_watch(cid, l0);
             } else if l0 == old_l1 {
                 watch_cache[!old_l0].remove_watch(&cid);
-                watch_cache[!l0].update_or_insert_watch(cid, l1);
-                watch_cache[!l1].update_or_insert_watch(cid, l0);
+                watch_cache[!l0].insert_watch(cid, l1);
+                watch_cache[!l1].insert_watch(cid, l0);
             } else {
                 watch_cache[!old_l0].remove_watch(&cid);
                 watch_cache[!old_l1].remove_watch(&cid);
-                watch_cache[!l0].update_or_insert_watch(cid, l1);
-                watch_cache[!l1].update_or_insert_watch(cid, l0);
+                watch_cache[!l0].insert_watch(cid, l1);
+                watch_cache[!l1].insert_watch(cid, l0);
             }
 
             if certification_store.is_active() {
@@ -839,20 +839,20 @@ impl ClauseDBIF for ClauseDB {
                 if old_l0 == l0 && old_l1 == l1 {
                 } else if old_l0 == l0 {
                     watch_cache[!old_l1].remove_watch(&cid);
-                    watch_cache[!l0].update_or_insert_watch(cid, l1);
-                    // watch_cache[!l1].update_or_insert_watch(cid, l0);
+                    watch_cache[!l0].insert_watch(cid, l1);
+                    // watch_cache[!l1].insert_watch(cid, l0);
                     watch_cache[!l1].insert_watch(cid, l0);
                 } else if old_l0 == l1 {
                     // watch_cache[!old_l0].remove_watch(&cid);
-                    // watch_cache[!l0].update_or_insert_watch(cid, l1);
+                    // watch_cache[!l0].insert_watch(cid, l1);
                     watch_cache[!l0].insert_watch(cid, l1);
-                    watch_cache[!l1].update_or_insert_watch(cid, l0);
+                    watch_cache[!l1].insert_watch(cid, l0);
                 } else {
                     watch_cache[!old_l0].remove_watch(&cid);
                     watch_cache[!old_l1].remove_watch(&cid);
-                    // watch_cache[!l0].update_or_insert_watch(cid, l1);
+                    // watch_cache[!l0].insert_watch(cid, l1);
                     watch_cache[!l0].insert_watch(cid, l1);
-                    // watch_cache[!l1].update_or_insert_watch(cid, l0);
+                    // watch_cache[!l1].insert_watch(cid, l0);
                     watch_cache[!l1].insert_watch(cid, l0);
                 }
 
@@ -907,7 +907,7 @@ impl ClauseDBIF for ClauseDB {
         #[cfg(feature = "maintain_watch_cache")]
         {
             //## Step:3
-            watcher[!c.lits[other]].update_or_insert_watch(cid, c.lits[new]);
+            watcher[!c.lits[other]].insert_watch(cid, c.lits[new]);
         }
 
         c.lits.swap(old, new);

--- a/src/cdb/db.rs
+++ b/src/cdb/db.rs
@@ -296,7 +296,7 @@ impl ClauseDBIF for ClauseDB {
         A: AssignIF,
     {
         debug_assert!(vec.iter().all(|l| !vec.contains(&!*l)), "{:?}", vec,);
-        assert!(1 < vec.len());
+        debug_assert!(1 < vec.len());
         if vec.len() == 2 {
             if let Some(cid) = self.has_bi_clause(vec[0], vec[1]) {
                 self.num_reregistration += 1;
@@ -387,7 +387,7 @@ impl ClauseDBIF for ClauseDB {
     where
         A: AssignIF,
     {
-        assert!(1 < vec.len());
+        debug_assert!(1 < vec.len());
         let mut learnt: bool = true;
         if vec.len() == 2 {
             if let Some(cid) = self.has_bi_clause(vec[0], vec[1]) {
@@ -458,7 +458,7 @@ impl ClauseDBIF for ClauseDB {
     /// remove a clause temporally
     fn detach_clause(&mut self, cid: ClauseId) -> (Lit, Lit) {
         let c = &self.clause[std::num::NonZeroU32::get(cid.ordinal) as usize];
-        assert!(1 < c.lits.len());
+        debug_assert!(1 < c.lits.len());
         let l0 = c.lit0();
         let l1 = c.lit1();
         if c.len() == 2 {
@@ -537,7 +537,7 @@ impl ClauseDBIF for ClauseDB {
 
         // self.watches(cid, "before strengthen_by_elimination");
         debug_assert!(!self[cid].is_dead());
-        assert!(1 < self[cid].len());
+        debug_assert!(1 < self[cid].len());
         let ClauseDB {
             ref mut clause,
             ref mut bi_clause,
@@ -551,7 +551,7 @@ impl ClauseDBIF for ClauseDB {
         // debug_assert!(1 < (*ch).len());
         debug_assert!(1 < usize::from(!p));
         let lits = &mut c.lits;
-        assert!(1 < lits.len());
+        debug_assert!(1 < lits.len());
         //
         //## Case:2-0
         //
@@ -619,7 +619,7 @@ impl ClauseDBIF for ClauseDB {
     }
     // Not in use so far
     fn transform_by_replacement(&mut self, cid: ClauseId, new_lits: &mut Vec<Lit>) -> RefClause {
-        assert!(1 < new_lits.len());
+        debug_assert!(1 < new_lits.len());
         //
         //## Clause transform rules
         //
@@ -628,7 +628,7 @@ impl ClauseDBIF for ClauseDB {
         // 2. a normal clause becomes a new bi-clause.             [Case:2]
         // 3. a normal clause becomes a shorter normal clause.     [Case:3]
         //
-        assert!(!self[cid].is_dead());
+        debug_assert!(!self[cid].is_dead());
         let ClauseDB {
             clause,
             bi_clause,
@@ -1036,9 +1036,9 @@ impl ClauseDBIF for ClauseDB {
     }
     fn watch_caches(&self, cid: ClauseId, mes: &str) -> (Lit, Lit) {
         // let mut _found = None;
-        assert!(!cid.is_lifted_lit());
+        debug_assert!(!cid.is_lifted_lit());
         let c = &self[cid];
-        assert!(1 < c.len());
+        debug_assert!(1 < c.len());
         let l0 = c.lits[0];
         let l1 = c.lits[1];
         let l0_blocker: Option<Lit>;

--- a/src/cdb/db.rs
+++ b/src/cdb/db.rs
@@ -908,7 +908,7 @@ impl ClauseDBIF for ClauseDB {
         #[cfg(feature = "maintain_watch_cache")]
         {
             //## Step:3
-            watcher[!c.lits[other]].insert_watch(cid, c.lits[new]);
+            watch_cache[!c.lits[other]].update_watch(cid, c.lits[new]);
         }
 
         c.lits.swap(old, new);

--- a/src/cdb/db.rs
+++ b/src/cdb/db.rs
@@ -617,6 +617,7 @@ impl ClauseDBIF for ClauseDB {
         }
         RefClause::Clause(cid)
     }
+    // Not in use so far
     fn transform_by_replacement(&mut self, cid: ClauseId, new_lits: &mut Vec<Lit>) -> RefClause {
         assert!(1 < new_lits.len());
         //
@@ -705,6 +706,7 @@ impl ClauseDBIF for ClauseDB {
         }
         RefClause::Clause(cid)
     }
+    // only used in `propagate_at_root_level`
     fn transform_by_simplification<A>(&mut self, asg: &mut A, cid: ClauseId) -> RefClause
     where
         A: AssignIF,
@@ -830,6 +832,7 @@ impl ClauseDBIF for ClauseDB {
             }
         }
     }
+    // used in `propagate`, `propagate_sandbox`, and `handle_conflict` for chronoBT
     fn transform_by_updating_watch(
         &mut self,
         cid: ClauseId,

--- a/src/cdb/db.rs
+++ b/src/cdb/db.rs
@@ -602,7 +602,7 @@ impl ClauseDBIF for ClauseDB {
             //
             if p == old_l0 || p == old_l1 {
                 watch_cache[!p].remove_watch(&cid);
-                watch_cache[!l1].insert_or_update_watch(cid, l0);
+                watch_cache[!l1].update_or_insert_watch(cid, l0);
                 // Here we assumed that there's no eliminated var in clause and *watch cache*.
                 // Fortunately the current implementation purges all eliminated vars completely.
             } else {
@@ -685,17 +685,17 @@ impl ClauseDBIF for ClauseDB {
             if l0 == old_l0 && l1 == old_l1 {
             } else if l0 == old_l0 {
                 watch_cache[!old_l1].remove_watch(&cid);
-                watch_cache[!l0].insert_or_update_watch(cid, l1);
-                watch_cache[!l1].insert_or_update_watch(cid, l0);
+                watch_cache[!l0].update_or_insert_watch(cid, l1);
+                watch_cache[!l1].update_or_insert_watch(cid, l0);
             } else if l0 == old_l1 {
                 watch_cache[!old_l0].remove_watch(&cid);
-                watch_cache[!l0].insert_or_update_watch(cid, l1);
-                watch_cache[!l1].insert_or_update_watch(cid, l0);
+                watch_cache[!l0].update_or_insert_watch(cid, l1);
+                watch_cache[!l1].update_or_insert_watch(cid, l0);
             } else {
                 watch_cache[!old_l0].remove_watch(&cid);
                 watch_cache[!old_l1].remove_watch(&cid);
-                watch_cache[!l0].insert_or_update_watch(cid, l1);
-                watch_cache[!l1].insert_or_update_watch(cid, l0);
+                watch_cache[!l0].update_or_insert_watch(cid, l1);
+                watch_cache[!l1].update_or_insert_watch(cid, l0);
             }
 
             if certification_store.is_active() {
@@ -805,20 +805,20 @@ impl ClauseDBIF for ClauseDB {
                 if old_l0 == l0 && old_l1 == l1 {
                 } else if old_l0 == l0 {
                     watch_cache[!old_l1].remove_watch(&cid);
-                    watch_cache[!l0].insert_or_update_watch(cid, l1);
-                    // watch_cache[!l1].insert_or_update_watch(cid, l0);
+                    watch_cache[!l0].update_or_insert_watch(cid, l1);
+                    // watch_cache[!l1].update_or_insert_watch(cid, l0);
                     watch_cache[!l1].insert_watch(cid, l0);
                 } else if old_l0 == l1 {
                     // watch_cache[!old_l0].remove_watch(&cid);
-                    // watch_cache[!l0].insert_or_update_watch(cid, l1);
+                    // watch_cache[!l0].update_or_insert_watch(cid, l1);
                     watch_cache[!l0].insert_watch(cid, l1);
-                    watch_cache[!l1].insert_or_update_watch(cid, l0);
+                    watch_cache[!l1].update_or_insert_watch(cid, l0);
                 } else {
                     watch_cache[!old_l0].remove_watch(&cid);
                     watch_cache[!old_l1].remove_watch(&cid);
-                    // watch_cache[!l0].insert_or_update_watch(cid, l1);
+                    // watch_cache[!l0].update_or_insert_watch(cid, l1);
                     watch_cache[!l0].insert_watch(cid, l1);
-                    // watch_cache[!l1].insert_or_update_watch(cid, l0);
+                    // watch_cache[!l1].update_or_insert_watch(cid, l0);
                     watch_cache[!l1].insert_watch(cid, l0);
                 }
 
@@ -872,7 +872,7 @@ impl ClauseDBIF for ClauseDB {
         #[cfg(feature = "maintain_watch_cache")]
         {
             //## Step:3
-            watcher[!c.lits[other]].insert_or_update_watch(cid, c.lits[new]);
+            watcher[!c.lits[other]].update_or_insert_watch(cid, c.lits[new]);
         }
 
         c.lits.swap(old, new);

--- a/src/cdb/db.rs
+++ b/src/cdb/db.rs
@@ -568,7 +568,7 @@ impl ClauseDBIF for ClauseDB {
         //
 
         // self.watches(cid, "before strengthen_by_elimination");
-        debug_assert!(!self[cid].is_dead());
+        assert!(!self[cid].is_dead());
         debug_assert!(1 < self[cid].len());
         let ClauseDB {
             ref mut clause,
@@ -660,7 +660,7 @@ impl ClauseDBIF for ClauseDB {
         // 2. a normal clause becomes a new bi-clause.             [Case:2]
         // 3. a normal clause becomes a shorter normal clause.     [Case:3]
         //
-        debug_assert!(!self[cid].is_dead());
+        assert!(!self[cid].is_dead());
         let ClauseDB {
             clause,
             bi_clause,
@@ -754,7 +754,7 @@ impl ClauseDBIF for ClauseDB {
         // 5. a normal clause becomes a new bi-clause.             [Case:3-2]
         // 5. a normal clause becomes a shorter normal clause.     [Case:3-3]
         //
-        debug_assert!(!self[cid].is_dead());
+        assert!(!self[cid].is_dead());
         // firstly sweep without consuming extra memory
         let mut need_to_shrink = false;
         for l in self[cid].iter() {
@@ -886,6 +886,7 @@ impl ClauseDBIF for ClauseDB {
         // 2. insert a new watch                  [Step:2]
         // 3. update a blocker cach e             [Step:3]
 
+        assert!(!self[cid].is_dead());
         debug_assert!(old < 2);
         debug_assert!(1 < new);
         let ClauseDB {

--- a/src/cdb/db.rs
+++ b/src/cdb/db.rs
@@ -887,8 +887,8 @@ impl ClauseDBIF for ClauseDB {
         // 3. update a blocker cach e             [Step:3]
 
         assert!(!self[cid].is_dead());
-        debug_assert!(old < 2);
-        debug_assert!(1 < new);
+        assert!(old < 2);
+        assert!(1 < new);
         let ClauseDB {
             ref mut clause,
             ref mut watch_cache,

--- a/src/cdb/db.rs
+++ b/src/cdb/db.rs
@@ -816,8 +816,10 @@ impl ClauseDBIF for ClauseDB {
                 } else {
                     watch_cache[!old_l0].remove_watch(&cid);
                     watch_cache[!old_l1].remove_watch(&cid);
-                    watch_cache[!l0].insert_or_update_watch(cid, l1);
-                    watch_cache[!l1].insert_or_update_watch(cid, l0);
+                    // watch_cache[!l0].insert_or_update_watch(cid, l1);
+                    watch_cache[!l0].insert_watch(cid, l1);
+                    // watch_cache[!l1].insert_or_update_watch(cid, l0);
+                    watch_cache[!l1].insert_watch(cid, l0);
                 }
 
                 if certification_store.is_active() {

--- a/src/cdb/db.rs
+++ b/src/cdb/db.rs
@@ -806,10 +806,12 @@ impl ClauseDBIF for ClauseDB {
                 } else if old_l0 == l0 {
                     watch_cache[!old_l1].remove_watch(&cid);
                     watch_cache[!l0].insert_or_update_watch(cid, l1);
-                    watch_cache[!l1].insert_or_update_watch(cid, l0);
+                    // watch_cache[!l1].insert_or_update_watch(cid, l0);
+                    watch_cache[!l1].insert_watch(cid, l0);
                 } else if old_l0 == l1 {
-                    watch_cache[!old_l0].remove_watch(&cid);
-                    watch_cache[!l0].insert_or_update_watch(cid, l1);
+                    // watch_cache[!old_l0].remove_watch(&cid);
+                    // watch_cache[!l0].insert_or_update_watch(cid, l1);
+                    watch_cache[!l0].insert_watch(cid, l1);
                     watch_cache[!l1].insert_or_update_watch(cid, l0);
                 } else {
                     watch_cache[!old_l0].remove_watch(&cid);

--- a/src/cdb/mod.rs
+++ b/src/cdb/mod.rs
@@ -330,7 +330,7 @@ mod tests {
 
     #[allow(dead_code)]
     fn check_watches(cdb: &ClauseDB, cid: ClauseId) {
-        let c = &cdb.clause[cid.ordinal as usize];
+        let c = &cdb.clause[std::num::NonZeroU32::get(cid.ordinal) as usize];
         if c.lits.is_empty() {
             println!("skip checking watches of an empty clause");
             return;

--- a/src/cdb/mod.rs
+++ b/src/cdb/mod.rs
@@ -76,11 +76,11 @@ pub trait ClauseDBIF:
     fn fetch_watch_cache_entry(&self, lit: Lit, index: WatchCacheProxy) -> (ClauseId, Lit);
     /// replace the mutable watcher list with an empty one, and return the list
     fn watch_cache_iter(&mut self, l: Lit) -> WatchCacheIterator;
-    /// detach the watch_cache refered by the head of a watch_cache iterator
+    /// detach the watch_cache referred by the head of a watch_cache iterator
     fn detach_watch_cache(&mut self, l: Lit, iter: &mut WatchCacheIterator);
     /// register the clause to the previous watch cache
     fn reregister_watch_cache(&mut self, l: Lit, target: Option<WatchCacheProxy>);
-    /// restorte detached watch cache
+    /// restore detached watch cache
     fn restore_detached_watch_cache(&mut self, l: Lit, wi: WatchCacheIterator);
     /// Merge two watch cache
     fn merge_watch_cache(&mut self, l: Lit, wc: WatchCache);

--- a/src/cdb/mod.rs
+++ b/src/cdb/mod.rs
@@ -67,14 +67,37 @@ pub trait ClauseDBIF:
     fn iter_mut(&mut self) -> IterMut<'_, Clause>;
     /// return a watcher list for bi-clauses
     fn bi_clause_map(&self, l: Lit) -> &BiClause;
+
+    //
+    //## abstraction to watch_cache
+    //
+
+    // get mutable reference to a watch_cache
+    fn fetch_watch_cache_entry(&self, lit: Lit, index: WatchCacheProxy) -> (ClauseId, Lit);
     /// replace the mutable watcher list with an empty one, and return the list
-    fn detach_watch_cache(&mut self, l: Lit) -> WatchCache;
+    fn watch_cache_iter(&mut self, l: Lit) -> WatchCacheIterator;
+    /// detach the watch_cache refered by the head of a watch_cache iterator
+    fn detach_watch_cache(&mut self, l: Lit, iter: &mut WatchCacheIterator);
     /// register the clause to the previous watch cache
-    fn reregister_watch_cache(&mut self, p: Lit, target: Option<(ClauseId, Lit)>) -> bool;
+    fn reregister_watch_cache(&mut self, l: Lit, target: Option<WatchCacheProxy>);
+    /// restorte detached watch cache
+    fn restore_detached_watch_cache(&mut self, l: Lit, wi: WatchCacheIterator);
     /// Merge two watch cache
-    fn merge_watch_cache(&mut self, p: Lit, wc: WatchCache);
+    fn merge_watch_cache(&mut self, l: Lit, wc: WatchCache);
     /// swap the first two literals in a clause.
     fn swap_watch(&mut self, cid: ClauseId);
+
+    //
+    //## clause transformation
+    //
+
+    /// TODO
+    fn transform_by_restoring_watch_cache(
+        &mut self,
+        l: Lit,
+        iter: &mut WatchCacheIterator,
+        p: Option<Lit>,
+    );
     /// swap i-th watch with j-th literal then update watch caches correctly
     fn transform_by_updating_watch(&mut self, cid: ClauseId, old: usize, new: usize, removed: bool);
     /// allocate a new clause and return its id.

--- a/src/cdb/watch_cache.rs
+++ b/src/cdb/watch_cache.rs
@@ -21,6 +21,7 @@ pub trait WatchCacheIF {
     fn remove_watch(&mut self, cid: &ClauseId);
     fn insert_watch(&mut self, cid: ClauseId, l: Lit);
     fn append_watch(&mut self, appendant: Self);
+    fn update_watch(&mut self, cid: ClauseId, l: Lit);
 }
 
 impl WatchCacheIF for WatchCacheHash {
@@ -37,6 +38,9 @@ impl WatchCacheIF for WatchCacheHash {
         for (k, v) in appendant.iter() {
             self.insert(*k, *v);
         }
+    }
+    fn update_watch(&mut self, _cid: ClauseId, _l: Lit) {
+        unimplemented!();
     }
 }
 
@@ -55,6 +59,14 @@ impl WatchCacheIF for WatchCacheList {
     }
     fn append_watch(&mut self, mut appendant: Self) {
         self.append(&mut appendant);
+    }
+    fn update_watch(&mut self, cid: ClauseId, l: Lit) {
+        for e in self.iter_mut() {
+            if e.0 == cid {
+                e.1 = l;
+                break;
+            }
+        }
     }
 }
 

--- a/src/cdb/watch_cache.rs
+++ b/src/cdb/watch_cache.rs
@@ -54,7 +54,7 @@ impl WatchCacheIF for WatchCacheList {
         }
     }
     fn insert_watch(&mut self, cid: ClauseId, l: Lit) {
-        debug_assert!(self.iter().all(|e| e.0 != cid));
+        assert!(self.iter().all(|e| e.0 != cid));
         self.push((cid, l));
     }
     fn append_watch(&mut self, mut appendant: Self) {

--- a/src/cdb/watch_cache.rs
+++ b/src/cdb/watch_cache.rs
@@ -20,7 +20,7 @@ pub trait WatchCacheIF {
     fn get_watch(&self, cid: &ClauseId) -> Option<&Lit>;
     fn remove_watch(&mut self, cid: &ClauseId) -> Option<Lit>;
     fn insert_watch(&mut self, cid: ClauseId, l: Lit);
-    fn insert_or_update_watch(&mut self, cid: ClauseId, l: Lit);
+    fn update_or_insert_watch(&mut self, cid: ClauseId, l: Lit);
     fn append_watch(&mut self, appendant: Self);
 }
 
@@ -34,7 +34,7 @@ impl WatchCacheIF for WatchCacheHash {
     fn insert_watch(&mut self, cid: ClauseId, l: Lit) {
         self.insert(cid, l);
     }
-    fn insert_or_update_watch(&mut self, cid: ClauseId, l: Lit) {
+    fn update_or_insert_watch(&mut self, cid: ClauseId, l: Lit) {
         self.insert(cid, l);
     }
     fn append_watch(&mut self, appendant: Self) {
@@ -65,7 +65,7 @@ impl WatchCacheIF for WatchCacheList {
     // Note: this is a (the) slow function.
     // Try to make assure the list doesn't contain it by prooving logically,
     // then you can skip call this function.
-    fn insert_or_update_watch(&mut self, cid: ClauseId, l: Lit) {
+    fn update_or_insert_watch(&mut self, cid: ClauseId, l: Lit) {
         for e in self.iter_mut() {
             if e.0 == cid {
                 e.1 = l;

--- a/src/cdb/watch_cache.rs
+++ b/src/cdb/watch_cache.rs
@@ -46,12 +46,7 @@ impl WatchCacheIF for WatchCacheHash {
 
 impl WatchCacheIF for WatchCacheList {
     fn get_watch(&self, cid: &ClauseId) -> Option<&Lit> {
-        for e in self.iter() {
-            if e.0 == *cid {
-                return Some(&e.1);
-            }
-        }
-        None
+        self.iter().find_map(|e| (e.0 == *cid).then(|| &e.1))
     }
     fn remove_watch(&mut self, cid: &ClauseId) -> Option<Lit> {
         for (i, e) in self.iter().enumerate() {
@@ -67,6 +62,9 @@ impl WatchCacheIF for WatchCacheList {
         debug_assert!(self.iter().all(|e| e.0 != cid));
         self.push((cid, l));
     }
+    // Note: this is a (the) slow function.
+    // Try to make assure the list doesn't contain it by prooving logically,
+    // then you can skip call this function.
     fn insert_or_update_watch(&mut self, cid: ClauseId, l: Lit) {
         for e in self.iter_mut() {
             if e.0 == cid {

--- a/src/cdb/watch_cache.rs
+++ b/src/cdb/watch_cache.rs
@@ -54,7 +54,7 @@ impl WatchCacheIF for WatchCacheList {
         }
     }
     fn insert_watch(&mut self, cid: ClauseId, l: Lit) {
-        assert!(self.iter().all(|e| e.0 != cid));
+        // assert!(self.iter().all(|e| e.0 != cid));
         self.push((cid, l));
     }
     fn append_watch(&mut self, mut appendant: Self) {
@@ -125,12 +125,18 @@ pub type WatchCacheProxy = usize;
 pub struct WatchCacheIterator {
     pub index: usize,
     end_at: usize,
+    checksum: usize,
 }
 
 impl Iterator for WatchCacheIterator {
     type Item = WatchCacheProxy;
     fn next(&mut self) -> Option<Self::Item> {
-        (self.index < self.end_at).then(|| self.index)
+        // assert!(self.checksum == self.end_at - self.index);
+        (self.index < self.end_at).then(|| {
+            // assert!(0 < self.checksum);
+            self.checksum -= 1;
+            self.index
+        })
     }
 }
 
@@ -139,13 +145,14 @@ impl WatchCacheIterator {
         WatchCacheIterator {
             index: 0,
             end_at: len,
+            checksum: len,
         }
     }
     pub fn restore_entry(&mut self) {
         self.index += 1;
     }
     pub fn detach_entry(&mut self) {
-        assert!(self.end_at != 0);
+        // assert!(self.end_at != 0);
         self.end_at -= 1;
     }
 }

--- a/src/cdb/watch_cache.rs
+++ b/src/cdb/watch_cache.rs
@@ -20,6 +20,11 @@ pub trait WatchCacheIF {
     fn get_watch(&self, cid: &ClauseId) -> Option<&Lit>;
     fn remove_watch(&mut self, cid: &ClauseId) -> Option<Lit>;
     fn insert_watch(&mut self, cid: ClauseId, l: Lit);
+    // used in
+    // * transform_by_elimination
+    // * transform_by_replacement
+    // * transform_by_simplification
+    // * transform_by_updating_watch under feature "maintain_watch_cache"
     fn update_or_insert_watch(&mut self, cid: ClauseId, l: Lit);
     fn append_watch(&mut self, appendant: Self);
 }

--- a/src/processor/eliminate.rs
+++ b/src/processor/eliminate.rs
@@ -89,12 +89,13 @@ where
                             return Err(SolverError::RootLevelConflict(Some(ClauseId::from(lit))))
                         }
                         None => {
+                            assert!(asg.assigned(lit).is_none());
+                            cdb.certificate_add_assertion(lit);
                             if asg.assign_at_root_level(lit).is_err() {
                                 return Err(SolverError::RootLevelConflict(Some(ClauseId::from(
                                     lit,
                                 ))));
                             }
-                            cdb.certificate_add_assertion(lit);
                         }
                     }
                 }
@@ -124,7 +125,7 @@ where
         if cdb[*cid].is_dead() {
             continue;
         }
-        assert!(!asg.locked(cdb[*cid].lit0(), *cid));
+        assert!(!asg.locked(&cdb[*cid], *cid));
         #[cfg(feature = "incremental_solver")]
         {
             if !cdb[*cid].is(Flag::LEARNT) {
@@ -138,7 +139,7 @@ where
         if cdb[*cid].is_dead() {
             continue;
         }
-        assert!(!asg.locked(cdb[*cid].lit0(), *cid));
+        assert!(!asg.locked(&cdb[*cid], *cid));
         #[cfg(feature = "incremental_solver")]
         {
             if !cdb[*cid].is(Flag::LEARNT) {

--- a/src/processor/eliminate.rs
+++ b/src/processor/eliminate.rs
@@ -124,7 +124,7 @@ where
         if cdb[*cid].is_dead() {
             continue;
         }
-        debug_assert!(!asg.locked(&cdb[*cid], *cid));
+        assert!(!asg.locked(cdb[*cid].lit0(), *cid));
         #[cfg(feature = "incremental_solver")]
         {
             if !cdb[*cid].is(Flag::LEARNT) {
@@ -138,7 +138,7 @@ where
         if cdb[*cid].is_dead() {
             continue;
         }
-        debug_assert!(!asg.locked(&cdb[*cid], *cid));
+        assert!(!asg.locked(cdb[*cid].lit0(), *cid));
         #[cfg(feature = "incremental_solver")]
         {
             if !cdb[*cid].is(Flag::LEARNT) {

--- a/src/processor/eliminator.rs
+++ b/src/processor/eliminator.rs
@@ -622,35 +622,6 @@ impl Eliminator {
         }
         Ok(())
     }
-    /// delete satisfied clauses at decision level zero.
-    pub fn eliminate_satisfied_clauses<A, C>(
-        &mut self,
-        asg: &mut A,
-        cdb: &mut C,
-        update_occur: bool,
-    ) where
-        A: AssignIF,
-        C: ClauseDBIF,
-    {
-        debug_assert_eq!(asg.decision_level(), 0);
-        self.num_sat_elimination += 1;
-        for ci in 1..cdb.len() {
-            let cid = ClauseId::from(ci);
-            if !cdb[cid].is_dead() && cdb[cid].is_satisfied_under(asg) {
-                if self.is_running() {
-                    let c = &mut cdb[cid];
-                    if update_occur {
-                        self.remove_cid_occur(asg, cid, c);
-                    }
-                    for l in c.iter() {
-                        self.enqueue_var(asg, l.vi(), true);
-                    }
-                }
-                // cdb.watches(cid, "eliminator645");
-                cdb.remove_clause(cid);
-            }
-        }
-    }
     /// remove a clause id from literal's occur list.
     pub fn remove_lit_occur<A>(&mut self, asg: &mut A, l: Lit, cid: ClauseId)
     where

--- a/src/processor/eliminator.rs
+++ b/src/processor/eliminator.rs
@@ -294,7 +294,10 @@ impl EliminateIF for Eliminator {
         {
             for v in asg.var_iter().skip(1) {
                 if asg.reason(v.index) != AssignReason::None {
-                    assert_eq!(asg.level(v.index), asg.root_level);
+                    assert_eq!(
+                        asg.level(v.index),
+                        asg.derefer(assign::property::Tusize::RootLevel) as DecisionLevel
+                    );
                     // asg.reason(v.index) = AssignReason::None;
                 }
             }

--- a/src/processor/subsume.rs
+++ b/src/processor/subsume.rs
@@ -117,7 +117,11 @@ where
             cdb.certificate_add_assertion(l0);
             elim.remove_cid_occur(asg, cid, &mut cdb[cid]);
             cdb.remove_clause(cid);
-            asg.assign_at_root_level(l0)
+            match asg.assigned(l0) {
+                None => asg.assign_at_root_level(l0),
+                Some(true) => Ok(()),
+                Some(false) => Err(SolverError::RootLevelConflict(Some(cid))),
+            }
         }
     }
 }

--- a/src/solver/build.rs
+++ b/src/solver/build.rs
@@ -182,7 +182,11 @@ impl SatSolverIF for Solver {
         }
         let lit = Lit::from(val);
         self.cdb.certificate_add_assertion(lit);
-        self.asg.assign_at_root_level(lit).map(|_| self)
+        match self.asg.assigned(lit) {
+            None => self.asg.assign_at_root_level(lit).map(|_| self),
+            Some(true) => Ok(self),
+            Some(false) => Err(SolverError::RootLevelConflict(Some(ClauseId::from(lit)))),
+        }
     }
     fn add_clause<V>(&mut self, vec: V) -> Result<&mut Solver, SolverError>
     where

--- a/src/solver/conflict.rs
+++ b/src/solver/conflict.rs
@@ -77,6 +77,14 @@ pub fn handle_conflict(
                     .all(|l| *l != decision || asg.assigned(*l).is_none()));
                 let l0 = c.lit0();
                 let l1 = c.lit1();
+                assert_ne!(
+                    2,
+                    c.len(),
+                    "biclause:{} has different levels {}-{}",
+                    cdb[ci],
+                    asg.level(cdb[ci].lit0().vi()),
+                    asg.level(cdb[ci].lit1().vi()),
+                );
                 if c.len() == 2 {
                     if decision == l0 {
                         asg.assign_by_implication(

--- a/src/solver/conflict.rs
+++ b/src/solver/conflict.rs
@@ -359,8 +359,13 @@ fn conflict_analyze(
                         if root_level == lvl {
                             continue;
                         }
-                        debug_assert!(!asg.var(vi).is(Flag::ELIMINATED));
-                        debug_assert!(asg.assign(vi).is_some());
+                        assert!(!asg.var(vi).is(Flag::ELIMINATED));
+                        assert!(
+                            asg.assign(vi).is_some(),
+                            "conflict_analysis found {} {}",
+                            asg.var(vi),
+                            asg.reason(vi),
+                        );
                         asg.var_mut(vi).turn_on(Flag::CA_SEEN);
                         if dl <= lvl {
                             // println!("- flag for {} which level is {}", q.int(), lvl);
@@ -427,7 +432,7 @@ fn conflict_analyze(
             #[cfg(feature = "boundary_check")]
             if 0 == ti {
                 panic!(
-                    "p:{}, path_cnt:{}, lv:{}, learnt:{:?}\nconflict:{:?}",
+                    "conflict_analysis broke the bottom:: lit {}, path_cnt {}, lv {}, learnt {:?}\n{:?}",
                     p,
                     path_cnt,
                     dl,

--- a/src/solver/conflict.rs
+++ b/src/solver/conflict.rs
@@ -48,6 +48,7 @@ pub fn handle_conflict(
     if use_chronobt {
         let level = asg.level_ref();
         let c = &mut cdb[ci];
+        assert!(!c.is_dead());
         let lit_count = c.iter().filter(|l| level[l.vi()] == original_dl).count();
         if 1 == lit_count {
             debug_assert!(c.iter().any(|l| level[l.vi()] == original_dl));
@@ -223,6 +224,7 @@ pub fn handle_conflict(
         let cid = new_clause.as_cid();
         state.c_lvl.update(cl as f64);
         state.b_lvl.update(bl as f64);
+        assert!(!cdb[cid].is_dead());
         asg.assign_by_implication(l0, AssignReason::Implication(cid, reason), al);
         let lbd = cdb[cid].rank;
         rst.update(ProgressUpdate::LBD(lbd));
@@ -317,6 +319,7 @@ fn conflict_analyze(
                 }
                 cdb.lbd_of_dp_ema.update(cdb[cid].rank as f64);
                 let c = &cdb[cid];
+                assert!(!c.is_dead());
 
                 #[cfg(feature = "boundary_check")]
                 if c.len() == 0 {
@@ -370,7 +373,11 @@ fn conflict_analyze(
             }
             AssignReason::None => {
                 #[cfg(feature = "boundary_check")]
-                panic!("conflict_analyze: faced AssignReason::None.");
+                panic!(
+                    "conflict_analyze: faced AssignReason::None. path_cnt {} at level {}",
+                    path_cnt,
+                    asg.level(p.vi()),
+                );
             }
         }
         // The following case was subsumed into `search`.

--- a/src/solver/conflict.rs
+++ b/src/solver/conflict.rs
@@ -416,12 +416,7 @@ fn conflict_analyze(
                     path_cnt,
                     dl,
                     asg.dump(&*learnt),
-                    asg.dump(
-                        &cdb[conflicting_clause]
-                            .iter()
-                            .map(|l| *l)
-                            .collect::<Vec<_>>()
-                    ),
+                    asg.dump(&cdb[conflicting_clause].iter().copied().collect::<Vec<_>>()),
                 );
             }
 

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -430,7 +430,7 @@ fn analyze_final(asg: &mut AssignStack, state: &mut State, c: &Clause) {
     for l in asg.stack_range(0..asg.len_upto(asg.root_level)) {
         let vi = l.vi();
         if seen[vi] {
-            if asg.reason(vi) == AssignReason::default() {
+            if let AssignReason::Decision(_) = asg.reason(vi) {
                 state.conflicts.push(!*l);
             } else {
                 let level = asg.level_ref();

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -357,12 +357,13 @@ fn search(
 fn check(asg: &mut AssignStack, cdb: &mut ClauseDB, all: bool, message: &str) {
     if let Some(cid) = cdb.validate(asg.assign_ref(), all) {
         println!("{}", message);
-        println!("| trail pos | level |   literal  |  assignment  |                  reason  |");
+        println!("| on trail |   time | level |   literal  |  assignment |              reason |");
         let l0 = i32::from(cdb[cid].lit0());
         let l1 = i32::from(cdb[cid].lit1());
-        for (t, lv, lit, reason, assign) in asg.dump(&cdb[cid]).iter() {
+        for (p, t, lv, lit, reason, assign) in asg.dump(&cdb[cid]).iter() {
             println!(
-                "|{:>10} |{:>6} | {:9}{} | {:12} | {:24} |",
+                "|{:>9} | {:>6} |{:>6} | {:9}{} | {:11} |{:20} |",
+                p,
                 t,
                 lv,
                 lit,
@@ -381,8 +382,10 @@ fn check(asg: &mut AssignStack, cdb: &mut ClauseDB, all: bool, message: &str) {
         }
         println!("clause detail: {}", &cdb[cid]);
         let (c0, c1) = cdb.watch_caches(cid, "check (search 441)");
-        println!("watch{} has blocker cache {}", cdb[cid].lit0(), c0);
-        println!("watch{} has blocker cache {}", cdb[cid].lit1(), c1);
+        println!(" - watch {} has watch cache {:?}", cdb[cid].lit0(), c0);
+        println!(" - watch {} has watch cache {:?}", cdb[cid].lit1(), c1);
+        println!(" which was born at {}", cdb[cid].birth);
+        println!(" which was used at {}", cdb[cid].timestamp());
         panic!(
             "Before extending, NC {}, Level {} generated assignment({:?}) falsifies by {}",
             asg.derefer(assign::property::Tusize::NumConflict),

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -112,11 +112,15 @@ impl SolveIF for Solver {
                     {
                         if m == 0 {
                             let l = Lit::from((vi, true));
+                            assert!(asg.assigned(l).is_none());
+                            cdb.certificate_add_assertion(l);
                             if asg.assign_at_root_level(l).is_err() {
                                 return Ok(Certificate::UNSAT);
                             }
                         } else if p == 0 {
                             let l = Lit::from((vi, false));
+                            assert!(asg.assigned(l).is_none());
+                            cdb.certificate_add_assertion(l);
                             if asg.assign_at_root_level(l).is_err() {
                                 return Ok(Certificate::UNSAT);
                             }
@@ -177,9 +181,21 @@ impl SolveIF for Solver {
                 // As a preparation for incremental solving, we need to backtrack to the
                 // root level. So all assignments, including assignments to eliminated vars,
                 // are stored in an extra storage. It has the same type of `AssignStack::assign`.
-                // check(asg, cdb, true, "Before extending the model");
+                #[cfg(feature = "boundary_check")]
+                check(asg, cdb, true, "Before extending the model");
+
+                #[cfg(fueature = "boundary_check")]
+                check(asg, cdb, true, "Before extending the model");
+
                 let model = asg.extend_model(cdb, elim.eliminated_lits());
-                check(asg, cdb, true, "After extending the model");
+
+                #[cfg(fueature = "boundary_check")]
+                check(
+                    asg,
+                    cdb,
+                    true,
+                    "After extending the model, (passed before extending)",
+                );
 
                 // Run validator on the extended model.
                 if cdb.validate(&model, false).is_some() {
@@ -353,46 +369,78 @@ fn search(
     Ok(true)
 }
 
+#[cfg(feature = "boundary_check")]
 #[allow(dead_code)]
 fn check(asg: &mut AssignStack, cdb: &mut ClauseDB, all: bool, message: &str) {
     if let Some(cid) = cdb.validate(asg.assign_ref(), all) {
         println!("{}", message);
-        println!("| on trail |   time | level |   literal  |  assignment |              reason |");
+        println!(
+            "falsifies by {} at level {}, NumConf {}",
+            cid,
+            asg.decision_level(),
+            asg.derefer(assign::property::Tusize::NumConflict),
+        );
+        assert!(asg.stack_iter().all(|l| asg.assigned(*l) == Some(true)));
+        let (c0, c1) = cdb.watch_caches(cid, "check (search 441)");
+        println!(
+            " which was born at {}, and used in conflict analysis at {}",
+            cdb[cid].birth,
+            cdb[cid].timestamp(),
+        );
+        println!(
+            " which was moved among watch caches at {:?}",
+            cdb[cid].moved_at
+        );
+        println!("Its literals: {}", &cdb[cid]);
+        println!(" |   pos |   time | level |   literal  |  assignment |               reason |");
         let l0 = i32::from(cdb[cid].lit0());
         let l1 = i32::from(cdb[cid].lit1());
-        for (p, t, lv, lit, reason, assign) in asg.dump(&cdb[cid]).iter() {
+        use crate::assign::DebugReportIF;
+
+        for assign::Assign {
+            lit,
+            val,
+            pos,
+            lvl,
+            by: reason,
+            at,
+            state,
+        } in cdb[cid].report(asg).iter()
+        {
             println!(
-                "|{:>9} | {:>6} |{:>6} | {:9}{} | {:11} |{:20} |",
-                p,
-                t,
-                lv,
+                " |{:>6} | {:>6} |{:>6} | {:9}{} | {:11} | {:20} | {:?}",
+                pos.unwrap_or(0),
+                at,
+                lvl,
                 lit,
                 if *lit == l0 || *lit == l1 { '*' } else { ' ' },
-                format!(
-                    "{:?}",
-                    assign,
-                    // if asg.var(lit.abs() as usize).is(Flag::PROPAGATED) {
-                    //     "x"
-                    // } else {
-                    //     "!"
-                    // },
-                ),
+                format!("{:?}", val),
                 format!("{}", reason),
+                state,
             );
         }
-        println!("clause detail: {}", &cdb[cid]);
-        let (c0, c1) = cdb.watch_caches(cid, "check (search 441)");
-        println!(" - watch {} has watch cache {:?}", cdb[cid].lit0(), c0);
-        println!(" - watch {} has watch cache {:?}", cdb[cid].lit1(), c1);
-        println!(" which was born at {}", cdb[cid].birth);
-        println!(" which was used at {}", cdb[cid].timestamp());
-        panic!(
-            "Before extending, NC {}, Level {} generated assignment({:?}) falsifies by {}",
-            asg.derefer(assign::property::Tusize::NumConflict),
-            asg.decision_level(),
-            cdb.validate(asg.assign_ref(), false).is_none(),
-            cid,
+        println!(
+            " - L0 {} has complements {:?} in its cache",
+            cdb[cid].lit0(),
+            c0
         );
+        println!(
+            " - L1 {} has complements {:?} in its cache",
+            cdb[cid].lit1(),
+            c1
+        );
+        println!("The last assigned literal in stack:");
+        let last_lit = asg.stack(asg.stack_len() - 1);
+        println!(
+            " |{:>6} | {:>6} |{:>6} | {:9}  | {:11} | {:20} |",
+            asg.stack_len() - 1,
+            asg.var(last_lit.vi()).propagated_at,
+            asg.level(last_lit.vi()),
+            i32::from(last_lit),
+            format!("{:?}", asg.assigned(last_lit),),
+            format!("{}", asg.reason(last_lit.vi())),
+        );
+        panic!();
     }
 }
 

--- a/src/solver/vivify.rs
+++ b/src/solver/vivify.rs
@@ -295,6 +295,8 @@ impl AssignStack {
                 learnt.push(!*l);
             }
             match self.reason(l.vi()) {
+                AssignReason::Asserted(_) => (),
+                AssignReason::Decision(_) => (),
                 AssignReason::Implication(_, bil) if bil != NULL_LIT => {
                     seen[bil.vi()] = key;
                 }
@@ -303,7 +305,7 @@ impl AssignStack {
                         seen[r.vi()] = key;
                     }
                 }
-                _ => (),
+                AssignReason::None => panic!("impossible"),
             }
         }
         // cnfs/unsat.cnf can panic at

--- a/src/solver/vivify.rs
+++ b/src/solver/vivify.rs
@@ -58,6 +58,12 @@ pub fn vivify(
     let mut to_display = 0;
     'next_clause: while let Some(cp) = clauses.pop() {
         asg.backtrack_sandbox();
+        assert_eq!(asg.decision_level(), asg.root_level);
+        if asg.remains() {
+            asg.propagate(cdb)
+                .map_or(Ok(()), |cid| Err(SolverError::RootLevelConflict(Some(cid))))?;
+        }
+
         debug_assert!(asg.stack_is_empty() || !asg.remains());
         debug_assert_eq!(asg.root_level, asg.decision_level());
         let cid = cp.to();
@@ -104,7 +110,8 @@ pub fn vivify(
                                 return Err(SolverError::RootLevelConflict(Some(cid)));
                             }
                             1 => {
-                                assert_lit(asg, cdb, state, vec[0])?;
+                                cdb.certificate_add_assertion(vec[0]);
+                                asg.assign_at_root_level(vec[0])?;
                                 num_assert += 1;
                             }
                             _ => {
@@ -127,6 +134,10 @@ pub fn vivify(
         }
     }
     asg.backtrack_sandbox();
+    if asg.remains() {
+        asg.propagate(cdb);
+    }
+    asg.clear_asserted_literals(cdb)?;
     debug_assert!(asg.stack_is_empty() || !asg.remains());
     state.flush("");
     state.flush(format!(
@@ -145,53 +156,6 @@ pub fn vivify(
     );
     state[Stat::VivifiedClause] += num_shrink;
     state[Stat::VivifiedVar] += num_assert;
-    Ok(())
-}
-
-fn assert_lit(
-    asg: &mut AssignStack,
-    cdb: &mut ClauseDB,
-    state: &mut State,
-    l0: Lit,
-) -> MaybeInconsistent {
-    assert_eq!(asg.decision_level(), asg.root_level);
-    // assert_eq!(asg.assigned(l0), None);
-    cdb.certificate_add_assertion(l0);
-    let mut tag: &str = "assign";
-    if let Err(e) = asg.assign_at_root_level(l0).and_then(|_| {
-        tag = "propagation";
-        debug_assert!(asg.remains());
-        asg.propagate(cdb)
-            .map_or(Ok(()), |cc| Err(SolverError::RootLevelConflict(Some(cc))))
-    }) {
-        state.flush("");
-        state.log(
-            asg.num_conflict,
-            format!(
-                "(vivify) root level inconsistency by {} after asserting {}",
-                tag, l0,
-            ),
-        );
-        return Err(e);
-    }
-    assert_eq!(asg.decision_level(), asg.root_level);
-    asg.propagate(cdb).map_or(Ok(()), |cc| {
-        state.log(asg.num_conflict, "By vivifier");
-        Err(SolverError::RootLevelConflict(Some(cc)))
-    })?;
-    if asg.remains() {
-        state.log(
-            asg.num_conflict,
-            format!(
-                "(vivify) root level propagation remains un-propagated literals {}/{}",
-                asg.q_head,
-                asg.stack_len(),
-            ),
-        );
-    }
-    debug_assert!(cdb
-        .iter()
-        .all(|c| c.iter().all(|l| asg.assigned(*l).is_none())));
     Ok(())
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -902,6 +902,30 @@ impl<T: Clone + Default + Sized + Ord> OrderedProxy<T> {
     }
 }
 
+#[cfg(feature = "boundary_check")]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub enum Propagate {
+    None,
+    CacheSatisfied(usize),
+    FindNewWatch(usize, Lit, Lit),
+    BecameUnit(usize, Lit),
+    EmitConflict(usize, Lit),
+    SandboxCacheSatisfied(usize),
+    SandboxFindNewWatch(usize, Lit, Lit),
+    SandboxBecameUnit(usize),
+    SandboxEmitConflict(usize, Lit),
+}
+
+#[cfg(feature = "boundary_check")]
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub enum VarState {
+    AssertedSandbox(usize),
+    Assigned(usize),
+    AssignedSandbox(usize),
+    Propagated(usize),
+    Unassigned(usize),
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
- fix bugs about chronoBT
- `AssignReason` has 4 states
- `ClauseDBIF` exports 'immutable' iterators on `WatchCache` instead of `WatchCache` itself to encapsulate internal state transitions
- revise all destructive methods of `ClausedDBIF` much more carefully
- re-implement `AssignStack::extend_model` using iterators
