### PR TITLE
more refactoring

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ default = [
         "clause_elimination",
         # "clause_rewarding",
         "clause_vivification",
-        "dynamic_restart_threshold",
+        # "dynamic_restart_threshold",
         # "incremental_solver",
         "LRB_rewarding",
         "Luby_stabilization",

--- a/splr-ema/Cargo.toml
+++ b/splr-ema/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "splr-ema"
 description = "various average and EMA implementations used in Splr"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [dependencies]

--- a/splr-ema/src/lib.rs
+++ b/splr-ema/src/lib.rs
@@ -32,8 +32,10 @@ pub trait EmaMutIF: EmaIF {
     fn reset(&mut self) {}
     /// catch up with the current state.
     fn update(&mut self, x: Self::Input);
-    // return a view.
+    /// return a view.
     fn as_view(&self) -> &EmaView;
+    /// set value.
+    fn set_value(&mut self, _x: f64) {}
 }
 
 #[derive(Clone, Debug)]
@@ -94,6 +96,10 @@ impl EmaMutIF for Ema {
     fn as_view(&self) -> &EmaView {
         &self.val
     }
+    fn set_value(&mut self, x: f64) {
+        self.val.fast = x;
+        self.val.slow = x;
+    }
 }
 
 impl Ema {
@@ -107,6 +113,12 @@ impl Ema {
             cal: 0.0,
             sca: 1.0 / (s as f64),
         }
+    }
+    /// set value.
+    pub fn with_value(mut self, x: f64) -> Ema {
+        self.val.fast = x;
+        self.val.slow = x;
+        self
     }
 }
 

--- a/splr-ema/src/lib.rs
+++ b/splr-ema/src/lib.rs
@@ -310,6 +310,7 @@ pub struct Ewa2<const N: usize> {
     #[cfg(feature = "EMA_calibration")]
     cals: f64,
     se: f64,
+    sx: f64,
 }
 
 impl<const N: usize> EmaIF for Ewa2<N> {
@@ -334,10 +335,10 @@ impl<const N: usize> EmaMutIF for Ewa2<N> {
         self.ema.fast += val;
         self.pool[self.last] = val;
         self.last = (self.last + 1) % N;
-        self.ema.slow = self.se * x + (1.0 - self.se) * self.ema.slow;
+        self.ema.slow = self.se * x + self.sx * self.ema.slow;
         #[cfg(feature = "EMA_calibration")]
         {
-            self.cals = self.se + (1.0 - self.se) * self.cals;
+            self.cals = self.se + self.sx * self.cals;
         }
     }
     #[cfg(not(feature = "EMA_calibration"))]
@@ -366,11 +367,13 @@ impl<const N: usize> Ewa2<N> {
             #[cfg(feature = "EMA_calibration")]
             cals: initial,
             se: 1.0 / (N as f64),
+            sx: 1.0 - 1.0 / (N as f64),
         }
     }
     // set secondary EMA parameter
     pub fn with_slow(mut self, s: usize) -> Self {
         self.se = 1.0 / (s as f64);
+        self.sx = 1.0 - self.se;
         self
     }
 }

--- a/src/assign/ema.rs
+++ b/src/assign/ema.rs
@@ -1,0 +1,45 @@
+use crate::{types::*, Ewa2};
+
+const ASG_EWA_LEN: usize = 24;
+
+/// An assignment history used for blocking restart.
+#[derive(Clone, Debug)]
+pub struct ProgressASG {
+    ema: Ewa2<ASG_EWA_LEN>,
+}
+
+impl Default for ProgressASG {
+    fn default() -> ProgressASG {
+        ProgressASG {
+            ema: Ewa2::<ASG_EWA_LEN>::new(0.0),
+        }
+    }
+}
+
+impl Instantiate for ProgressASG {
+    fn instantiate(config: &Config, _cnf: &CNFDescription) -> Self {
+        ProgressASG {
+            ema: Ewa2::new(0.0).with_slow(config.rst_asg_slw),
+            ..ProgressASG::default()
+        }
+    }
+}
+
+impl EmaIF for ProgressASG {
+    fn get_fast(&self) -> f64 {
+        self.ema.get()
+    }
+    fn trend(&self) -> f64 {
+        self.ema.trend()
+    }
+}
+
+impl EmaMutIF for ProgressASG {
+    type Input = usize;
+    fn update(&mut self, n: usize) {
+        self.ema.update(n as f64);
+    }
+    fn as_view(&self) -> &EmaView {
+        self.ema.as_view()
+    }
+}

--- a/src/assign/mod.rs
+++ b/src/assign/mod.rs
@@ -364,12 +364,12 @@ pub mod property {
         #[inline]
         fn refer(&self, k: TEma) -> &EmaView {
             match k {
-                TEma::AssignRate => &self.assign_rate.as_view(),
+                TEma::AssignRate => self.assign_rate.as_view(),
                 TEma::DecisionPerConflict => self.dpc_ema.as_view(),
                 TEma::PropagationPerConflict => self.ppc_ema.as_view(),
                 TEma::ConflictPerRestart => self.cpr_ema.as_view(),
                 TEma::ConflictPerBaseRestart => self.cpr_ema.as_view(),
-                TEma::BestPhaseDivergenceRate => &self.bp_divergence_ema.as_view(),
+                TEma::BestPhaseDivergenceRate => self.bp_divergence_ema.as_view(),
             }
         }
     }

