### PR TITLE
Allow infinite restart thresholds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "splr"
-version = "0.15.0-alpha3"
+version = "0.15.0-alpha4"
 authors = ["Narazaki Shuji <shujinarazaki@protonmail.com>"]
 description = "A modern CDCL SAT solver in Rust"
 edition = "2021"

--- a/src/cdb/db.rs
+++ b/src/cdb/db.rs
@@ -195,6 +195,10 @@ impl Instantiate for ClauseDB {
                 self.watch_cache.push(WatchCache::new());
                 self.lbd_temp.push(0);
             }
+            SolverEvent::Restart => {
+                // self.lbd.reset_to(self.lb_entanglement.get());
+                self.lbd.reset_to(0.0);
+            }
             _ => (),
         }
     }

--- a/src/cdb/ema.rs
+++ b/src/cdb/ema.rs
@@ -1,11 +1,11 @@
 use crate::types::*;
 
-const LBD_EWA_LEN: usize = 16;
+const LBD_EWA_LEN: usize = 24;
 
 /// An EMA of learnt clauses' LBD, used for forcing restart.
 #[derive(Clone, Debug)]
 pub struct ProgressLBD {
-    ema: Ewa2<LBD_EWA_LEN>,
+    ema: Ema2,
     num: usize,
     sum: usize,
 }
