### PR TITLE
20210822 adjust restart parameters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,11 @@ bitflags = "1.3"
 
 [features]
 default = [
-        "adjust_restart_parameters",
         # DEBUG "boundary_check",
         "bi_clause_completion",
         "clause_elimination",
         "clause_vivification",
+        "dynamic_restart_threshold",
         # "incremental_solver",
         "LR_rewarding",
         "Luby_stabilization",
@@ -29,13 +29,13 @@ default = [
         "rephase",
         "unsafe_access"
         ]
-adjust_restart_parameters = []
 best_phases_tracking = []
 bi_clause_completion = []
 boundary_check = []
 clause_elimination = []
 clause_vivification = []
 debug_propagation = []
+dynamic_restart_threshold = []
 EMA_calibration = []
 EVSIDS = []
 hashed_watch_cache = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ bitflags = "1.3"
 
 [features]
 default = [
-        # EXPERIMENTAL "adjust_restart_parameters",
+        "adjust_restart_parameters",
         # DEBUG "boundary_check",
         "bi_clause_completion",
         "clause_elimination",

--- a/src/assign/mod.rs
+++ b/src/assign/mod.rs
@@ -170,11 +170,6 @@ pub struct AssignStack {
     ppc_ema: EmaSU,
     /// Conflicts Per Restart
     cpr_ema: EmaSU,
-    #[cfg(feature = "adjust_restart_parameters")]
-    /// Conflicts Per Base Interval Restart
-    cpbrema: EmaSU,
-    #[cfg(feature = "adjust_restart_parameters")]
-    in_base_interval_restart: bool,
 
     //
     //## Var DB

--- a/src/assign/propagate.rs
+++ b/src/assign/propagate.rs
@@ -255,13 +255,6 @@ impl PropagateIF for AssignStack {
         if lv == self.root_level {
             self.num_restart += 1;
             self.cpr_ema.update(self.num_conflict);
-
-            #[cfg(feature = "adjust_restart_parameters")]
-            {
-                if self.in_base_interval_restart {
-                    self.cpbrema.update(self.num_conflict);
-                }
-            }
         }
 
         debug_assert!(self.q_head == 0 || self.assign[self.trail[self.q_head - 1].vi()].is_some());

--- a/src/assign/stack.rs
+++ b/src/assign/stack.rs
@@ -47,11 +47,6 @@ impl Default for AssignStack {
             ppc_ema: EmaSU::new(100),
             cpr_ema: EmaSU::new(100),
 
-            #[cfg(feature = "adjust_restart_parameters")]
-            cpbrema: EmaSU::new(100),
-            #[cfg(feature = "adjust_restart_parameters")]
-            in_base_interval_restart: true,
-
             ordinal: 0,
             var: Vec::new(),
 
@@ -114,16 +109,6 @@ impl Instantiate for AssignStack {
             }
             #[allow(unused_variables)]
             SolverEvent::Stabilize(scale) => {
-                #[cfg(feature = "adjust_restart_parameters")]
-                {
-                    if scale == 1 {
-                        self.in_base_interval_restart = true;
-                        self.cpbrema.update_base(self.num_conflict);
-                    } else {
-                        self.in_base_interval_restart = false;
-                    }
-                }
-
                 #[cfg(feature = "rephase")]
                 self.select_rephasing_target(None, scale);
             }

--- a/src/config.rs
+++ b/src/config.rs
@@ -147,7 +147,7 @@ impl Default for Config {
             rst_asg_thr: 0.6,
             rst_lbd_len: 8,
             rst_lbd_slw: 8192,
-            rst_lbd_thr: 1.4,
+            rst_lbd_thr: 2.0,
 
             stg_rwd_dcy: 0.5,
             stg_rwd_val: 1.0,

--- a/src/config.rs
+++ b/src/config.rs
@@ -142,12 +142,12 @@ impl Default for Config {
             elm_var_occ: 20000,
 
             rst_step: 2,
-            rst_asg_len: 24,
+            rst_asg_len: 16,
             rst_asg_slw: 8192,
             rst_asg_thr: 0.6,
             rst_lbd_len: 8,
             rst_lbd_slw: 8192,
-            rst_lbd_thr: 1.6,
+            rst_lbd_thr: 1.4,
 
             stg_rwd_dcy: 0.5,
             stg_rwd_val: 1.0,

--- a/src/config.rs
+++ b/src/config.rs
@@ -147,7 +147,7 @@ impl Default for Config {
             rst_asg_thr: 0.6,
             rst_lbd_len: 8,
             rst_lbd_slw: 8192,
-            rst_lbd_thr: 1.8,
+            rst_lbd_thr: 1.6,
 
             stg_rwd_dcy: 0.5,
             stg_rwd_val: 1.0,

--- a/src/config.rs
+++ b/src/config.rs
@@ -147,7 +147,7 @@ impl Default for Config {
             rst_asg_thr: 0.6,
             rst_lbd_len: 8,
             rst_lbd_slw: 8192,
-            rst_lbd_thr: 2.0,
+            rst_lbd_thr: 1.8,
 
             stg_rwd_dcy: 0.5,
             stg_rwd_val: 1.0,

--- a/src/solver/restart.rs
+++ b/src/solver/restart.rs
@@ -104,6 +104,7 @@ pub trait RestartIF:
     /// - `Some(false)` if returns to the base restart interval
     /// - `None` if not at the base restart interval
     fn stabilize(&mut self) -> Option<bool>;
+    #[cfg(feature = "adjust_restart_parameters")]
     /// adjust restart threshold
     fn adjust(&mut self, base: f64, range: f64);
     /// update specific sub-module
@@ -507,6 +508,7 @@ impl RestartIF for Restarter {
     fn stabilize(&mut self) -> Option<bool> {
         None
     }
+    #[cfg(feature = "adjust_restart_parameters")]
     fn adjust(&mut self, base: f64, range: f64) {
         const DECAY: f64 = 0.9;
         let update = base.min(range / self.lbd.ema.get_slow());

--- a/src/solver/restart.rs
+++ b/src/solver/restart.rs
@@ -510,15 +510,15 @@ impl RestartIF for Restarter {
     }
     #[cfg(feature = "dynamic_restart_threshold")]
     fn adjust(&mut self, base: f64, range: f64, used: f64) {
-        const DECAY: f64 = 0.8;
+        const DECAY: f64 = 0.75;
         let lbd = self.lbd.ema.get_slow();
         // map the degree of freedom to [1.0, 2.0]; the larger freedom, the smaller value.
         let factor1 = 1.0 + 1.0 / range.log(lbd).max(1.0);
         // map the usability of learnt to [1.0, 2.0]; the smaller gap, the smaller value.
         let factor2 = 1.0 + 1.0 / lbd.log(used).max(1.0);
         self.lbd.threshold *= DECAY;
-        // finally map the product to [1.0, base]
-        self.lbd.threshold += (1.0 - DECAY) * (factor1 * factor2).sqrt() * 0.5 * base;
+        // finally map the product [1.0, 4.0] to [1.0, base]
+        self.lbd.threshold += (1.0 - DECAY) * (factor1 * factor2).powf(base.log(4.0));
     }
     fn update(&mut self, kind: ProgressUpdate) {
         match kind {

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -319,7 +319,7 @@ fn search(
                             return Err(SolverError::UndescribedError);
                         }
 
-                        #[cfg(feature = "adjust_restart_parameters")]
+                        #[cfg(feature = "dynamic_restart_threshold")]
                         rst.adjust(
                             state.config.rst_lbd_thr,
                             state.c_lvl.get(),

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -297,8 +297,7 @@ fn search(
                 state.log(
                     asg.num_conflict,
                     format!(
-                        "#cycle:{:>5}, core:{:>10}, level:{:>9}, /cpr:{:>9.2}, rt:{:>9.2}",
-                        rst.derefer(restart::property::Tusize::NumCycle),
+                        "#core:{:>10}, scale:{:>9}, /cpr:{:>9.2}, rlt:{:>7.4}",
                         asg.derefer(assign::property::Tusize::NumUnreachableVar),
                         rst.derefer(restart::property::Tusize::IntervalScale),
                         asg.refer(assign::property::TEma::PropagationPerConflict)

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -322,7 +322,7 @@ fn search(
                         #[cfg(feature = "adjust_restart_parameters")]
                         rst.adjust(
                             state.config.rst_lbd_thr,
-                            state.b_lvl.get(),
+                            state.c_lvl.get(),
                             cdb.derefer(cdb::property::Tf64::DpAverageLBD),
                         );
 

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -9,7 +9,7 @@ use {
     },
     crate::{
         assign::{self, AssignIF, AssignStack, PropagateIF, VarManipulateIF, VarSelectIF},
-        cdb::{ClauseDB, ClauseDBIF},
+        cdb::{self, ClauseDB, ClauseDBIF},
         processor::{EliminateIF, Eliminator},
         state::{Stat, State, StateIF},
         types::*,
@@ -320,7 +320,11 @@ fn search(
                         }
 
                         #[cfg(feature = "adjust_restart_parameters")]
-                        rst.adjust(state.config.rst_lbd_thr, state.c_lvl.get());
+                        rst.adjust(
+                            state.config.rst_lbd_thr,
+                            state.b_lvl.get(),
+                            cdb.derefer(cdb::property::Tf64::DpAverageLBD),
+                        );
 
                         #[allow(unused_variables)]
                         if new_cycle {

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -326,6 +326,10 @@ fn search(
                             return Err(SolverError::UndescribedError);
                         }
 
+                        let range = state.c_lvl.get();
+                        let shrink = (state.c_lvl.get() - state.b_lvl.get() - 1.0).max(0.0);
+                        rst.adjust_restart(range, shrink);
+
                         #[allow(unused_variables)]
                         if new_cycle {
                             let num_cycle = rst.derefer(restart::property::Tusize::NumCycle);

--- a/src/state.rs
+++ b/src/state.rs
@@ -588,9 +588,9 @@ impl StateIF for State {
             ),
         );
         println!(
-            "\x1B[2K         LBD|avrg:{}, trnd:{}, depG:{}, /dpc:{}",
-            fm!("{:>9.4}", self, LogF64Id::EmaLBD, rst_lbd.get()),
+            "\x1B[2K         LBD|trnd:{}, avrg:{}, depG:{}, /dpc:{}",
             fm!("{:>9.4}", self, LogF64Id::TrendLBD, rst_lbd.trend()),
+            fm!("{:>9.4}", self, LogF64Id::EmaLBD, rst_lbd.get()),
             fm!("{:>9.4}", self, LogF64Id::DpAverageLBD, cdb_lbd_of_dp),
             fm!(
                 "{:>9.2}",


### PR DESCRIPTION
- rename feature 'adjust_restart_parameters' to 'dynamic_restart_threshold'
- homeostatic restart
- change the layout of the progress report

### Original motivation
There are major possibilities that the restart threshold isn't appropriate. This branch adds a control 'rlt' based on the coverage rate defined as `Ema(backtrack level) / Ema(lbd of learnt clauses)`.