--- a/src/assign/propagate.rs
+++ b/src/assign/propagate.rs
@@ -279,6 +279,13 @@ impl PropagateIF for AssignStack {
         if lv == self.root_level {
             self.num_restart += 1;
             self.cpr_ema.update(self.num_conflict);
+        } else {
+            self.assign_rate.update(
+                self.num_vars
+                    - self.num_asserted_vars
+                    - self.num_eliminated_vars
+                    - self.trail.len(),
+            );
         }
 
         debug_assert!(self.q_head == 0 || self.assign[self.trail[self.q_head - 1].vi()].is_some());

--- a/src/assign/stack.rs
+++ b/src/assign/stack.rs
@@ -93,7 +93,7 @@ impl Instantiate for AssignStack {
         let nv = cnf.num_of_variables;
         AssignStack {
             assign: vec![None; 1 + nv],
-            level: vec![DecisionLevel::default(); nv + 1],
+            level: (0..nv as u32 + 1).collect::<Vec<_>>(), // each literal occupies a single level.
             reason: vec![AssignReason::None; nv + 1],
             trail: Vec::with_capacity(nv),
             var_order: VarIdHeap::new(nv),

--- a/src/assign/stack.rs
+++ b/src/assign/stack.rs
@@ -3,8 +3,8 @@
 use std::collections::HashMap;
 use {
     super::{
-        AssignIF, AssignStack, TrailSavingIF, Var, VarHeapIF, VarIdHeap, VarManipulateIF,
-        VarSelectIF,
+        ema::ProgressASG, AssignIF, AssignStack, TrailSavingIF, Var, VarHeapIF, VarIdHeap,
+        VarManipulateIF, VarSelectIF,
     },
     crate::{cdb::ClauseDBIF, types::*},
     std::{fmt, ops::Range, slice::Iter},
@@ -53,6 +53,7 @@ impl Default for AssignStack {
             num_propagation: 0,
             num_conflict: 0,
             num_restart: 0,
+            assign_rate: ProgressASG::default(),
             dpc_ema: EmaSU::new(100),
             ppc_ema: EmaSU::new(100),
             cpr_ema: EmaSU::new(100),
@@ -103,6 +104,7 @@ impl Instantiate for AssignStack {
             reason_saved: vec![AssignReason::None; nv + 1],
 
             num_vars: cnf.num_of_variables,
+            assign_rate: ProgressASG::instantiate(config, cnf),
             var: Var::new_vars(nv),
 
             #[cfg(feature = "EVSIDS")]

--- a/src/assign/trail_saving.rs
+++ b/src/assign/trail_saving.rs
@@ -56,7 +56,9 @@ impl TrailSavingIF for AssignStack {
         }
     }
     fn from_saved_trail(&mut self, cdb: &impl ClauseDBIF) -> PropagationResult {
-        let q = (REASON_THRESHOLD * cdb.derefer(crate::cdb::property::Tf64::DpAverageLBD)) as u16;
+        let q = (REASON_THRESHOLD
+            * cdb.derefer(crate::cdb::property::Tf64::LiteralBlockEntanglement))
+            as u16;
 
         #[cfg(feature = "chrono_BT")]
         let dl = self.decision_level();

--- a/src/assign/trail_saving.rs
+++ b/src/assign/trail_saving.rs
@@ -3,10 +3,7 @@
 /// This version can handle Chronological and Non Chronological Backtrack.
 use {
     super::{AssignStack, PropagateIF, VarHeapIF, VarManipulateIF},
-    crate::{
-        cdb::{self, ClauseDBIF},
-        types::*,
-    },
+    crate::{cdb::ClauseDBIF, types::*},
 };
 
 #[cfg(feature = "chrono_BT")]
@@ -19,7 +16,7 @@ pub trait TrailSavingIF {
     fn clear_saved_trail(&mut self);
 }
 
-const REASON_THRESHOLD: f64 = 1.5;
+const REASON_THRESHOLD: f64 = 2.0;
 
 impl TrailSavingIF for AssignStack {
     fn save_trail(&mut self, to_lvl: DecisionLevel) {
@@ -59,7 +56,7 @@ impl TrailSavingIF for AssignStack {
         }
     }
     fn from_saved_trail(&mut self, cdb: &impl ClauseDBIF) -> PropagationResult {
-        let q = (REASON_THRESHOLD * cdb.derefer(cdb::property::Tf64::DpAverageLBD)).max(6.0) as u16;
+        let q = (REASON_THRESHOLD * cdb.derefer(crate::cdb::property::Tf64::DpAverageLBD)) as u16;
 
         #[cfg(feature = "chrono_BT")]
         let dl = self.decision_level();

--- a/src/bin/splr.rs
+++ b/src/bin/splr.rs
@@ -291,7 +291,7 @@ fn report(s: &Solver, out: &mut dyn Write) -> std::io::Result<()> {
             "c          LBD|avrg:{:>9.4}, trnd:{:>9.4}, depG:{:>9.4}, /dpc:{:>9.2},\n",
             state[LogF64Id::EmaLBD],
             state[LogF64Id::TrendLBD],
-            state[LogF64Id::DpAverageLBD],
+            state[LogF64Id::LiteralBlockEntanglement],
             state[LogF64Id::DecisionPerConflict],
         )
         .as_bytes(),

--- a/src/cdb/db.rs
+++ b/src/cdb/db.rs
@@ -42,7 +42,7 @@ impl Default for ClauseDB {
             num_learnt: 0,
             num_reduction: 0,
             num_reregistration: 0,
-            lbd_of_dp_ema: Ema::new(100_000).with_value(2.0),
+            lb_entanglement: Ema::new(100_000).with_value(2.0),
             eliminated_permanent: Vec::new(),
         }
     }
@@ -966,12 +966,12 @@ impl ClauseDBIF for ClauseDB {
             self.reward_at_analysis(cid);
         }
         if 1 < rank {
-            self.lbd_of_dp_ema.update(rank as f64);
+            self.lb_entanglement.update(rank as f64);
         }
         learnt
     }
     /// reduce the number of 'learnt' or *removable* clauses.
-    fn reduce(&mut self, asg: &mut impl AssignIF, portion: usize, average_lbd: f64) {
+    fn reduce(&mut self, asg: &mut impl AssignIF, portion: usize) {
         impl Clause {
             fn pure_weight(&self, asg: &mut impl AssignIF) -> f64 {
                 let act_v = self
@@ -1054,7 +1054,7 @@ impl ClauseDBIF for ClauseDB {
         // there're exception. Since this is the pre-stage of clause vivification,
         // we want keep usefull clauses as many as possible.
         // Therefore I save the clauses which will become vivification targets.
-        let thr = ((average_lbd/* + self.lbd_of_dp_ema.get() */) as u16).max(4);
+        let thr = (self.lb_entanglement.get() as u16).max(4);
         for i in &perm[keep..] {
             let c = &self.clause[i.to()];
             if !c.is_vivify_target() || thr < c.rank {

--- a/src/cdb/db.rs
+++ b/src/cdb/db.rs
@@ -216,6 +216,9 @@ impl Instantiate for ClauseDB {
                     (crate::state::SearchStrategy::ManyGlues, _) => (),
                 }
             }
+            SolverEvent::Assert(_) => {
+                self.lbd.update(0);
+            }
             SolverEvent::NewVar => {
                 self.binary_link.add_new_var();
                 // for negated literal

--- a/src/cdb/db.rs
+++ b/src/cdb/db.rs
@@ -5,7 +5,7 @@ use {
         watch_cache::*,
         BinaryLinkDB, CertificationStore, Clause, ClauseDB, ClauseDBIF, ClauseId, RefClause,
     },
-    crate::{assign::AssignIF, types::*},
+    crate::{assign::AssignIF, cdb::ema::ProgressLBD, types::*},
     std::{
         num::NonZeroU32,
         ops::{Index, IndexMut, Range, RangeFrom},
@@ -35,6 +35,8 @@ impl Default for ClauseDB {
             activity_anti_decay: 0.01,
 
             lbd_temp: Vec::new(),
+            lbd: ProgressLBD::default(),
+
             num_clause: 0,
             num_bi_clause: 0,
             num_bi_learnt: 0,
@@ -383,6 +385,7 @@ impl ClauseDBIF for ClauseDB {
             // assert!(2 < c.lits.len());
             watch_cache[!l0].insert_watch(cid, l1);
             watch_cache[!l1].insert_watch(cid, l0);
+            self.lbd.update(c.rank);
         }
         RefClause::Clause(cid)
     }

--- a/src/cdb/db.rs
+++ b/src/cdb/db.rs
@@ -42,7 +42,7 @@ impl Default for ClauseDB {
             num_learnt: 0,
             num_reduction: 0,
             num_reregistration: 0,
-            lbd_of_dp_ema: Ema::new(100_000),
+            lbd_of_dp_ema: Ema::new(100_000).with_value(2.0),
             eliminated_permanent: Vec::new(),
         }
     }
@@ -965,7 +965,9 @@ impl ClauseDBIF for ClauseDB {
             #[cfg(feature = "clause_rewading")]
             self.reward_at_analysis(cid);
         }
-        self.lbd_of_dp_ema.update(rank as f64);
+        if 1 < rank {
+            self.lbd_of_dp_ema.update(rank as f64);
+        }
         learnt
     }
     /// reduce the number of 'learnt' or *removable* clauses.
@@ -1052,7 +1054,7 @@ impl ClauseDBIF for ClauseDB {
         // there're exception. Since this is the pre-stage of clause vivification,
         // we want keep usefull clauses as many as possible.
         // Therefore I save the clauses which will become vivification targets.
-        let thr = ((average_lbd + self.lbd_of_dp_ema.get()) as u16).max(4);
+        let thr = ((average_lbd/* + self.lbd_of_dp_ema.get() */) as u16).max(4);
         for i in &perm[keep..] {
             let c = &self.clause[i.to()];
             if !c.is_vivify_target() || thr < c.rank {

--- a/src/cdb/db.rs
+++ b/src/cdb/db.rs
@@ -1,11 +1,12 @@
 use {
     super::{
         binary::{BinaryLinkIF, BinaryLinkList},
+        ema::ProgressLBD,
         property,
         watch_cache::*,
         BinaryLinkDB, CertificationStore, Clause, ClauseDB, ClauseDBIF, ClauseId, RefClause,
     },
-    crate::{assign::AssignIF, cdb::ema::ProgressLBD, types::*},
+    crate::{assign::AssignIF, types::*},
     std::{
         num::NonZeroU32,
         ops::{Index, IndexMut, Range, RangeFrom},
@@ -170,6 +171,7 @@ impl Instantiate for ClauseDB {
             watch_cache: watcher,
             certification_store: CertificationStore::instantiate(config, cnf),
             soft_limit: config.c_cls_lim,
+            lbd: ProgressLBD::instantiate(config, cnf),
 
             #[cfg(feature = "clause_rewarding")]
             activity_decay: config.crw_dcy_rat,
@@ -360,6 +362,7 @@ impl ClauseDBIF for ClauseDB {
             c.update_lbd(asg, lbd_temp);
             c.rank_old = c.rank;
         }
+        self.lbd.update(c.rank);
         if learnt && len2 {
             *num_bi_learnt += 1;
         }
@@ -385,7 +388,6 @@ impl ClauseDBIF for ClauseDB {
             // assert!(2 < c.lits.len());
             watch_cache[!l0].insert_watch(cid, l1);
             watch_cache[!l1].insert_watch(cid, l0);
-            self.lbd.update(c.rank);
         }
         RefClause::Clause(cid)
     }

--- a/src/cdb/db.rs
+++ b/src/cdb/db.rs
@@ -969,7 +969,7 @@ impl ClauseDBIF for ClauseDB {
         learnt
     }
     /// reduce the number of 'learnt' or *removable* clauses.
-    fn reduce(&mut self, asg: &mut impl AssignIF, portion: usize) {
+    fn reduce(&mut self, asg: &mut impl AssignIF, portion: usize, average_lbd: f64) {
         impl Clause {
             fn pure_weight(&self, asg: &mut impl AssignIF) -> f64 {
                 let act_v = self
@@ -1052,7 +1052,7 @@ impl ClauseDBIF for ClauseDB {
         // there're exception. Since this is the pre-stage of clause vivification,
         // we want keep usefull clauses as many as possible.
         // Therefore I save the clauses which will become vivification targets.
-        let thr = self.lbd_of_dp_ema.get() as u16 * 2;
+        let thr = ((average_lbd + self.lbd_of_dp_ema.get()) as u16).max(4);
         for i in &perm[keep..] {
             let c = &self.clause[i.to()];
             if !c.is_vivify_target() || thr < c.rank {

--- a/src/cdb/ema.rs
+++ b/src/cdb/ema.rs
@@ -1,0 +1,51 @@
+use crate::{types::*, Ewa2};
+
+const LBD_EWA_LEN: usize = 24;
+
+/// An EMA of learnt clauses' LBD, used for forcing restart.
+#[derive(Clone, Debug)]
+pub struct ProgressLBD {
+    ema: Ewa2<LBD_EWA_LEN>,
+    num: usize,
+    sum: usize,
+}
+
+impl Default for ProgressLBD {
+    fn default() -> ProgressLBD {
+        ProgressLBD {
+            ema: Ewa2::<LBD_EWA_LEN>::new(0.0),
+            num: 0,
+            sum: 0,
+        }
+    }
+}
+
+impl Instantiate for ProgressLBD {
+    fn instantiate(config: &Config, _: &CNFDescription) -> Self {
+        ProgressLBD {
+            ema: Ewa2::new(0.0).with_slow(config.rst_lbd_slw),
+            ..ProgressLBD::default()
+        }
+    }
+}
+
+impl EmaIF for ProgressLBD {
+    fn get_fast(&self) -> f64 {
+        self.ema.get_fast()
+    }
+    fn trend(&self) -> f64 {
+        self.ema.trend()
+    }
+}
+
+impl EmaMutIF for ProgressLBD {
+    type Input = u16;
+    fn update(&mut self, d: Self::Input) {
+        self.num += 1;
+        self.sum += d as usize;
+        self.ema.update(d as f64);
+    }
+    fn as_view(&self) -> &EmaView {
+        self.ema.as_view()
+    }
+}

--- a/src/cdb/mod.rs
+++ b/src/cdb/mod.rs
@@ -129,7 +129,7 @@ pub trait ClauseDBIF:
     /// reduce learnt clauses
     /// # CAVEAT
     /// *precondition*: decision level == 0.
-    fn reduce(&mut self, asg: &mut impl AssignIF, portion: usize, average_lbd: f64);
+    fn reduce(&mut self, asg: &mut impl AssignIF, portion: usize);
     /// remove all learnt clauses.
     fn reset(&mut self);
     /// update flags.
@@ -276,8 +276,9 @@ pub struct ClauseDB {
     num_reduction: usize,
     /// the number of reregistration of a bi-clause
     num_reregistration: usize,
+    /// Literal Block Entanglement
     /// EMA of LBD of clauses used in conflict analysis (dependency graph)
-    pub lbd_of_dp_ema: Ema,
+    pub lb_entanglement: Ema,
 
     //
     //## incremental solving
@@ -337,16 +338,16 @@ pub mod property {
 
     #[derive(Clone, Copy, Debug, PartialEq)]
     pub enum Tf64 {
-        DpAverageLBD,
+        LiteralBlockEntanglement,
     }
 
-    pub const F64: [Tf64; 1] = [Tf64::DpAverageLBD];
+    pub const F64: [Tf64; 1] = [Tf64::LiteralBlockEntanglement];
 
     impl PropertyDereference<Tf64, f64> for ClauseDB {
         #[inline]
         fn derefer(&self, k: Tf64) -> f64 {
             match k {
-                Tf64::DpAverageLBD => self.lbd_of_dp_ema.get(),
+                Tf64::LiteralBlockEntanglement => self.lb_entanglement.get(),
             }
         }
     }

--- a/src/cdb/mod.rs
+++ b/src/cdb/mod.rs
@@ -402,24 +402,30 @@ mod tests {
         };
         let mut asg = AssignStack::instantiate(&config, &cnf);
         let mut cdb = ClauseDB::instantiate(&config, &cnf);
-        asg.assign_by_decision(lit(1));
-        asg.assign_by_decision(lit(-2));
+        // Now `asg.level` = [_, 1, 2, 3, 4, 5, 6].
+        let c0 = cdb
+            .new_clause(&mut asg, &mut vec![lit(1), lit(2), lit(3), lit(4)], false)
+            .as_cid();
+        assert_eq!(cdb[c0].rank, 4);
 
+        asg.assign_by_decision(lit(-2)); // at level 1
+        asg.assign_by_decision(lit(1)); // at level 2
+                                        // Now `asg.level` = [_, 2, 1, 3, 4, 5, 6].
         let c1 = cdb
             .new_clause(&mut asg, &mut vec![lit(1), lit(2), lit(3)], false)
             .as_cid();
         let c = &cdb[c1];
-        assert_eq!(c.rank, 2);
+
+        assert_eq!(c.rank, 3);
         assert!(!c.is_dead());
         assert!(!c.is(FlagClause::LEARNT));
         #[cfg(feature = "just_used")]
         assert!(!c.is(Flag::USED));
-
         let c2 = cdb
             .new_clause(&mut asg, &mut vec![lit(-1), lit(2), lit(3)], true)
             .as_cid();
         let c = &cdb[c2];
-        assert_eq!(c.rank, 2);
+        assert_eq!(c.rank, 3);
         assert!(!c.is_dead());
         assert!(c.is(FlagClause::LEARNT));
         #[cfg(feature = "just_used")]

--- a/src/cdb/mod.rs
+++ b/src/cdb/mod.rs
@@ -8,6 +8,8 @@ mod cid;
 mod clause;
 /// methods on `ClauseDB`
 mod db;
+/// EMA
+mod ema;
 /// methods for UNSAT certification
 mod unsat_certificate;
 /// implementation of clause vivification
@@ -24,6 +26,7 @@ pub use self::{
     unsat_certificate::CertificationStore,
 };
 use {
+    self::ema::ProgressLBD,
     crate::{assign::AssignIF, types::*},
     std::{
         num::NonZeroU32,
@@ -258,6 +261,7 @@ pub struct ClauseDB {
     //
     /// a working buffer for LBD calculation
     lbd_temp: Vec<usize>,
+    lbd: ProgressLBD,
 
     //
     //## statistics
@@ -348,6 +352,20 @@ pub mod property {
         fn derefer(&self, k: Tf64) -> f64 {
             match k {
                 Tf64::LiteralBlockEntanglement => self.lb_entanglement.get(),
+            }
+        }
+    }
+
+    #[derive(Clone, Debug, PartialEq)]
+    pub enum TEma {
+        LBD,
+    }
+
+    impl PropertyReference<TEma, EmaView> for ClauseDB {
+        #[inline]
+        fn refer(&self, k: TEma) -> &EmaView {
+            match k {
+                TEma::LBD => &self.lbd.as_view(),
             }
         }
     }

--- a/src/cdb/mod.rs
+++ b/src/cdb/mod.rs
@@ -129,7 +129,7 @@ pub trait ClauseDBIF:
     /// reduce learnt clauses
     /// # CAVEAT
     /// *precondition*: decision level == 0.
-    fn reduce(&mut self, asg: &mut impl AssignIF, portion: usize);
+    fn reduce(&mut self, asg: &mut impl AssignIF, portion: usize, average_lbd: f64);
     /// remove all learnt clauses.
     fn reset(&mut self);
     /// update flags.

--- a/src/cdb/mod.rs
+++ b/src/cdb/mod.rs
@@ -365,7 +365,7 @@ pub mod property {
         #[inline]
         fn refer(&self, k: TEma) -> &EmaView {
             match k {
-                TEma::LBD => &self.lbd.as_view(),
+                TEma::LBD => self.lbd.as_view(),
             }
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -137,7 +137,7 @@ impl Default for Config {
             rst_asg_thr: 0.6,
             // rst_lbd_len: 8,
             rst_lbd_slw: 8192,
-            rst_lbd_thr: 1.6,
+            rst_lbd_thr: 1.4,
 
             #[cfg(feature = "EVSIDS")]
             vrw_dcy_rat: 0.98,

--- a/src/config.rs
+++ b/src/config.rs
@@ -137,7 +137,7 @@ impl Default for Config {
             rst_asg_thr: 0.6,
             // rst_lbd_len: 8,
             rst_lbd_slw: 8192,
-            rst_lbd_thr: 1.4,
+            rst_lbd_thr: 1.65,
 
             #[cfg(feature = "EVSIDS")]
             vrw_dcy_rat: 0.98,

--- a/src/processor/eliminate.rs
+++ b/src/processor/eliminate.rs
@@ -10,6 +10,9 @@ use {
     },
 };
 
+// Stop elimination if a generated resolvent is larger than this
+const COMBINATION_LIMIT: f64 = 32.0;
+
 pub fn eliminate_var(
     asg: &mut impl AssignIF,
     cdb: &mut impl ClauseDBIF,
@@ -44,7 +47,6 @@ pub fn eliminate_var(
             &w.neg_occurs,
             vi,
             elim.eliminate_grow_limit,
-            elim.eliminate_combination_limit,
         )
     {
         return Ok(());
@@ -160,7 +162,6 @@ fn skip_var_elimination(
     neg: &[ClauseId],
     v: VarId,
     grow_limit: usize,
-    combination_limit: f64,
 ) -> bool {
     // avoid thrashing
     let limit = match cdb.check_size() {
@@ -181,9 +182,7 @@ fn skip_var_elimination(
                 cnt += 1;
                 average_len *= 1.0 - scale;
                 average_len += scale * clause_size as f64;
-                if clslen + limit < cnt
-                    || (combination_limit != 0.0 && combination_limit < average_len)
-                {
+                if clslen + limit < cnt || COMBINATION_LIMIT < average_len {
                     return true;
                 }
             } else {

--- a/src/processor/eliminator.rs
+++ b/src/processor/eliminator.rs
@@ -30,7 +30,7 @@ impl Default for Eliminator {
             bwdsub_assigns: 0,
             elim_lits: Vec::new(),
             eliminate_var_occurrence_limit: 1_000,
-            eliminate_combination_limit: 2.0,
+            eliminate_combination_limit: 0.0,
             eliminate_grow_limit: 0, // 64
             eliminate_occurrence_limit: 800,
             subsume_literal_limit: 100,
@@ -289,14 +289,13 @@ impl EliminateIF for Eliminator {
         }
         if self.enable {
             self.eliminate_grow_limit = state.derefer(state::property::Tusize::IntervalScale) / 2;
-            self.subsume_literal_limit = (state.config.elm_cls_lim
-                + cdb.derefer(cdb::property::Tf64::DpAverageLBD) as usize)
-                / 2;
+            self.subsume_literal_limit =
+                state.config.elm_cls_lim + cdb.derefer(cdb::property::Tf64::DpAverageLBD) as usize;
             if self.is_waiting() {
                 self.prepare(asg, cdb, true);
             }
             debug_assert!(!cdb.derefer(cdb::property::Tf64::DpAverageLBD).is_nan());
-            self.eliminate_combination_limit = cdb.derefer(cdb::property::Tf64::DpAverageLBD);
+            // self.eliminate_combination_limit = cdb.derefer(cdb::property::Tf64::DpAverageLBD);
             self.eliminate(asg, cdb, rst, state)?;
             if self.is_running() {
                 self.stop(asg, cdb);

--- a/src/processor/mod.rs
+++ b/src/processor/mod.rs
@@ -102,10 +102,6 @@ pub struct Eliminator {
     elim_lits: Vec<Lit>,
     /// Maximum number of clauses to try to eliminate a var
     eliminate_var_occurrence_limit: usize,
-    /// 0 for no limit
-    /// Stop elimination if a generated resolvent is larger than this
-    /// 0 means no limit.
-    eliminate_combination_limit: f64,
     /// Stop elimination if the increase of clauses is over this
     eliminate_grow_limit: usize,
     /// A criteria by the product's of its positive occurrences and negative ones

--- a/src/processor/mod.rs
+++ b/src/processor/mod.rs
@@ -22,8 +22,8 @@
 //!```
 
 mod eliminate;
-mod eliminator;
 mod heap;
+mod simplify;
 mod subsume;
 
 use {

--- a/src/processor/simplify.rs
+++ b/src/processor/simplify.rs
@@ -288,13 +288,15 @@ impl EliminateIF for Eliminator {
         }
         if self.enable {
             self.eliminate_grow_limit = state.derefer(state::property::Tusize::IntervalScale) / 2;
-            self.subsume_literal_limit =
-                state.config.elm_cls_lim + cdb.derefer(cdb::property::Tf64::DpAverageLBD) as usize;
+            self.subsume_literal_limit = state.config.elm_cls_lim
+                + cdb.derefer(cdb::property::Tf64::LiteralBlockEntanglement) as usize;
             if self.is_waiting() {
                 self.prepare(asg, cdb, true);
             }
-            debug_assert!(!cdb.derefer(cdb::property::Tf64::DpAverageLBD).is_nan());
-            // self.eliminate_combination_limit = cdb.derefer(cdb::property::Tf64::DpAverageLBD);
+            debug_assert!(!cdb
+                .derefer(cdb::property::Tf64::LiteralBlockEntanglement)
+                .is_nan());
+            // self.eliminate_combination_limit = cdb.derefer(cdb::property::Tf64::LiteralBlockEntanglement);
             self.eliminate(asg, cdb, rst, state)?;
             if self.is_running() {
                 self.stop(asg, cdb);

--- a/src/processor/simplify.rs
+++ b/src/processor/simplify.rs
@@ -30,7 +30,6 @@ impl Default for Eliminator {
             bwdsub_assigns: 0,
             elim_lits: Vec::new(),
             eliminate_var_occurrence_limit: 1_000,
-            eliminate_combination_limit: 0.0,
             eliminate_grow_limit: 0, // 64
             eliminate_occurrence_limit: 800,
             subsume_literal_limit: 100,

--- a/src/solver/conflict.rs
+++ b/src/solver/conflict.rs
@@ -120,7 +120,9 @@ pub fn handle_conflict(
                 if asg.assign_at_root_level(l0).is_err() {
                     unreachable!("handle_conflict::root_level_conflict_by_assertion");
                 }
-                rst.handle(SolverEvent::Assert(l0.vi()));
+                let vi = l0.vi();
+                rst.handle(SolverEvent::Assert(vi));
+                cdb.handle(SolverEvent::Assert(vi));
                 return Ok(0);
             }
         }

--- a/src/solver/conflict.rs
+++ b/src/solver/conflict.rs
@@ -195,7 +195,6 @@ pub fn handle_conflict(
                 assign_level,
             );
             // || check_graph(asg, cdb, l0, "biclause");
-            rst.update(ProgressUpdate::LBD(1));
             for cid in &state.derive20 {
                 cdb[cid].turn_on(FlagClause::DERIVE20);
             }
@@ -217,7 +216,6 @@ pub fn handle_conflict(
             );
             // || check_graph(asg, cdb, l0, "clause");
             rank = cdb[cid].rank;
-            rst.update(ProgressUpdate::LBD(rank));
             if rank <= 20 {
                 for cid in &state.derive20 {
                     cdb[cid].turn_on(FlagClause::DERIVE20);

--- a/src/solver/conflict.rs
+++ b/src/solver/conflict.rs
@@ -1,13 +1,12 @@
 //! Conflict Analysis
 
+#[cfg(feature = "Luby_restart")]
+use super::restart::{ProgressUpdate, RestartIF};
 #[cfg(feature = "boundary_check")]
 use crate::assign::DebugReportIF;
 
 use {
-    super::{
-        restart::{ProgressUpdate, RestartIF, Restarter},
-        State,
-    },
+    super::{restart::Restarter, State},
     crate::{
         assign::{AssignIF, AssignStack, PropagateIF, VarManipulateIF},
         cdb::{ClauseDB, ClauseDBIF},
@@ -50,6 +49,7 @@ pub fn handle_conflict(
     #[cfg(not(feature = "chrono_BT"))]
     let chronobt: bool = false;
 
+    #[cfg(feature = "Luby_restart")]
     rst.update(ProgressUpdate::Counter);
     // rst.block_restart(); // to update asg progress_evaluator
 

--- a/src/solver/restart.rs
+++ b/src/solver/restart.rs
@@ -12,28 +12,23 @@ trait ProgressEvaluator {
 }
 
 /// Update progress observer sub-modules
+#[cfg(feature = "Luby_restart")]
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd)]
-pub enum ProgressUpdate {
-    ASG(usize),
+enum ProgressUpdate {
     Counter,
-
-    #[cfg(feature = "Luby_restart")]
     Luby,
 }
 
 /// API for [`restart`](`crate::solver::RestartIF::restart`) and [`stabilize`](`crate::solver::RestartIF::stabilize`).
-pub trait RestartIF:
-    Instantiate
-    + PropertyDereference<property::Tusize, usize>
-    + PropertyReference<property::TEma2, EmaView>
-{
+pub trait RestartIF: Instantiate + PropertyDereference<property::Tusize, usize> {
     /// check blocking and forcing restart condition.
-    fn restart(&mut self, lbd: &EmaView) -> Option<RestartDecision>;
+    fn restart(&mut self, asg: &EmaView, lbd: &EmaView) -> Option<RestartDecision>;
     /// set stabilization parameters
     fn set_sensibility(&mut self, step: usize, step_max: usize);
     #[cfg(feature = "dynamic_restart_threshold")]
     /// adjust restart threshold
     fn adjust(&mut self, base: f64, c_lvl: f64, b_lvl: f64, used: f64);
+    #[cfg(feature = "Luby_restart")]
     /// update specific sub-module
     fn update(&mut self, kind: ProgressUpdate);
 
@@ -41,128 +36,6 @@ pub trait RestartIF:
     /// dynamic adaptation of restart interval
     fn scale_restart_step(&mut self, scale: f64);
 }
-
-const ASG_EWA_LEN: usize = 24;
-
-/// An assignment history used for blocking restart.
-#[derive(Clone, Debug)]
-struct ProgressASG {
-    enable: bool,
-    ema: Ewa2<ASG_EWA_LEN>,
-    /// For block restart based on average assignments: 1.40.
-    /// This is called `R` in Glucose
-    threshold: f64,
-}
-
-impl Default for ProgressASG {
-    fn default() -> ProgressASG {
-        ProgressASG {
-            enable: true,
-            ema: Ewa2::<ASG_EWA_LEN>::new(0.0),
-            threshold: 1.6,
-        }
-    }
-}
-
-impl Instantiate for ProgressASG {
-    fn instantiate(config: &Config, _cnf: &CNFDescription) -> Self {
-        ProgressASG {
-            ema: Ewa2::new(0.0).with_slow(config.rst_asg_slw),
-            threshold: config.rst_asg_thr,
-            ..ProgressASG::default()
-        }
-    }
-}
-
-impl EmaIF for ProgressASG {
-    fn get_fast(&self) -> f64 {
-        self.ema.get()
-    }
-    fn trend(&self) -> f64 {
-        self.ema.trend()
-    }
-}
-
-impl EmaMutIF for ProgressASG {
-    type Input = usize;
-    fn update(&mut self, n: usize) {
-        self.ema.update(n as f64);
-    }
-    fn as_view(&self) -> &EmaView {
-        self.ema.as_view()
-    }
-}
-
-impl ProgressEvaluator for ProgressASG {
-    fn is_active(&self) -> bool {
-        self.enable && self.trend() < self.threshold
-    }
-    fn shift(&mut self) {}
-}
-
-/*
-/// An EMA of learnt clauses' LBD, used for forcing restart.
-#[derive(Clone, Debug)]
-struct ProgressLBD {
-    enable: bool,
-    ema: Ewa2<LBD_EWA_LEN>,
-    num: usize,
-    sum: usize,
-    /// For force restart based on average LBD of newly generated clauses: 0.80.
-    /// This is called `K` in Glucose
-    threshold: f64,
-}
-
-impl Default for ProgressLBD {
-    fn default() -> ProgressLBD {
-        ProgressLBD {
-            enable: true,
-            ema: Ewa2::<LBD_EWA_LEN>::new(0.0),
-            num: 0,
-            sum: 0,
-            threshold: 1.4,
-        }
-    }
-}
-
-impl Instantiate for ProgressLBD {
-    fn instantiate(config: &Config, _: &CNFDescription) -> Self {
-        ProgressLBD {
-            ema: Ewa2::new(0.0).with_slow(config.rst_lbd_slw),
-            threshold: config.rst_lbd_thr,
-            ..ProgressLBD::default()
-        }
-    }
-}
-
-impl EmaIF for ProgressLBD {
-    fn get_fast(&self) -> f64 {
-        self.ema.get_fast()
-    }
-    fn trend(&self) -> f64 {
-        self.ema.trend()
-    }
-}
-
-impl EmaMutIF for ProgressLBD {
-    type Input = u16;
-    fn update(&mut self, d: Self::Input) {
-        self.num += 1;
-        self.sum += d as usize;
-        self.ema.update(d as f64);
-    }
-    fn as_view(&self) -> &EmaView {
-        self.ema.as_view()
-    }
-}
-
-impl ProgressEvaluator for ProgressLBD {
-    fn is_active(&self) -> bool {
-        self.enable && self.threshold < self.trend()
-    }
-    fn shift(&mut self) {}
-}
-*/
 
 /// An EMA of decision level.
 #[derive(Clone, Debug)]
@@ -282,12 +155,12 @@ impl ProgressEvaluator for ProgressLuby {
 /// `Restarter` provides restart API and holds data about restart conditions.
 #[derive(Clone, Debug, Default)]
 pub struct Restarter {
-    asg: ProgressASG,
+    /// For block restart based on average assignments: 1.40.
+    /// This is called `R` in Glucose
+    asg_threshold: f64,
     /// For force restart based on average LBD of newly generated clauses: 0.80.
     /// This is called `K` in Glucose
     lbd_threshold: f64,
-    // pub blvl: ProgressLVL,
-    // pub clvl: ProgressLVL,
     luby: ProgressLuby,
     after_restart: usize,
     restart_step: usize,
@@ -307,10 +180,8 @@ pub struct Restarter {
 impl Instantiate for Restarter {
     fn instantiate(config: &Config, cnf: &CNFDescription) -> Self {
         Restarter {
-            asg: ProgressASG::instantiate(config, cnf),
+            asg_threshold: config.rst_asg_thr,
             lbd_threshold: config.rst_lbd_thr,
-            // blvl: ProgressLVL::instantiate(config, cnf),
-            // clvl: ProgressLVL::instantiate(config, cnf),
             luby: ProgressLuby::instantiate(config, cnf),
             restart_step: config.rst_step,
             initial_restart_step: config.rst_step,
@@ -340,7 +211,7 @@ pub enum RestartDecision {
 }
 
 impl RestartIF for Restarter {
-    fn restart(&mut self, lbd: &EmaView) -> Option<RestartDecision> {
+    fn restart(&mut self, asg: &EmaView, lbd: &EmaView) -> Option<RestartDecision> {
         macro_rules! next_step {
             () => {
                 self.stb_step * self.initial_restart_step
@@ -357,7 +228,7 @@ impl RestartIF for Restarter {
         }
 
         if self.stb_step_max * self.num_block < self.stb_step * self.num_restart
-            && self.asg.is_active()
+            && asg.trend() < self.asg_threshold
         {
             self.num_block += 1;
             self.after_restart = 0;
@@ -396,29 +267,28 @@ impl RestartIF for Restarter {
                 .powf(CONTROL_FACTOR)
                 .clamp(1.0, base);
     }
+    #[cfg(feature = "Luby_restart")]
     fn update(&mut self, kind: ProgressUpdate) {
         match kind {
             ProgressUpdate::Counter => {
                 self.after_restart += 1;
                 self.luby.update(self.after_restart);
             }
-            ProgressUpdate::ASG(val) => self.asg.update(val),
-
-            #[cfg(feature = "Luby_restart")]
+            // ProgressUpdate::ASG(val) => self.asg.update(val),
             ProgressUpdate::Luby => self.luby.update(0),
         }
     }
     #[cfg(feature = "Luby_restart")]
     fn scale_restart_step(&mut self, scale: f64) {
         const LIMIT: f64 = 1.2;
-        let thr = self.lbd.threshold * scale;
+        let thr = self.lbd_threshold * scale;
         if LIMIT <= thr {
-            self.lbd.threshold = thr;
+            self.lbd_threshold = thr;
         } else {
-            self.lbd.threshold += LIMIT;
-            self.lbd.threshold *= 0.5;
+            self.lbd_threshold += LIMIT;
+            self.lbd_threshold *= 0.5;
         }
-        dbg!(self.lbd.threshold);
+        dbg!(self.lbd_threshold);
     }
 }
 
@@ -455,20 +325,6 @@ pub mod property {
         fn derefer(&self, k: Tf64) -> f64 {
             match k {
                 Tf64::RestartThreshold => self.lbd_threshold,
-            }
-        }
-    }
-
-    #[derive(Clone, Debug, PartialEq)]
-    pub enum TEma2 {
-        ASG,
-    }
-
-    impl PropertyReference<TEma2, EmaView> for Restarter {
-        #[inline]
-        fn refer(&self, k: TEma2) -> &EmaView {
-            match k {
-                TEma2::ASG => &self.asg.as_view(),
             }
         }
     }

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -185,18 +185,10 @@ impl SolveIF for Solver {
                 #[cfg(feature = "boundary_check")]
                 check(asg, cdb, true, "Before extending the model");
 
-                #[cfg(fueature = "boundary_check")]
-                check(asg, cdb, true, "Before extending the model");
-
                 let model = asg.extend_model(cdb, elim.eliminated_lits());
 
-                #[cfg(fueature = "boundary_check")]
-                check(
-                    asg,
-                    cdb,
-                    true,
-                    "After extending the model, (passed before extending)",
-                );
+                #[cfg(feature = "boundary_check")]
+                check(asg, cdb, true, "After extending the model");
 
                 // Run validator on the extended model.
                 if cdb.validate(&model, false).is_some() {

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -10,7 +10,7 @@ use {
     },
     crate::{
         assign::{self, AssignIF, AssignStack, PropagateIF, VarManipulateIF, VarSelectIF},
-        cdb::{self, ClauseDB, ClauseDBIF},
+        cdb::{ClauseDB, ClauseDBIF},
         processor::{EliminateIF, Eliminator},
         state::{Stat, State, StateIF},
         types::*,
@@ -301,7 +301,11 @@ fn search(
                     return Err(SolverError::UndescribedError);
                 }
                 RESTART!(asg, rst);
-                cdb.reduce(asg, state.stm.num_reducible());
+                cdb.reduce(
+                    asg,
+                    state.stm.num_reducible(),
+                    rst.refer(restart::property::TEma2::LBD).get_slow(),
+                );
 
                 #[cfg(feature = "trace_equivalency")]
                 cdb.check_consistency(asg, "before simplify");
@@ -349,7 +353,7 @@ fn search(
                             state.config.rst_lbd_thr,
                             state.c_lvl.get(),
                             state.b_lvl.get(),
-                            cdb.derefer(cdb::property::Tf64::DpAverageLBD),
+                            cdb.derefer(crate::cdb::property::Tf64::DpAverageLBD),
                         );
                     }
 

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -5,7 +5,7 @@ use crate::cdb::VivifyIF;
 use {
     super::{
         conflict::handle_conflict,
-        restart::{self, ProgressUpdate, RestartDecision, RestartIF, Restarter},
+        restart::{self, RestartDecision, RestartIF, Restarter},
         Certificate, Solver, SolverEvent, SolverResult,
     },
     crate::{
@@ -281,9 +281,6 @@ fn search(
             if 1 < handle_conflict(asg, cdb, rst, state, &cc)? {
                 num_learnt += 1;
             }
-            rst.update(ProgressUpdate::ASG(
-                asg.derefer(assign::property::Tusize::NumUnassignedVar),
-            ));
             if state.stm.stage_ended(num_learnt) {
                 if let Some(p) = state.elapsed() {
                     if 1.0 <= p {
@@ -349,8 +346,10 @@ fn search(
                     // call the enhanced phase saver
                     asg.handle(SolverEvent::Stabilize(scale));
                 }
-            } else if rst.restart(cdb.refer(cdb::property::TEma::LBD))
-                == Some(RestartDecision::Force)
+            } else if rst.restart(
+                asg.refer(assign::property::TEma::AssignRate),
+                cdb.refer(cdb::property::TEma::LBD),
+            ) == Some(RestartDecision::Force)
             {
                 RESTART!(asg, rst);
             }

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -293,11 +293,7 @@ fn search(
                     return Err(SolverError::UndescribedError);
                 }
                 RESTART!(asg, rst);
-                cdb.reduce(
-                    asg,
-                    state.stm.num_reducible(),
-                    rst.refer(restart::property::TEma2::LBD).get_slow(),
-                );
+                cdb.reduce(asg, state.stm.num_reducible());
 
                 #[cfg(feature = "trace_equivalency")]
                 cdb.check_consistency(asg, "before simplify");
@@ -345,7 +341,7 @@ fn search(
                             state.config.rst_lbd_thr,
                             state.c_lvl.get(),
                             state.b_lvl.get(),
-                            cdb.derefer(crate::cdb::property::Tf64::DpAverageLBD),
+                            cdb.derefer(crate::cdb::property::Tf64::LiteralBlockEntanglement),
                         );
                     }
 

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -10,7 +10,7 @@ use {
     },
     crate::{
         assign::{self, AssignIF, AssignStack, PropagateIF, VarManipulateIF, VarSelectIF},
-        cdb::{ClauseDB, ClauseDBIF},
+        cdb::{self, ClauseDB, ClauseDBIF},
         processor::{EliminateIF, Eliminator},
         state::{Stat, State, StateIF},
         types::*,
@@ -349,7 +349,9 @@ fn search(
                     // call the enhanced phase saver
                     asg.handle(SolverEvent::Stabilize(scale));
                 }
-            } else if rst.restart() == Some(RestartDecision::Force) {
+            } else if rst.restart(cdb.refer(cdb::property::TEma::LBD))
+                == Some(RestartDecision::Force)
+            {
                 RESTART!(asg, rst);
             }
             if let Some(na) = asg.best_assigned() {

--- a/src/solver/stage.rs
+++ b/src/solver/stage.rs
@@ -84,7 +84,9 @@ impl StageManager {
         self.cycle * self.unit_size
     }
     pub fn num_reducible(&self) -> usize {
-        self.current_span()
+        let span = self.current_span();
+        let keep = 2 * (span as f64).sqrt() as usize;
+        span - keep
     }
     pub fn current_stage(&self) -> usize {
         self.stage

--- a/src/solver/stage.rs
+++ b/src/solver/stage.rs
@@ -84,10 +84,7 @@ impl StageManager {
         self.cycle * self.unit_size
     }
     pub fn num_reducible(&self) -> usize {
-        // self.current_span() - self.scale / 2
-        // self.current_span().saturating_sub(100)
-        let num_keep = 2 * (self.current_span() as f64).sqrt() as usize;
-        self.current_span() - num_keep
+        self.current_span()
     }
     pub fn current_stage(&self) -> usize {
         self.stage

--- a/src/state.rs
+++ b/src/state.rs
@@ -42,7 +42,8 @@ pub trait StateIF {
         A: PropertyDereference<assign::property::Tusize, usize>
             + PropertyReference<assign::property::TEma, EmaView>,
         C: PropertyDereference<cdb::property::Tusize, usize>
-            + PropertyDereference<cdb::property::Tf64, f64>,
+            + PropertyDereference<cdb::property::Tf64, f64>
+            + PropertyReference<cdb::property::TEma, EmaView>,
         E: PropertyDereference<processor::property::Tusize, usize>,
         R: PropertyDereference<solver::restart::property::Tusize, usize>
             + PropertyReference<solver::restart::property::TEma2, EmaView>;
@@ -463,7 +464,8 @@ impl StateIF for State {
         A: PropertyDereference<assign::property::Tusize, usize>
             + PropertyReference<assign::property::TEma, EmaView>,
         C: PropertyDereference<cdb::property::Tusize, usize>
-            + PropertyDereference<cdb::property::Tf64, f64>,
+            + PropertyDereference<cdb::property::Tf64, f64>
+            + PropertyReference<cdb::property::TEma, EmaView>,
         E: PropertyDereference<processor::property::Tusize, usize>,
         R: PropertyDereference<solver::restart::property::Tusize, usize>
             + PropertyReference<solver::restart::property::TEma2, EmaView>,
@@ -505,7 +507,7 @@ impl StateIF for State {
         let rst_int_scl: usize = self.stm.current_scale();
         let rst_int_scl_max: usize = self.stm.max_scale();
         let rst_asg: &EmaView = rst.refer(solver::restart::property::TEma2::ASG);
-        let rst_lbd: &EmaView = rst.refer(solver::restart::property::TEma2::LBD);
+        let rst_lbd: &EmaView = cdb.refer(cdb::property::TEma::LBD);
 
         if self.config.use_log {
             self.dump(asg, cdb, rst);
@@ -667,7 +669,8 @@ impl State {
         A: PropertyDereference<assign::property::Tusize, usize>
             + PropertyReference<assign::property::TEma, EmaView>,
         C: PropertyDereference<cdb::property::Tusize, usize>
-            + PropertyDereference<cdb::property::Tf64, f64>,
+            + PropertyDereference<cdb::property::Tf64, f64>
+            + PropertyReference<cdb::property::TEma, EmaView>,
         E: PropertyDereference<processor::property::Tusize, usize>,
         R: PropertyDereference<solver::restart::property::Tusize, usize>
             + PropertyReference<solver::restart::property::TEma2, EmaView>,
@@ -701,7 +704,7 @@ impl State {
         self[LogUsizeId::VivifiedClause] = self[Stat::VivifiedClause];
         self[LogUsizeId::VivifiedVar] = self[Stat::VivifiedVar];
         self[LogUsizeId::Vivify] = self[Stat::Vivification];
-        let rst_lbd: &EmaView = rst.refer(solver::restart::property::TEma2::LBD);
+        let rst_lbd: &EmaView = cdb.refer(cdb::property::TEma::LBD);
         self[LogF64Id::EmaLBD] = rst_lbd.get_fast();
         self[LogF64Id::TrendLBD] = rst_lbd.trend();
 
@@ -869,7 +872,8 @@ impl State {
     fn dump_details<'r, A, C, E, R, V>(&mut self, asg: &A, cdb: &C, rst: &'r R)
     where
         A: PropertyDereference<assign::property::Tusize, usize>,
-        C: PropertyDereference<cdb::property::Tusize, usize>,
+        C: PropertyDereference<cdb::property::Tusize, usize>
+            + PropertyReference<cdb::property::TEma, EmaView>,
         R: PropertyDereference<solver::restart::property::Tusize, usize>
             + PropertyReference<solver::restart::property::TEma2, Ema2>,
     {
@@ -884,7 +888,7 @@ impl State {
         let cdb_num_learnt = cdb.derefer(cdb::property::Tusize::NumLearnt);
         let rst_num_block = rst.derefer(solver::restart::property::Tusize::NumBlock);
         let rst_asg = rst.refer(solver::restart::property::TEma2::ASG);
-        let rst_lbd = rst.refer(solver::restart::property::TEma2::LBD);
+        let rst_lbd = cdb.refer(cdb::property::TEma::LBD);
 
         println!(
             "{:>3},{:>7},{:>7},{:>7},{:>6.3},,{:>7},{:>7},\

--- a/src/state.rs
+++ b/src/state.rs
@@ -495,7 +495,7 @@ impl StateIF for State {
         let cdb_num_bi_clause = cdb.derefer(cdb::property::Tusize::NumBiClause);
         let cdb_num_lbd2 = cdb.derefer(cdb::property::Tusize::NumLBD2);
         let cdb_num_learnt = cdb.derefer(cdb::property::Tusize::NumLearnt);
-        let cdb_lbd_of_dp: f64 = cdb.derefer(cdb::property::Tf64::DpAverageLBD);
+        let cdb_lbd_of_dp: f64 = cdb.derefer(cdb::property::Tf64::LiteralBlockEntanglement);
 
         let elim_num_full = elim.derefer(processor::property::Tusize::NumFullElimination);
         let elim_num_sub = elim.derefer(processor::property::Tusize::NumSubsumedClause);
@@ -595,7 +595,12 @@ impl StateIF for State {
             "\x1B[2K         LBD|trnd:{}, avrg:{}, depG:{}, /dpc:{}",
             fm!("{:>9.4}", self, LogF64Id::TrendLBD, rst_lbd.trend()),
             fm!("{:>9.4}", self, LogF64Id::EmaLBD, rst_lbd.get_fast()),
-            fm!("{:>9.4}", self, LogF64Id::DpAverageLBD, cdb_lbd_of_dp),
+            fm!(
+                "{:>9.4}",
+                self,
+                LogF64Id::LiteralBlockEntanglement,
+                cdb_lbd_of_dp
+            ),
             fm!(
                 "{:>9.2}",
                 self,
@@ -700,7 +705,8 @@ impl State {
         self[LogF64Id::EmaLBD] = rst_lbd.get_fast();
         self[LogF64Id::TrendLBD] = rst_lbd.trend();
 
-        self[LogF64Id::DpAverageLBD] = cdb.derefer(cdb::property::Tf64::DpAverageLBD);
+        self[LogF64Id::LiteralBlockEntanglement] =
+            cdb.derefer(cdb::property::Tf64::LiteralBlockEntanglement);
         self[LogF64Id::DecisionPerConflict] =
             asg.refer(assign::property::TEma::DecisionPerConflict).get();
 
@@ -972,7 +978,7 @@ pub enum LogF64Id {
     DecisionPerConflict,
     ConflictPerRestart,
     PropagationPerConflict,
-    DpAverageLBD,
+    LiteralBlockEntanglement,
     End,
 }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -1115,8 +1115,8 @@ pub mod property {
         #[inline]
         fn refer(&self, k: TEma) -> &EmaView {
             match k {
-                TEma::BackjumpLevel => &self.b_lvl.as_view(),
-                TEma::ConflictLevel => &self.c_lvl.as_view(),
+                TEma::BackjumpLevel => self.b_lvl.as_view(),
+                TEma::ConflictLevel => self.c_lvl.as_view(),
             }
         }
     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -45,8 +45,7 @@ pub trait StateIF {
             + PropertyDereference<cdb::property::Tf64, f64>
             + PropertyReference<cdb::property::TEma, EmaView>,
         E: PropertyDereference<processor::property::Tusize, usize>,
-        R: PropertyDereference<solver::restart::property::Tusize, usize>
-            + PropertyReference<solver::restart::property::TEma2, EmaView>;
+        R: PropertyDereference<solver::restart::property::Tusize, usize>;
     /// write a short message to stdout.
     fn flush<S: AsRef<str>>(&self, mes: S);
     /// write a one-line message as log.
@@ -467,8 +466,7 @@ impl StateIF for State {
             + PropertyDereference<cdb::property::Tf64, f64>
             + PropertyReference<cdb::property::TEma, EmaView>,
         E: PropertyDereference<processor::property::Tusize, usize>,
-        R: PropertyDereference<solver::restart::property::Tusize, usize>
-            + PropertyReference<solver::restart::property::TEma2, EmaView>,
+        R: PropertyDereference<solver::restart::property::Tusize, usize>,
     {
         if !self.config.splr_interface || self.config.quiet_mode {
             self.log_messages.clear();
@@ -506,7 +504,7 @@ impl StateIF for State {
         let rst_num_rst: usize = rst.derefer(solver::restart::property::Tusize::NumRestart);
         let rst_int_scl: usize = self.stm.current_scale();
         let rst_int_scl_max: usize = self.stm.max_scale();
-        let rst_asg: &EmaView = rst.refer(solver::restart::property::TEma2::ASG);
+        let rst_asg: &EmaView = asg.refer(assign::property::TEma::AssignRate);
         let rst_lbd: &EmaView = cdb.refer(cdb::property::TEma::LBD);
 
         if self.config.use_log {
@@ -672,8 +670,7 @@ impl State {
             + PropertyDereference<cdb::property::Tf64, f64>
             + PropertyReference<cdb::property::TEma, EmaView>,
         E: PropertyDereference<processor::property::Tusize, usize>,
-        R: PropertyDereference<solver::restart::property::Tusize, usize>
-            + PropertyReference<solver::restart::property::TEma2, EmaView>,
+        R: PropertyDereference<solver::restart::property::Tusize, usize>,
     {
         self[LogUsizeId::NumConflict] = asg.derefer(assign::property::Tusize::NumConflict);
         self[LogUsizeId::NumDecision] = asg.derefer(assign::property::Tusize::NumDecision);
@@ -713,7 +710,7 @@ impl State {
         self[LogF64Id::DecisionPerConflict] =
             asg.refer(assign::property::TEma::DecisionPerConflict).get();
 
-        self[LogF64Id::TrendASG] = rst.refer(solver::restart::property::TEma2::ASG).trend();
+        self[LogF64Id::TrendASG] = asg.refer(assign::property::TEma::AssignRate).trend();
         self[LogF64Id::CLevel] = self.c_lvl.get();
         self[LogF64Id::BLevel] = self.b_lvl.get();
         self[LogF64Id::PropagationPerConflict] = asg
@@ -871,11 +868,11 @@ impl State {
     #[allow(dead_code)]
     fn dump_details<'r, A, C, E, R, V>(&mut self, asg: &A, cdb: &C, rst: &'r R)
     where
-        A: PropertyDereference<assign::property::Tusize, usize>,
+        A: PropertyDereference<assign::property::Tusize, usize>
+            + PropertyReference<assign::property::TEma, EmaView>,
         C: PropertyDereference<cdb::property::Tusize, usize>
             + PropertyReference<cdb::property::TEma, EmaView>,
-        R: PropertyDereference<solver::restart::property::Tusize, usize>
-            + PropertyReference<solver::restart::property::TEma2, Ema2>,
+        R: PropertyDereference<solver::restart::property::Tusize, usize>,
     {
         self.progress_cnt += 1;
         let asg_num_vars = asg.derefer(assign::property::Tusize::NumVar);
@@ -887,7 +884,7 @@ impl State {
         let cdb_num_clause = cdb.derefer(cdb::property::Tusize::NumClause);
         let cdb_num_learnt = cdb.derefer(cdb::property::Tusize::NumLearnt);
         let rst_num_block = rst.derefer(solver::restart::property::Tusize::NumBlock);
-        let rst_asg = rst.refer(solver::restart::property::TEma2::ASG);
+        let rst_asg = asg.refer(assign::property::TEma::AssignRate);
         let rst_lbd = cdb.refer(cdb::property::TEma::LBD);
 
         println!(

--- a/src/types.rs
+++ b/src/types.rs
@@ -26,6 +26,7 @@ pub use {
 pub trait PropertyReference<I, O> {
     fn refer(&self, key: I) -> &O;
 }
+
 pub trait PropertyDereference<I, O: Sized> {
     fn derefer(&self, key: I) -> O;
 }


### PR DESCRIPTION
In this branch, we

- change the definition of `ProgressASG`. It counts the number of literals ***after*** restart. 
- change the definition of `lbd_of_dp` and rename it to `literal block entanglement`.