@@ -13,7 +13,7 @@ pub struct ProgressLBD {
 impl Default for ProgressLBD {
     fn default() -> ProgressLBD {
         ProgressLBD {
-            ema: Ewa2::<LBD_EWA_LEN>::new(0.0),
+            ema: Ema2::new(LBD_EWA_LEN),
             num: 0,
             sum: 0,
         }
@@ -23,7 +23,7 @@ impl Default for ProgressLBD {
 impl Instantiate for ProgressLBD {
     fn instantiate(config: &Config, _: &CNFDescription) -> Self {
         ProgressLBD {
-            ema: Ewa2::new(0.0).with_slow(config.rst_lbd_slw),
+            ema: Ema2::new(LBD_EWA_LEN).with_slow(config.rst_lbd_slw),
             ..ProgressLBD::default()
         }
     }
@@ -44,6 +44,9 @@ impl EmaMutIF for ProgressLBD {
         self.num += 1;
         self.sum += d as usize;
         self.ema.update(d as f64);
+    }
+    fn reset_to(&mut self, val: f64) {
+        self.ema.reset_to(val);
     }
     fn as_view(&self) -> &EmaView {
         self.ema.as_view()

--- a/src/cdb/mod.rs
+++ b/src/cdb/mod.rs
@@ -355,13 +355,17 @@ pub mod property {
 
     #[derive(Clone, Debug, PartialEq)]
     pub enum TEma {
+        Entanglement,
         LBD,
     }
+
+    pub const EMAS: [TEma; 2] = [TEma::Entanglement, TEma::LBD];
 
     impl PropertyReference<TEma, EmaView> for ClauseDB {
         #[inline]
         fn refer(&self, k: TEma) -> &EmaView {
             match k {
+                TEma::Entanglement => self.lb_entanglement.as_view(),
                 TEma::LBD => self.lbd.as_view(),
             }
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -74,8 +74,6 @@ pub struct Config {
     //
     //## restarter
     //
-    /// #conflicts between restarts
-    pub rst_step: usize,
 
     // /// Length of assign. fast EMA
     // pub rst_asg_len: usize,
@@ -131,7 +129,6 @@ impl Default for Config {
             elm_grw_lim: 0,
             elm_var_occ: 20000,
 
-            rst_step: 6,
             // rst_asg_len: 16,
             rst_asg_slw: 8192,
             rst_asg_thr: 0.6,
@@ -171,7 +168,7 @@ impl Config {
                 let options_u32 = ["cbt"];
                 let options_usize = [
                     // "cl", "ii", "stat", "ecl", "evl", "evo", "rs", "ral", "ras", "rll", "rls",
-                    "cl", "ii", "stat", "ecl", "evl", "evo", "rs", "ras", "rls",
+                    "cl", "ii", "stat", "ecl", "evl", "evo", "ras", "rls",
                 ];
                 let options_f64 = ["timeout", "cdr", "rat", "rlt", "vdr", "vds"];
                 let options_path = ["dir", "proof", "result"];
@@ -212,7 +209,6 @@ impl Config {
                                         "ecl" => self.elm_cls_lim = val,
                                         "evl" => self.elm_grw_lim = val,
                                         "evo" => self.elm_var_occ = val,
-                                        "rs" => self.rst_step = val,
                                         // "ral" => self.rst_asg_len = val,
                                         "ras" => self.rst_asg_slw = val,
                                         // "rll" => self.rst_lbd_len = val,
@@ -386,7 +382,6 @@ OPTIONS (\x1B[000m\x1B[031mred\x1B[000m options depend on features in Cargo.toml
       --rat <rst-asg-thr>   Blocking restart threshold        {:>10.2}
       --rls <rst-lbd-slw>   Length of LBD slow EMA         {:>10}
       --rlt <rst-lbd-thr>   Forcing restart threshold         {:>10.2}
-      --rs  <rst-step>      #conflicts between restarts    {:>10}
       --vdr <vrw-dcy-rat>   Var reward decay rate             {:>10.2}
       \x1B[000m\x1B[031m--vds <vrw-dcy-stp>   Var reward decay change step      {:>10.2}\x1B[000m
 ARGS:
@@ -409,7 +404,6 @@ ARGS:
         // config.rst_lbd_len,
         config.rst_lbd_slw,
         config.rst_lbd_thr,
-        config.rst_step,
         config.vrw_dcy_rat,
         config.vrw_dcy_stp,
     )

--- a/src/primitive/ema.rs
+++ b/src/primitive/ema.rs
@@ -29,7 +29,9 @@ pub trait EmaMutIF: EmaIF {
     /// the type of the argument of `update`.
     type Input;
     /// reset internal data.
-    fn reset(&mut self) {}
+    fn reset_to(&mut self, _: f64) {}
+    fn reset_fast(&mut self) {}
+    fn reset_slow(&mut self) {}
     /// catch up with the current state.
     fn update(&mut self, x: Self::Input);
     /// return a view.
@@ -175,12 +177,24 @@ impl EmaMutIF for Ema2 {
         self.calf = self.fe + (1.0 - self.fe) * self.calf;
         self.cals = self.se + (1.0 - self.se) * self.cals;
     }
+    fn reset_to(&mut self, val: f64) {
+        self.ema.fast = val;
+    }
     #[cfg(not(feature = "EMA_calibration"))]
-    fn reset(&mut self) {
+    fn reset_fast(&mut self) {
+        self.ema.fast = self.ema.slow;
+    }
+    #[cfg(feature = "EMA_calibration")]
+    fn reset_fast(&mut self) {
+        self.ema.fast = self.ema.slow;
+        self.calf = self.cals;
+    }
+    #[cfg(not(feature = "EMA_calibration"))]
+    fn reset_slow(&mut self) {
         self.ema.slow = self.ema.fast;
     }
     #[cfg(feature = "EMA_calibration")]
-    fn reset(&mut self) {
+    fn reset_slow(&mut self) {
         self.ema.slow = self.ema.fast;
         self.cals = self.calf;
     }
@@ -341,12 +355,23 @@ impl<const N: usize> EmaMutIF for Ewa2<N> {
             self.cals = self.se + self.sx * self.cals;
         }
     }
+    fn reset_to(&mut self, val: f64) {
+        self.ema.fast = val;
+    }
     #[cfg(not(feature = "EMA_calibration"))]
-    fn reset(&mut self) {
+    fn reset_fast(&mut self) {
+        unimplemented!();
+    }
+    #[cfg(feature = "EMA_calibration")]
+    fn reset_fast(&mut self) {
+        unimplemented!();
+    }
+    #[cfg(not(feature = "EMA_calibration"))]
+    fn reset_slow(&mut self) {
         self.ema.slow = self.ema.fast;
     }
     #[cfg(feature = "EMA_calibration")]
-    fn reset(&mut self) {
+    fn reset_slow(&mut self) {
         self.ema.slow = self.fast.get();
         self.cals = self.calf;
     }

--- a/src/solver/restart.rs
+++ b/src/solver/restart.rs
@@ -81,7 +81,7 @@ impl RestartIF for Restarter {
             let restarts = (self.num_restart - self.num_restart_pre) as f64;
             let center: f64 = 1.0;
             let s = restarts.log(expects) - center;
-            center + s.signum() * s.abs().powf(1.4)
+            center + s.signum() * s.powf(1.4)
         };
         self.restart_threshold = self.restart_threshold.powf(scale);
         self.num_restart_pre = self.num_restart;

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -233,6 +233,7 @@ fn search(
 ) -> Result<bool, SolverError> {
     let mut current_stage: Option<bool> = Some(true);
     let mut num_learnt = 0;
+    let mut found_assignment = false;
 
     state.stm.initialize(
         (asg.derefer(assign::property::Tusize::NumUnassertedVar) as f64).sqrt() as usize,
@@ -249,8 +250,10 @@ fn search(
             asg.update_activity_tick();
             #[cfg(feature = "clause_rewarding")]
             cdb.update_activity_tick();
-            if 1 < handle_conflict(asg, cdb, rst, state, &cc)? {
-                num_learnt += 1;
+            match handle_conflict(asg, cdb, rst, state, &cc)? {
+                0 => found_assignment = true,
+                n if 1 < n => num_learnt += 1,
+                _ => (),
             }
             if state.stm.stage_ended(num_learnt) {
                 if let Some(p) = state.elapsed() {
@@ -284,8 +287,13 @@ fn search(
                             elim.simplify(asg, cdb, rst, state, false)?;
                         }
                         if cfg!(feature = "dynamic_restart_threshold") {
-                            rst.adjust_threshold(span_pre, state.stm.current_segment());
+                            rst.adjust_threshold(
+                                span_pre,
+                                state.stm.current_segment(),
+                                !found_assignment,
+                            );
                         }
+                        found_assignment = false;
                     }
                 }
                 asg.clear_asserted_literals(cdb)?;

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -323,26 +323,31 @@ fn search(
 
 /// display the current stats. before updating stabiliation parameters
 fn dump_stage(state: &mut State, asg: &AssignStack, rst: &Restarter, current_stage: Option<bool>) {
+    let active = rst.derefer(restart::property::Tbool::Active);
     let cycle = state.stm.current_cycle();
     let scale = state.stm.current_scale();
     let stage = state.stm.current_stage();
     let segment = state.stm.current_segment();
+    let cpr = asg.refer(assign::property::TEma::ConflictPerRestart).get();
+    let thr = if active {
+        rst.derefer(restart::property::Tf64::RestartThreshold)
+    } else {
+        f64::NAN
+    };
     state.log(
         asg.num_conflict,
         match current_stage {
             None => format!(
-                "                   stg:{:>5}, scl:{:>4}, cpr:{:>9.2}",
-                stage,
-                scale,
-                asg.refer(assign::property::TEma::ConflictPerRestart).get(),
+                "                 stg:{:>5}, scl:{:>4}, cpr:{:>9.2}, thr:{:>9.4}",
+                stage, scale, cpr, thr,
             ),
-            Some(false) => format!("         cyc:{:4}, stg:{:>5}", cycle, stage),
+            Some(false) => format!(
+                "        cyc:{:3}, stg:{:>5}, scl:{:>4}, cpr:{:>9.2}, thr:{:>9.4}",
+                cycle, stage, scale, cpr, thr,
+            ),
             Some(true) => format!(
-                "seg:{:3}, cyc:{:4}, stg:{:>5}, rlt:{:>7.4}",
-                segment,
-                cycle,
-                stage,
-                rst.derefer(restart::property::Tf64::RestartThreshold),
+                "seg:{:2}, cyc:{:3}, stg:{:>5}, scl:{:>4}, cpr:{:>9.2}, thr:{:>9.4}",
+                segment, cycle, stage, scale, cpr, thr,
             ),
         },
     );

--- a/src/solver/stage.rs
+++ b/src/solver/stage.rs
@@ -106,7 +106,10 @@ impl StageManager {
         span.saturating_sub(keep)
     }
     /// return the maximum factor so far.
+    /// None: `luby_iter.max_value` holds the maximum value so far.
+    /// This means it is the value found at the last segment.
+    /// So the current value should be the next value, which is the double.
     pub fn max_scale(&self) -> usize {
-        self.luby_iter.max_value()
+        2 * self.luby_iter.max_value()
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -33,6 +33,7 @@ pub trait StateIF {
             + PropertyReference<cdb::property::TEma, EmaView>,
         E: PropertyDereference<processor::property::Tusize, usize>,
         R: PropertyDereference<solver::restart::property::Tusize, usize>
+            + PropertyDereference<solver::restart::property::Tbool, bool>
             + PropertyDereference<solver::restart::property::Tf64, f64>;
     /// write a short message to stdout.
     fn flush<S: AsRef<str>>(&self, mes: S);
@@ -347,6 +348,7 @@ impl StateIF for State {
             + PropertyReference<cdb::property::TEma, EmaView>,
         E: PropertyDereference<processor::property::Tusize, usize>,
         R: PropertyDereference<solver::restart::property::Tusize, usize>
+            + PropertyDereference<solver::restart::property::Tbool, bool>
             + PropertyDereference<solver::restart::property::Tf64, f64>,
     {
         if !self.config.splr_interface || self.config.quiet_mode {
@@ -464,7 +466,11 @@ impl StateIF for State {
             "\x1B[2K     Restart|#BLK:{}, #RST:{}, thrs:{}, #seg:{}",
             im!("{:>9}", self, LogUsizeId::RestartBlock, rst_num_blk),
             im!("{:>9}", self, LogUsizeId::Restart, rst_num_rst),
-            fm!("{:>9.4}", self, LogF64Id::RestartThreshold, rst_lbd_thr),
+            if rst.derefer(solver::restart::property::Tbool::Active) {
+                fm!("{:>9.4}", self, LogF64Id::RestartThreshold, rst_lbd_thr)
+            } else {
+                "      NaN".to_string()
+            },
             im!("{:>9}", self, LogUsizeId::StageSegment, stg_segment),
         );
         println!(


### PR DESCRIPTION
### A broken version is the best somehow
As shown below, allowing infinite restart thresholds leads to massive speed-up. This destroys the gradual restart threshold control scheme. We need to investigate the CaDiCaL-like alternating blocking scheme again.

#### How did the threshold become infinite?

Once the number of restarts during a segment is smaller than the expected one.

#### New scheme 93dcf334

- Allow infinite threshold.
  - If the number of restarts during a segment is smaller than the expected one, and
  - There is no progress during the segment
- And it back to a finite value if it was infinite during the previous segment.

```
solver,       num,                       target, b7fd2d68, 52b9a01b, 
"splr",         1,                 "UF250(100)",   57.766,   56.353
"splr",         2,                "UUF250(100)",  219.474,  217.488
"splr",         3,   "3SAT/360  S144043535-002",   51.697,    4.180
"splr",         4,   "3SAT/360  S722433227-030",   12.007,   16.767
"splr",         5,   "3SAT/360 S1459690542-033",    8.107,    1.983
"splr",         6,   "3SAT/360 S2032263657-035",    0.508,    0.589
"splr",         7,   "3SAT/360 S1293537826-039",   25.179,   71.767
"splr",         8,   "3SAT/360  S368632549-051",    3.074,   82.734
"splr",         9,   "3SAT/360 S1448866403-060",   11.418,   90.206
"splr",        10,   "3SAT/360 S1684547485-073",  218.623,   40.206
"splr",        11,   "3SAT/360 S1826927554-087",    1.246,    2.160
"splr",        12,   "3SAT/360 S1711406314-093",    0.485,    0.483
"splr",        13,   "3UNS/360  S404185236-001",  665.484,  747.269
"splr",        14,   "3UNS/360 S1369720750-015",  147.637,  279.315
"splr",        15,   "3UNS/360   S23373420-028",  272.670,  576.595
"splr",        16,   "3UNS/360  S367138237-029",  392.754, 1314.222
"splr",        17,   "3UNS/360  S305156909-031",  309.574,  797.580
"splr",        18,   "3UNS/360  S680239195-053",  256.843,  983.809
"splr",        19,   "3UNS/360 S2025517367-061",  469.063, 1644.678
"splr",        20,   "3UNS/360  S253750560-086",  142.477,  414.492
"splr",        21,   "3UNS/360 S1906521511-089",  221.624,  823.727
"splr",        22,   "3UNS/360 S1028159446-096",  191.360,  413.640
"splr",        23,                "SR2015/itox",    4.209,    4.364
"splr",        24,                "SR2015/m283",   77.207,   39.324
"splr",        25,                 "SR2015/38b",   26.427,   54.125
"splr",        26,                 "SR2015/44b",   30.399,  368.013
b7fd2d68, med:    67.486, max:   665.484,           total: 3817.312
52b9a01b, med:    86.470, max:  1644.678,           total: 9046.069
```
