### PR TITLE
SLS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,51 +17,57 @@ bitflags = "^1.3"
 
 [features]
 default = [
-        # "boundary_check", # for DEBUG
-        # "bi_clause_completion", # increase memory pressure
+        # "boundary_check",           # for DEBUG
+        # "bi_clause_completion",
         # "no_clause_elimination",
         # "clause_rewarding",
         "clause_vivification",
         "dynamic_restart_threshold",
         # "incremental_solver",
         "LRB_rewarding",
-        # "maintain_watch_cache", # for DEBUG
+        # "maintain_watch_cache",    # for DEBUG
         "reason_side_rewarding",
         "rephase",
-        "reward_annealing", # for big problems since 0.17(need to evalate with larger timeout)
-        "stochastic_local_search", # since 0.17
+        "reward_annealing",
+        "stochastic_local_search",
         # "suppress_reason_chain",
         "trail_saving",
         "unsafe_access"
         ]
-assign_rate = []
-best_phases_tracking = []
-bi_clause_completion = []
-boundary_check = []
-chrono_BT = []
-no_clause_elimination = []
-clause_rewarding = []
-clause_vivification = []
-debug_propagation = []
-dynamic_restart_threshold = []
-EMA_calibration = []
-EVSIDS = []
-incremental_solver = ["no_clause_elimination"]
-just_used = []
-LRB_rewarding = []
-maintain_watch_cache = []
-no_IO = []
-reason_side_rewarding = []
-rephase = ["best_phases_tracking"]
-reward_annealing = []
-stochastic_local_search = []
-support_user_assumption = []
-suppress_reason_chain = []
-trace_analysis = []
-trace_elimination = []
-trace_equivalency = []
-trail_saving = []
-unsafe_access = []
+assign_rate = []                # for debug and study
+best_phases_tracking = []       # save the best-so-far assignment, used by 'rephase'
+bi_clause_completion = []       # increase memory pressure
+boundary_check = []             # for debug
+chrono_BT = []                  # NOT WORK
+no_clause_elimination = []      # pre(in)-processor setting
+clause_rewarding = []           # clauses have activities w/ decay rate
+clause_vivification = []        # pre(in)-processor setting
+debug_propagation = []          # for debug
+dynamic_restart_threshold = []  # control restart spans like Glucose
+EMA_calibration = []            # each exponential moving average has a calbration value
+EVSIDS = []                     # Eponential Variable State Independent Decaying Sum
+incremental_solver = [          # for all solution SAT sover
+        "no_clause_elimination"
+        ]
+just_used = []                  # Var and clause have 'just_used' flags
+LRB_rewarding = []              # Vearning Rate Based rewarding, a new var activity criteria
+maintain_watch_cache = []       # for DEBUG
+no_IO = []                      # to embed Splr into non-std environments
+reason_side_rewarding = []      # an idea used in Learning-rate based rewarding
+rephase = [                     # search around the best-so-far candidate repeatedly
+        "best_phases_tracking"
+        ]
+reward_annealing = []           # use bigger and smaller decay rates cycliclly
+stochastic_local_search = [     # since 0.17
+        "reward_annealing"
+        ]
+support_user_assumption = []    # NOT WORK (defined in Glucose)
+suppress_reason_chain = []      # make direct links between a dicision var and its implications
+trace_analysis = []             # for debug
+trace_elimination = []          # for debug
+trace_equivalency = []          # for debug
+trail_saving = []               # reduce propagation cost by reusing propagation chain
+unsafe_access = []              # access elements of vectors without boundary checking
 
 [profile.release]
 lto = "fat"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ default = [
         "reason_side_rewarding",
         "rephase",
         # "reward_annealing", # for big problems since 0.17(need to evalate with larger timeout)
+        "stochastic_local_search", # since 0.17
         # "suppress_reason_chain",
         "trail_saving",
         "unsafe_access"
@@ -53,6 +54,7 @@ no_IO = []
 reason_side_rewarding = []
 rephase = ["best_phases_tracking"]
 reward_annealing = []
+stochastic_local_search = []
 support_user_assumption = []
 suppress_reason_chain = []
 trace_analysis = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,22 +17,29 @@ bitflags = "^1.3"
 
 [features]
 default = [
-        # "boundary_check",           # for DEBUG
-        # "bi_clause_completion",
-        # "no_clause_elimination",
-        # "clause_rewarding",
-        "clause_vivification",
-        "dynamic_restart_threshold",
+        ### Essential
         # "incremental_solver",
         "LRB_rewarding",
-        # "maintain_watch_cache",    # for DEBUG
         "reason_side_rewarding",
+        "unsafe_access",
+        "trail_saving",
+
+        ### heuristics
+        # "bi_clause_completion",
+        # "clause_rewarding",
+        "dynamic_restart_threshold",
         "rephase",
-        "reward_annealing",
+        # "reward_annealing",
         "stochastic_local_search",
         # "suppress_reason_chain",
-        "trail_saving",
-        "unsafe_access"
+
+        ### proceccor
+        # "no_clause_elimination",
+        "clause_vivification",
+
+        ### for DEBUG
+        # "boundary_check",
+        # "maintain_watch_cache",
         ]
 assign_rate = []                # for debug and study
 best_phases_tracking = []       # save the best-so-far assignment, used by 'rephase'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "splr"
-version = "0.17.0-alpha.2"
+version = "0.17.0-alpha.3"
 authors = ["Narazaki Shuji <shujinarazaki@protonmail.com>"]
 description = "A modern CDCL SAT solver in Rust"
 edition = "2021"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ default = [
         # "maintain_watch_cache", # for DEBUG
         "reason_side_rewarding",
         "rephase",
-        # "reward_annealing", # for big problems since 0.17(need to evalate with larger timeout)
+        "reward_annealing", # for big problems since 0.17(need to evalate with larger timeout)
         "stochastic_local_search", # since 0.17
         # "suppress_reason_chain",
         "trail_saving",

--- a/src/assign/mod.rs
+++ b/src/assign/mod.rs
@@ -76,6 +76,8 @@ pub trait AssignIF:
     /// return a reference to `level`.
     fn level_ref(&self) -> &[DecisionLevel];
     fn best_assigned(&mut self) -> Option<usize>;
+    /// return true if no best_phases
+    fn best_phases_invalid(&self) -> bool;
     /// inject assignments for eliminated vars.
     fn extend_model(&mut self, c: &mut impl ClauseDBIF) -> Vec<Option<bool>>;
     /// return `true` if the set of literals is satisfiable under the current assignment.

--- a/src/assign/select.rs
+++ b/src/assign/select.rs
@@ -73,18 +73,18 @@ impl VarSelectIF for AssignStack {
     fn override_rephasing_target(&mut self, assignment: &HashMap<VarId, bool>) -> usize {
         let mut num_flipped = 0;
         for (vi, b) in assignment.iter() {
-            let v = &mut self.var[*vi];
-            if v.is(FlagVar::PHASE) != *b {
-                num_flipped += 1;
-                v.set(FlagVar::PHASE, *b);
-                // v.reward *= self.activity_decay;
-                // v.reward += self.activity_anti_decay;
-                // self.update_heap(*vi);
-            }
-            // if !self.best_phases.get(vi).map_or(false, |(p, _)| *p == *b) {
+            // let v = &mut self.var[*vi];
+            // if v.is(FlagVar::PHASE) != *b {
             //     num_flipped += 1;
-            //     self.best_phases.insert(*vi, (*b, AssignReason::None));
+            //     v.set(FlagVar::PHASE, *b);
+            //     // v.reward *= self.activity_decay;
+            //     // v.reward += self.activity_anti_decay;
+            //     // self.update_heap(*vi);
             // }
+            if !self.best_phases.get(vi).map_or(false, |(p, _)| *p == *b) {
+                num_flipped += 1;
+                self.best_phases.insert(*vi, (*b, AssignReason::None));
+            }
         }
         // self.num_best_assign = self.num_asserted_vars + self.num_eliminated_vars;
         num_flipped

--- a/src/assign/select.rs
+++ b/src/assign/select.rs
@@ -71,7 +71,7 @@ impl VarSelectIF for AssignStack {
     }
     #[cfg(feature = "stochastic_local_search")]
     fn override_rephasing_target(&mut self, assignment: &HashMap<VarId, bool>) -> usize {
-        let mut num_fliped = 0;
+        let mut num_flipped = 0;
         for (vi, b) in assignment.iter() {
             let v = &mut self.var[*vi];
             if v.is(FlagVar::PHASE) != *b {
@@ -81,12 +81,12 @@ impl VarSelectIF for AssignStack {
                 // self.update_heap(*vi);
             }
             if !self.best_phases.get(vi).map_or(false, |(p, _)| *p == *b) {
-                num_fliped += 1;
-                // self.best_phases.insert(*vi, (*b, AssignReason::None));
+                num_flipped += 1;
+                self.best_phases.insert(*vi, (*b, AssignReason::None));
             }
         }
         // self.num_best_assign = self.num_asserted_vars + self.num_eliminated_vars;
-        num_fliped
+        num_flipped
     }
     #[cfg(feature = "rephase")]
     fn select_rephasing_target(&mut self) {

--- a/src/assign/select.rs
+++ b/src/assign/select.rs
@@ -2,12 +2,11 @@
 
 #[cfg(feature = "rephase")]
 use super::property;
-#[cfg(feature = "stochastic_local_search")]
-use std::collections::HashMap;
 
 use {
     super::{AssignStack, VarHeapIF},
     crate::types::*,
+    std::collections::HashMap,
 };
 
 /// ```ignore
@@ -28,10 +27,8 @@ macro_rules! var_assign {
 
 /// API for var selection, depending on an internal heap.
 pub trait VarSelectIF {
-    #[cfg(feature = "stochastic_local_search")]
     /// return best phases
     fn best_phases_ref(&mut self, default_value: Option<bool>) -> HashMap<VarId, bool>;
-    #[cfg(feature = "stochastic_local_search")]
     /// force an assignment obtained by SLS
     fn override_rephasing_target(&mut self, assignment: &HashMap<VarId, bool>) -> usize;
     #[cfg(feature = "rephase")]
@@ -49,7 +46,6 @@ pub trait VarSelectIF {
 }
 
 impl VarSelectIF for AssignStack {
-    #[cfg(feature = "stochastic_local_search")]
     fn best_phases_ref(&mut self, default_value: Option<bool>) -> HashMap<VarId, bool> {
         self.var
             .iter()
@@ -69,7 +65,6 @@ impl VarSelectIF for AssignStack {
             })
             .collect::<HashMap<VarId, bool>>()
     }
-    #[cfg(feature = "stochastic_local_search")]
     fn override_rephasing_target(&mut self, assignment: &HashMap<VarId, bool>) -> usize {
         let mut num_flipped = 0;
         for (vi, b) in assignment.iter() {

--- a/src/assign/select.rs
+++ b/src/assign/select.rs
@@ -28,7 +28,7 @@ macro_rules! var_assign {
 pub trait VarSelectIF {
     #[cfg(feature = "rephase")]
     /// select rephasing target
-    fn select_rephasing_target(&mut self);
+    fn select_rephasing_target(&mut self, assignment: Option<Vec<bool>>);
     #[cfg(feature = "rephase")]
     /// check the consistency
     fn check_consistency_of_best_phases(&mut self);
@@ -42,7 +42,14 @@ pub trait VarSelectIF {
 
 impl VarSelectIF for AssignStack {
     #[cfg(feature = "rephase")]
-    fn select_rephasing_target(&mut self) {
+    fn select_rephasing_target(&mut self, assignment: Option<Vec<bool>>) {
+        if let Some(assignment) = assignment {
+            for (vi, b) in assignment.iter().enumerate().skip(1) {
+                let v = &mut self.var[vi];
+                v.set(FlagVar::PHASE, *b);
+            }
+            return;
+        }
         if self.best_phases.is_empty() {
             return;
         }

--- a/src/assign/select.rs
+++ b/src/assign/select.rs
@@ -55,9 +55,10 @@ impl VarSelectIF for AssignStack {
                 } else {
                     Some((
                         vi,
-                        self.best_phases
-                            .get(&vi)
-                            .map_or(v.is(FlagVar::PHASE), |(b, _)| *b),
+                        self.best_phases.get(&vi).map_or(
+                            self.assign[vi].unwrap_or_else(|| v.is(FlagVar::PHASE)),
+                            |(b, _)| *b,
+                        ),
                     ))
                 }
             })
@@ -71,6 +72,7 @@ impl VarSelectIF for AssignStack {
                 v.set(FlagVar::PHASE, *b);
                 self.best_phases.insert(*vi, (*b, AssignReason::None));
             }
+            self.num_best_assign = self.num_asserted_vars + self.num_eliminated_vars;
             return;
         }
         if self.best_phases.is_empty() {

--- a/src/assign/stack.rs
+++ b/src/assign/stack.rs
@@ -196,6 +196,9 @@ impl AssignIF for AssignStack {
     fn best_assigned(&mut self) -> Option<usize> {
         (self.build_best_at == self.num_propagation).then_some(self.num_vars - self.num_best_assign)
     }
+    fn best_phases_invalid(&self) -> bool {
+        self.best_phases.is_empty()
+    }
     #[allow(unused_variables)]
     fn extend_model(&mut self, cdb: &mut impl ClauseDBIF) -> Vec<Option<bool>> {
         let lits = &self.eliminated;

--- a/src/cdb/activity.rs
+++ b/src/cdb/activity.rs
@@ -20,6 +20,10 @@ impl ActivityIF<ClauseId> for ClauseDB {
     fn update_activity_tick(&mut self) {
         self.tick += 1;
     }
+    fn update_activity_decay(&mut self, decay: f64) {
+        self.activity_decay = decay;
+        self.activity_anti_decay = 1.0 - decay;
+    }
 }
 
 impl Clause {

--- a/src/cdb/db.rs
+++ b/src/cdb/db.rs
@@ -953,8 +953,8 @@ impl ClauseDBIF for ClauseDB {
                 let act_c = self.reward;
                 #[cfg(not(feature = "clause_rewarding"))]
                 let act_c = 0.25;
+
                 self.rank as f64 / (act_c + act_v)
-                // (self.rank as f64).log2().powf(1.0 - act_v)
             }
             #[cfg(feature = "just_used")]
             fn weight(&mut self, asg: &mut impl AssignIF) -> f64 {

--- a/src/cdb/db.rs
+++ b/src/cdb/db.rs
@@ -1025,7 +1025,9 @@ impl ClauseDBIF for ClauseDB {
         // there're exception. Since this is the pre-stage of clause vivification,
         // we want keep usefull clauses as many as possible.
         // Therefore I save the clauses which will become vivification targets.
-        let thr = (self.lb_entanglement.get_slow() + 1.0).min(self.lbd.get_fast().max(5.0)) as u16;
+        // let thr = (self.lb_entanglement.get_slow() + 1.0).min(self.lbd.get_fast().max(5.0)) as u16;
+        let extra = 100.0 / (self.num_learnt as f64).log2();
+        let thr = ((self.lb_entanglement.get_slow() + self.lbd.get_slow()).log2() + extra) as u16;
         for i in &perm[keep..] {
             let c = &self.clause[i.to()];
             if !c.is_vivify_target() || thr < c.rank {

--- a/src/cdb/db.rs
+++ b/src/cdb/db.rs
@@ -953,8 +953,8 @@ impl ClauseDBIF for ClauseDB {
                 let act_c = self.reward;
                 #[cfg(not(feature = "clause_rewarding"))]
                 let act_c = 0.25;
-
                 self.rank as f64 / (act_c + act_v)
+                // (self.rank as f64).log2().powf(1.0 - act_v)
             }
             #[cfg(feature = "just_used")]
             fn weight(&mut self, asg: &mut impl AssignIF) -> f64 {

--- a/src/cdb/db.rs
+++ b/src/cdb/db.rs
@@ -1028,7 +1028,7 @@ impl ClauseDBIF for ClauseDB {
         // Therefore I save the clauses which will become vivification targets.
         // And since the current Splr adopts stage-based GC policy, I drop this simple halve'em if doubled,
         // based on memomy pressure and clause sizes used in conflict analysis.
-        let entanglement = 1.5 * (self.lb_entanglement.get_slow() + self.lbd.get_slow()).powf(0.5);
+        let entanglement = 1.75 * (self.lb_entanglement.get_slow() + self.lbd.get_slow()).powf(0.5);
         let memory_pressure = 2000.0 * (self.num_learnt as f64).powf(-0.5);
         let thr = (entanglement + memory_pressure).min(entanglement) as u16;
         for i in &perm[keep..] {

--- a/src/cdb/mod.rs
+++ b/src/cdb/mod.rs
@@ -289,7 +289,9 @@ pub struct ClauseDB {
     num_reregistration: usize,
     /// Literal Block Entanglement
     /// EMA of LBD of clauses used in conflict analysis (dependency graph)
-    pub lb_entanglement: Ema2,
+    lb_entanglement: Ema2,
+    /// the decision level used in th last invocation of `reduce`
+    last_reduction_threshold: usize,
 
     //
     //## incremental solving
@@ -311,10 +313,11 @@ pub mod property {
         NumLearnt,
         NumReduction,
         NumReRegistration,
+        ReductionThreshold,
         Timestamp,
     }
 
-    pub const USIZES: [Tusize; 9] = [
+    pub const USIZES: [Tusize; 10] = [
         Tusize::NumBiClause,
         Tusize::NumBiClauseCompletion,
         Tusize::NumBiLearnt,
@@ -323,6 +326,7 @@ pub mod property {
         Tusize::NumLearnt,
         Tusize::NumReduction,
         Tusize::NumReRegistration,
+        Tusize::ReductionThreshold,
         Tusize::Timestamp,
     ];
 
@@ -338,6 +342,7 @@ pub mod property {
                 Tusize::NumLearnt => self.num_learnt,
                 Tusize::NumReduction => self.num_reduction,
                 Tusize::NumReRegistration => self.num_reregistration,
+                Tusize::ReductionThreshold => self.last_reduction_threshold,
 
                 #[cfg(feature = "clause_rewarding")]
                 Tusize::Timestamp => self.tick,

--- a/src/cdb/mod.rs
+++ b/src/cdb/mod.rs
@@ -10,6 +10,8 @@ mod clause;
 mod db;
 /// EMA
 mod ema;
+/// methods for Stochastic Local Search
+mod sls;
 /// methods for UNSAT certification
 mod unsat_certificate;
 /// implementation of clause vivification

--- a/src/cdb/mod.rs
+++ b/src/cdb/mod.rs
@@ -10,6 +10,7 @@ mod clause;
 mod db;
 /// EMA
 mod ema;
+#[cfg(feature = "stochastic_local_search")]
 /// methods for Stochastic Local Search
 mod sls;
 /// methods for UNSAT certification
@@ -26,6 +27,9 @@ pub use self::{
     unsat_certificate::CertificationStore,
     vivify::VivifyIF,
 };
+#[cfg(feature = "stochastic_local_search")]
+pub use sls::StochasticLocalSearchIF;
+
 use {
     self::ema::ProgressLBD,
     crate::{assign::AssignIF, types::*},

--- a/src/cdb/mod.rs
+++ b/src/cdb/mod.rs
@@ -10,7 +10,6 @@ mod clause;
 mod db;
 /// EMA
 mod ema;
-#[cfg(feature = "stochastic_local_search")]
 /// methods for Stochastic Local Search
 mod sls;
 /// methods for UNSAT certification
@@ -24,11 +23,10 @@ pub use self::{
     binary::{BinaryLinkDB, BinaryLinkList},
     cid::ClauseIdIF,
     property::*,
+    sls::StochasticLocalSearchIF,
     unsat_certificate::CertificationStore,
     vivify::VivifyIF,
 };
-#[cfg(feature = "stochastic_local_search")]
-pub use sls::StochasticLocalSearchIF;
 
 use {
     self::ema::ProgressLBD,

--- a/src/cdb/sls.rs
+++ b/src/cdb/sls.rs
@@ -44,7 +44,7 @@ impl StochasticLocalSearchIF for ClauseDB {
             }
             returns.1 = unsat_clauses;
             if let Some(c) = target_clause {
-                let factor = |vi| 1.4_f64.powf(-(*flip_target.get(vi).unwrap() as f64));
+                let factor = |vi| 3.2_f64.powf(-(*flip_target.get(vi).unwrap() as f64));
                 let vars = c.lits.iter().map(|l| l.vi()).collect::<Vec<_>>();
                 let index = (((step + last_flip) & 63) as f64 / 63.0)
                     * vars.iter().map(factor).sum::<f64>();
@@ -59,7 +59,6 @@ impl StochasticLocalSearchIF for ClauseDB {
                         //     assignment[vi]
                         // );
                         assignment.entry(*vi).and_modify(|e| *e = !*e);
-                        // print1ln!(" -> {}", assignment[vi]);
                         last_flip = *vi;
                         break;
                     }
@@ -75,7 +74,7 @@ impl StochasticLocalSearchIF for ClauseDB {
 impl Clause {
     fn check_parity(
         &self,
-        assignment: &mut HashMap<VarId, bool>,
+        assignment: &HashMap<VarId, bool>,
         flip_target: &mut HashMap<VarId, usize>,
     ) -> Option<&Self> {
         let mut num_sat = 0;
@@ -83,14 +82,11 @@ impl Clause {
         for l in self.iter() {
             let vi = l.vi();
             match assignment.get(&vi) {
-                None => {
-                    // println!("{:?}|{:?}", l, self);
-                    return None;
-                }
                 Some(b) if *b == l.as_bool() => {
                     num_sat += 1;
                     sat_vi = vi;
                 }
+                None => unreachable!(),
                 _ => (),
             }
         }

--- a/src/cdb/sls.rs
+++ b/src/cdb/sls.rs
@@ -1,0 +1,45 @@
+/// Implementation of Stochastic Local Search
+use {crate::types::*, std::collections::HashMap};
+
+pub trait StochasticLocalSearchIF {
+    fn stochastic_local_search(&mut self, start: &[Option<bool>], limit: usize) -> Vec<bool>;
+}
+
+impl StochasticLocalSearchIF for ClauseDB {
+    fn stochastic_local_search(&mut self, start: &[Option<bool>], limit: usize) -> Vec<bool> {
+        let mut assignment: Vec<bool> = start
+            .iter()
+            .map(|a| a.map_or(false, |b| b))
+            .collect::<Vec<_>>();
+        for _ in 0..limit {
+            let mut flip_target: HashMap<VarId, usize> = HashMap::new();
+            let mut satisfied = true;
+            for c in self
+                .clause
+                .iter()
+                .skip(1)
+                .filter(|c| !c.is(FlagClause::LEARNT))
+            {
+                satisfied &= c.check_parity(&assignment, &mut flip_target);
+            }
+            if satisfied {
+                return assignment;
+            }
+            let i: usize = flip_target.iter().map(|(k, v)| (*v, *k)).max().unwrap().1;
+            assignment[i] = !assignment[i];
+        }
+        assignment
+    }
+}
+
+impl Clause {
+    fn check_parity(&self, assignment: &[bool], flip_target: &mut HashMap<VarId, usize>) -> bool {
+        for l in self.iter() {
+            let vi = l.vi();
+            if assignment[vi] != l.as_bool() {
+                *flip_target.entry(vi).or_insert(0) += 1;
+            }
+        }
+        todo!();
+    }
+}

--- a/src/cdb/sls.rs
+++ b/src/cdb/sls.rs
@@ -26,7 +26,7 @@ impl StochasticLocalSearchIF for ClauseDB {
     ) -> (usize, usize) {
         let mut returns: (usize, usize) = (0, 0);
         let mut last_flip = self.num_clause;
-        let mut seed = 38_721_103;
+        let mut seed = 721_109;
         for step in 1..=limit {
             let mut unsat_clauses = 0;
             // let mut level: DecisionLevel = 0;
@@ -58,9 +58,9 @@ impl StochasticLocalSearchIF for ClauseDB {
             if unsat_clauses == 0 || step == limit {
                 break;
             }
-            seed = (((((!seed % 10_000_000) * 11_304_001) % 22_003_811) ^ (!last_flip * seed))
-                % 31_754_873)
-                >> 4;
+            seed = ((((!seed & 0x0000_0000_ffff_ffff) * 1_304_003) % 2_003_819)
+                ^ ((!last_flip & 0x0000_0000_ffff_ffff) * seed))
+                % 3_754_873;
             if let Some(c) = target_clause {
                 let beta: f64 = 3.2 - 2.1 / (1.0 + unsat_clauses as f64).log(2.0);
                 // let beta: f64 = if unsat_clauses <= 3 { 1.0 } else { 3.0 };

--- a/src/cdb/vivify.rs
+++ b/src/cdb/vivify.rs
@@ -163,7 +163,7 @@ impl VivifyIF for ClauseDB {
         debug_assert!(asg.stack_is_empty() || !asg.remains());
         state.flush("");
         state.flush(format!(
-            "vivified(assert:{} shorten:{}), ",
+            "vivification(assert:{} shorten:{}), ",
             num_assert, num_shrink
         ));
         // state.log(

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -291,9 +291,16 @@ fn search(
                 let scale = state.stm.current_scale();
                 let max_scale = state.stm.max_scale();
                 if cfg!(feature = "reward_annealing") {
-                    let base = (1 << (state.stm.current_segment() - 1)) - 1;
-                    let decay_index = state.stm.current_cycle() - base;
-                    let decay = (decay_index as f64 - 1.0) / decay_index as f64;
+                    let base = {
+                        let seg = state.stm.current_segment();
+                        if seg == 0 {
+                            state.stm.current_cycle()
+                        } else {
+                            state.stm.current_cycle() - (1 << (seg - 1))
+                        }
+                    };
+                    let decay_index: f64 = 1.25 + base as f64;
+                    let decay = (decay_index - 1.0) / decay_index;
                     asg.update_activity_decay(decay);
                 }
                 if let Some(new_segment) = next_stage {

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -291,14 +291,19 @@ fn search(
                         #[cfg(feature = "stochastic_local_search")]
                         {
                             use cdb::StochasticLocalSearchIF;
-                            let limit = 100; // FIXME: use entanglement
-
-                            let _assignment = cdb.stochastic_local_search(asg.assign_ref(), limit);
-                            // asg.select_rephasing_target(Some(assignment));
+                            let entanglement = cdb.refer(cdb::property::TEma::Entanglement).get();
+                            if 16.0 < entanglement {
+                                let limit = entanglement.powi(2) as usize;
+                                let assignment =
+                                    cdb.stochastic_local_search(asg.assign_ref(), limit);
+                                asg.select_rephasing_target(Some(assignment));
+                            } else {
+                                asg.select_rephasing_target(None);
+                            }
                         }
                         #[cfg(not(feature = "stochastic_local_search"))]
                         {
-                            asg.select_rephasing_target();
+                            asg.select_rephasing_target(None);
                         }
                     }
                     if cfg!(feature = "clause_vivification") {

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -287,7 +287,20 @@ fn search(
                 }
                 if let Some(new_segment) = next_stage {
                     #[cfg(feature = "rephase")]
-                    asg.select_rephasing_target();
+                    {
+                        #[cfg(feature = "stochastic_local_search")]
+                        {
+                            use cdb::StochasticLocalSearchIF;
+                            let limit = 100; // FIXME: use entanglement
+
+                            let _assignment = cdb.stochastic_local_search(asg.assign_ref(), limit);
+                            // asg.select_rephasing_target(Some(assignment));
+                        }
+                        #[cfg(not(feature = "stochastic_local_search"))]
+                        {
+                            asg.select_rephasing_target();
+                        }
+                    }
                     if cfg!(feature = "clause_vivification") {
                         cdb.vivify(asg, state)?;
                     }

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -266,8 +266,8 @@ fn search(
             // }
             match handle_conflict(asg, cdb, state, &cc)? {
                 0 => {
-                    best_phases_invalid = true;
-                    state.stm.reset();
+                    best_phases_invalid = asg.best_phases_invalid();
+                    // state.stm.reset();
                 }
                 1 => (),
                 _ => num_learnt += 1,
@@ -313,7 +313,8 @@ fn search(
                                     let stats =
                                         cdb.stochastic_local_search(asg, &mut $assign, $limit);
                                     if $improved(stats) {
-                                        state.sls_index = stats.1;
+                                        state.sls_index += 1;
+                                        // state.sls_index = stats.1;
                                         let num_flipped = asg.override_rephasing_target(&$assign);
                                         state.flush(format!(
                                             "({} clauses, {} flips), ",
@@ -324,18 +325,13 @@ fn search(
                                     }
                                 };
                             }
-                            if best_phases_invalid {
+                            if best_phases_invalid || new_segment {
                                 best_phases_invalid = false;
                                 let mut assignment = asg.best_phases_ref(Some(false));
                                 sls!(assignment, |_: (usize, usize)| true, 200);
-                            } else {
-                                asg.select_rephasing_target();
                             }
                         }
-                        #[cfg(not(feature = "stochastic_local_search"))]
-                        {
-                            asg.select_rephasing_target();
-                        }
+                        asg.select_rephasing_target();
                     }
                     if cfg!(feature = "clause_vivification") {
                         cdb.vivify(asg, state)?;

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -301,6 +301,7 @@ fn search(
                         // asg.rescale_activity((max_scale - scale) as f64 / max_scale as f64);
                         if !cfg!(feature = "no_clause_elimination") {
                             let mut elim = Eliminator::instantiate(&state.config, &state.cnf);
+                            state.flush("clause subsumption, ");
                             elim.simplify(asg, cdb, state, false)?;
                             asg.eliminated.append(elim.eliminated_lits());
                             state[Stat::Simplify] += 1;

--- a/src/solver/stage.rs
+++ b/src/solver/stage.rs
@@ -71,7 +71,8 @@ impl StageManager {
         self.scale = self.luby_iter.next_unchecked();
         if self.scale == 1 {
             self.cycle += 1;
-            new_cycle = true;
+            // new_cycle = true;
+            new_cycle = self.cycle % 2 == 0;
             if self.next_is_new_segment {
                 self.segment += 1;
                 self.next_is_new_segment = false;
@@ -89,13 +90,15 @@ impl StageManager {
     }
     /// returns the number of conflicts in the current stage
     pub fn current_span(&self) -> usize {
-        self.cycle * self.unit_size
+        // self.cycle * self.unit_size
+        (self.cycle / 2 + 1) * self.unit_size
     }
     pub fn current_stage(&self) -> usize {
         self.stage
     }
     pub fn current_cycle(&self) -> usize {
-        self.cycle
+        // self.cycle
+        self.cycle / 2
     }
     /// returns the scaling factor used in the current span
     pub fn current_scale(&self) -> usize {

--- a/src/solver/stage.rs
+++ b/src/solver/stage.rs
@@ -50,7 +50,7 @@ impl StageManager {
         self.end_of_stage = unit_size;
     }
     /// returns:
-    /// - Some(true): it's a beginning of a new cycle and a new cycle, a 2nd-level group.
+    /// - Some(true): it's a beginning of a new cycle and a new segment, a 2nd-level group.
     /// - Some(false): a beginning of a new cycle.
     /// - None: the other case.
     pub fn prepare_new_stage(&mut self, rescale: usize, now: usize) -> Option<bool> {

--- a/src/solver/stage.rs
+++ b/src/solver/stage.rs
@@ -23,7 +23,7 @@ impl Instantiate for StageManager {
             unit_size,
             scale: 1,
             end_of_stage: unit_size,
-            next_is_new_segment: true,
+            next_is_new_segment: false,
             ..StageManager::default()
         }
     }
@@ -40,7 +40,7 @@ impl StageManager {
             luby_iter: LubySeries::default(),
             scale: 1,
             end_of_stage: unit_size,
-            next_is_new_segment: true,
+            next_is_new_segment: false,
         }
     }
     pub fn initialize(&mut self, unit_size: usize) {

--- a/src/solver/stage.rs
+++ b/src/solver/stage.rs
@@ -49,6 +49,11 @@ impl StageManager {
         self.scale = 1;
         self.end_of_stage = unit_size;
     }
+    pub fn reset(&mut self) {
+        self.cycle = 0;
+        self.scale = 1;
+        self.end_of_stage = self.unit_size;
+    }
     /// returns:
     /// - Some(true): it's a beginning of a new cycle and a new segment, a 2nd-level group.
     /// - Some(false): a beginning of a new cycle.

--- a/src/state.rs
+++ b/src/state.rs
@@ -112,8 +112,14 @@ pub struct State {
     /// hold conflicting user-defined *assumed* literals for UNSAT problems
     pub conflicts: Vec<Lit>,
 
+    #[cfg(feature = "chronoBT")]
     /// chronoBT threshold
     pub chrono_bt_threshold: DecisionLevel,
+
+    #[cfg(feature = "stochastic_local_search")]
+    /// criteria for SLS
+    pub sls_index: usize,
+
     /// hold the previous number of non-conflicting assignment
     pub last_asg: usize,
     /// working place to build learnt clauses
@@ -148,7 +154,13 @@ impl Default for State {
 
             #[cfg(feature = "support_user_assumption")]
             conflicts: Vec::new(),
+
+            #[cfg(feature = "chronoBT")]
             chrono_bt_threshold: 100,
+
+            #[cfg(feature = "stochastic_local_search")]
+            sls_index: 9_999_999,
+
             last_asg: 0,
             new_learnt: Vec::new(),
             derive20: Vec::new(),
@@ -521,7 +533,7 @@ impl StateIF for State {
                 LogUsizeId::VivifiedClause,
                 self[Stat::VivifiedClause]
             ),
-            im!("{:>9}", self, LogUsizeId::SLS, self[Stat::SLS]),
+            im!("{:>9}", self, LogUsizeId::SLS, self.sls_index),
             im!(
                 "{:>9}",
                 self,
@@ -858,6 +870,7 @@ pub enum LogF64Id {
     PropagationPerConflict,
     LiteralBlockEntanglement,
     RestartEnergy,
+
     End,
 }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -116,10 +116,6 @@ pub struct State {
     /// chronoBT threshold
     pub chrono_bt_threshold: DecisionLevel,
 
-    #[cfg(feature = "stochastic_local_search")]
-    /// criteria for SLS
-    pub sls_index: usize,
-
     /// hold the previous number of non-conflicting assignment
     pub last_asg: usize,
     /// working place to build learnt clauses
@@ -130,6 +126,8 @@ pub struct State {
     pub progress_cnt: usize,
     /// keep the previous statistics values
     pub record: ProgressRecord,
+    /// criteria for SLS
+    pub sls_index: usize,
     /// start clock for timeout handling
     pub start: Instant,
     /// upper limit for timeout handling
@@ -158,14 +156,12 @@ impl Default for State {
             #[cfg(feature = "chronoBT")]
             chrono_bt_threshold: 100,
 
-            #[cfg(feature = "stochastic_local_search")]
-            sls_index: 0,
-
             last_asg: 0,
             new_learnt: Vec::new(),
             derive20: Vec::new(),
             progress_cnt: 0,
             record: ProgressRecord::default(),
+            sls_index: 0,
             start: Instant::now(),
             time_limit: 0.0,
             log_messages: Vec::new(),

--- a/src/state.rs
+++ b/src/state.rs
@@ -51,6 +51,8 @@ pub enum Stat {
     Simplify,
     /// the number of subsumed clause by processor
     SubsumedClause,
+    /// SLS core
+    UnsatsBySLS,
     /// don't use this dummy (sentinel at the tail).
     EndOfStatIndex,
 }
@@ -512,7 +514,7 @@ impl StateIF for State {
             ),
         );
         println!(
-            "\x1B[2K        misc|vivC:{}, subC:{}, core:{}, /ppc:{}",
+            "\x1B[2K        misc|vivC:{}, -SLS:{}, core:{}, /ppc:{}",
             im!(
                 "{:>9}",
                 self,
@@ -522,8 +524,8 @@ impl StateIF for State {
             im!(
                 "{:>9}",
                 self,
-                LogUsizeId::SubsumedClause,
-                self[Stat::SubsumedClause]
+                LogUsizeId::UnsatsBySLS,
+                self[Stat::UnsatsBySLS]
             ),
             im!(
                 "{:>9}",
@@ -834,6 +836,11 @@ pub enum LogUsizeId {
     VivifiedClause,
     VivifiedVar,
     Vivify,
+
+    //
+    //## Stochastic Local Search
+    //
+    UnsatsBySLS,
 
     // the sentinel
     End,

--- a/src/state.rs
+++ b/src/state.rs
@@ -52,7 +52,7 @@ pub enum Stat {
     /// the number of subsumed clause by processor
     SubsumedClause,
     /// SLS core
-    UnsatsBySLS,
+    SLS,
     /// don't use this dummy (sentinel at the tail).
     EndOfStatIndex,
 }
@@ -514,19 +514,14 @@ impl StateIF for State {
             ),
         );
         println!(
-            "\x1B[2K        misc|vivC:{}, -SLS:{}, core:{}, /ppc:{}",
+            "\x1B[2K        misc|vivC:{}, !SLS:{}, core:{}, /ppc:{}",
             im!(
                 "{:>9}",
                 self,
                 LogUsizeId::VivifiedClause,
                 self[Stat::VivifiedClause]
             ),
-            im!(
-                "{:>9}",
-                self,
-                LogUsizeId::UnsatsBySLS,
-                self[Stat::UnsatsBySLS]
-            ),
+            im!("{:>9}", self, LogUsizeId::SLS, self[Stat::SLS]),
             im!(
                 "{:>9}",
                 self,
@@ -840,7 +835,7 @@ pub enum LogUsizeId {
     //
     //## Stochastic Local Search
     //
-    UnsatsBySLS,
+    SLS,
 
     // the sentinel
     End,

--- a/src/state.rs
+++ b/src/state.rs
@@ -159,7 +159,7 @@ impl Default for State {
             chrono_bt_threshold: 100,
 
             #[cfg(feature = "stochastic_local_search")]
-            sls_index: 9_999_999,
+            sls_index: 0,
 
             last_asg: 0,
             new_learnt: Vec::new(),


### PR DESCRIPTION
- main objective: #159 
- side effect: 'reluctant', _memory pressure based_ reduction = delete a clause $C$ if $$A_{1} \times (\overline{LBD} + \overline{entanglement})^{0.5} + A_{2}\times|database|^{-0.5} < LBD_{C}$$
- side effect: Luby reinitialization


base line

```
$ sat-bench splr-016
# 0.14.1, timeout:2000 on demorgan @ 2022-10-02T09:11:15
# ~/.cargo/bin/splr-016 (0.16.3) @ 2022-09-16T22:26:35
solver,       num,                       target,     time
"splr-016",     1,                 "UF250(100)",   61.353
"splr-016",     2,                "UUF250(100)",  197.929
"splr-016",     3,   "3SAT/360  S722433227-030",  169.532
"splr-016",     4,   "3SAT/360 S2032263657-035",    2.434
"splr-016",     5,   "3SAT/360  S368632549-051",    2.459
"splr-016",     6,   "3SAT/360 S1684547485-073",   12.344
"splr-016",     7,   "3SAT/360 S1711406314-093",   19.522
"splr-016",     8,   "3UNS/360 S1369720750-015",  172.912
"splr-016",     9,   "3UNS/360  S367138237-029",  617.952
"splr-016",    10,   "3UNS/360  S680239195-053",  259.947
"splr-016",    11,   "3UNS/360  S253750560-086",  194.485
"splr-016",    12,   "3UNS/360 S1028159446-096",  253.592
"splr-016",    13,   "[SAT] SR2015/m283,  3553",   46.279
"splr-016",    14,   "[SAT] SR2015/38b,    448",   58.293
"splr-016",    15,   "[SAT] SR2015/44b,    609",   86.086
"splr-016",    16,   "[SAT] SC21/b04_s_unknown",   90.473
"splr-016",    17,   "[SAT] SC21/quad_r21_m22 ",   49.054
"splr-016",    18,   "[SAT] SC21/toughsat_895s",  146.428
"splr-016",    19,   "[UNS] SC21/assoc_mult_e3",  224.545
"splr-016",    20,   "[UNS] SC21/dist4.c      ",  279.228
"splr-016",    21,   "[UNS] SC21/p01_lb_05    ",  237.824
"splr-016",    22,   "[UNS] SC21/shift1add    ",   22.143
med:   118.451, max:   617.952,           total: 3204.814
```