### PR TITLE
Fix misc calculation bugs on stage/cycle/segment model

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "splr"
-version = "0.17.0-alpha.2"
+version = "0.17.0-alpha.3"
 authors = ["Narazaki Shuji <shujinarazaki@protonmail.com>"]
 description = "A modern CDCL SAT solver in Rust"
 edition = "2021"

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,7 @@
   if a given vector contains an empty clause. All expressions corresponding to valid CNFs
   should be converted to `Certificate` successfully. (#191)
 - Add a new feature 'reward_annealing'
+- Fix misc wrong calculations on Luby series and stage-cycle-segment model
 
 ## 0.16.3, 2022-09-16
 

--- a/src/primitive/luby.rs
+++ b/src/primitive/luby.rs
@@ -6,6 +6,7 @@ pub struct LubySeries {
     seq: isize,
     size: usize,
     max_value: usize,
+    carry: bool,
 }
 
 impl Default for LubySeries {
@@ -15,6 +16,7 @@ impl Default for LubySeries {
             seq: 0,
             size: 1,
             max_value: 1,
+            carry: true,
         }
     }
 }
@@ -46,8 +48,11 @@ impl Iterator for LubySeries {
             index %= size;
         }
         let val = 2usize.pow(seq as u32);
-        if self.max_value < val {
-            self.max_value = val;
+        if self.max_value == val {
+            self.carry = true;
+        } else if self.carry {
+            self.max_value *= 2;
+            self.carry = false;
         }
         NonZeroU32::new(val as u32)
     }
@@ -71,8 +76,11 @@ impl LubySeries {
             index %= size;
         }
         let val = 2usize.pow(seq as u32);
-        if self.max_value < val {
-            self.max_value = val;
+        if self.carry {
+            self.max_value *= 2;
+            self.carry = false;
+        } else if self.max_value == val {
+            self.carry = true;
         }
         val
     }
@@ -83,6 +91,8 @@ impl LubySeries {
         self.index = 0;
         self.seq = 0;
         self.size = 1;
+        self.max_value = 1;
+        self.carry = true;
     }
 }
 

--- a/src/primitive/luby.rs
+++ b/src/primitive/luby.rs
@@ -6,7 +6,6 @@ pub struct LubySeries {
     seq: isize,
     size: usize,
     max_value: usize,
-    carry: bool,
 }
 
 impl Default for LubySeries {
@@ -16,7 +15,6 @@ impl Default for LubySeries {
             seq: 0,
             size: 1,
             max_value: 1,
-            carry: true,
         }
     }
 }
@@ -48,11 +46,8 @@ impl Iterator for LubySeries {
             index %= size;
         }
         let val = 2usize.pow(seq as u32);
-        if self.max_value == val {
-            self.carry = true;
-        } else if self.carry {
-            self.max_value *= 2;
-            self.carry = false;
+        if self.max_value < val {
+            self.max_value = val;
         }
         NonZeroU32::new(val as u32)
     }
@@ -76,11 +71,8 @@ impl LubySeries {
             index %= size;
         }
         let val = 2usize.pow(seq as u32);
-        if self.carry {
-            self.max_value *= 2;
-            self.carry = false;
-        } else if self.max_value == val {
-            self.carry = true;
+        if self.max_value < val {
+            self.max_value = val;
         }
         val
     }
@@ -91,8 +83,6 @@ impl LubySeries {
         self.index = 0;
         self.seq = 0;
         self.size = 1;
-        self.max_value = 1;
-        self.carry = true;
     }
 }
 

--- a/src/solver/stage.rs
+++ b/src/solver/stage.rs
@@ -66,7 +66,7 @@ impl StageManager {
         self.scale = self.luby_iter.next_unchecked();
         if self.scale == 1 {
             self.cycle += 1;
-            new_cycle = self.cycle % 2 == 0;
+            new_cycle = true;
             if self.next_is_new_segment {
                 self.segment += 1;
                 self.next_is_new_segment = false;
@@ -90,7 +90,7 @@ impl StageManager {
         self.stage
     }
     pub fn current_cycle(&self) -> usize {
-        self.cycle / 2
+        self.cycle
     }
     /// returns the scaling factor used in the current span
     pub fn current_scale(&self) -> usize {

--- a/src/solver/stage.rs
+++ b/src/solver/stage.rs
@@ -84,7 +84,7 @@ impl StageManager {
     }
     /// returns the number of conflicts in the current stage
     pub fn current_span(&self) -> usize {
-        self.cycle + self.unit_size
+        self.cycle * self.unit_size
     }
     pub fn current_stage(&self) -> usize {
         self.stage

--- a/src/solver/stage.rs
+++ b/src/solver/stage.rs
@@ -61,23 +61,24 @@ impl StageManager {
     pub fn prepare_new_stage(&mut self, rescale: usize, now: usize) -> Option<bool> {
         self.unit_size = rescale;
         let mut new_cycle = false;
-        let old_max = self.luby_iter.max_value();
-        let old_scale = self.scale;
+        let mut new_segment = false;
+        if self.scale == self.luby_iter.max_value() {
+            self.next_is_new_segment = true;
+        }
         self.scale = self.luby_iter.next_unchecked();
         if self.scale == 1 {
             self.cycle += 1;
             new_cycle = true;
             if self.next_is_new_segment {
+                new_segment = true;
                 self.segment += 1;
                 self.next_is_new_segment = false;
             }
-        } else if old_max < self.scale {
-            self.next_is_new_segment = true;
         }
         self.stage += 1;
         let span = self.current_span();
         self.end_of_stage = now + span;
-        new_cycle.then(|| old_scale == self.luby_iter.max_value())
+        new_cycle.then_some(new_segment)
     }
     pub fn stage_ended(&self, now: usize) -> bool {
         self.end_of_stage < now
@@ -113,6 +114,6 @@ impl StageManager {
     /// This means it is the value found at the last segment.
     /// So the current value should be the next value, which is the double.
     pub fn max_scale(&self) -> usize {
-        2 * self.luby_iter.max_value()
+        self.luby_iter.max_value()
     }
 }


### PR DESCRIPTION
0.17.00 alpha0
```
# 0.14.2, timeout:2000 on demorgan @ 2022-10-25T09:54:30
# ~/.cargo/bin/splr (0.17.0-alpha.2) @ 2022-10-25T09:53:41
solver,       num,                       target,     time
"splr",         1,                 "UF250(100)",   60.618
"splr",         2,                "UUF250(100)",  195.583
"splr",         3,   "3SAT/360  S722433227-030",  181.444
"splr",         4,   "3SAT/360 S2032263657-035",    2.390
"splr",         5,   "3SAT/360  S368632549-051",    2.414
"splr",         6,   "3SAT/360 S1684547485-073",   12.048
"splr",         7,   "3SAT/360 S1711406314-093",   19.031
"splr",         8,   "3UNS/360 S1369720750-015",  185.851
"splr",         9,   "3UNS/360  S367138237-029",  626.194
"splr",        10,   "3UNS/360  S680239195-053",  284.889
"splr",        11,   "3UNS/360  S253750560-086",  207.354
"splr",        12,   "3UNS/360 S1028159446-096",  262.507
"splr",        13,   "[SAT] SR2015/m283,  3553",   49.925
"splr",        14,   "[SAT] SR2015/38b,    448",   53.161
"splr",        15,   "[SAT] SR2015/44b,    609",   84.621
"splr",        16,   "[SAT] SC21/b04_s_unknown",   88.208
"splr",        17,   "[SAT] SC21/quad_r21_m22 ",   48.215
"splr",        18,   "[SAT] SC21/toughsat_895s",  136.037
"splr",        19,   "[UNS] SC21/assoc_mult_e3",  211.858
"splr",        20,   "[UNS] SC21/dist4.c      ",  266.553
"splr",        21,   "[UNS] SC21/p01_lb_05    ",  233.096
"splr",        22,   "[UNS] SC21/shift1add    ",   21.693
med:   112.123, max:   626.194,           total: 3233.690
# ~/Repositories/splr@10-25T10:12:49 95c84985@dev-0.17.00*
```

span = cycle + unit_size
```
# 0.14.2, timeout:2000 on demorgan @ 2022-10-25T08:29:14
# ~/.cargo/bin/splr (0.17.0-alpha.2) @ 2022-10-25T08:29:07
solver,       num,                       target,     time
"splr",         1,                 "UF250(100)",   80.854
"splr",         2,                "UUF250(100)",  289.530
"splr",         3,   "3SAT/360  S722433227-030",  342.179
"splr",         4,   "3SAT/360 S2032263657-035",    0.875
"splr",         5,   "3SAT/360  S368632549-051", 1239.544
"splr",         6,   "3SAT/360 S1684547485-073",  342.179
"splr",         7,   "3SAT/360 S1711406314-093",   50.877
"splr",         8,   "3UNS/360 S1369720750-015",  521.836
"splr",         9,   "3UNS/360  S367138237-029", 1522.816
"splr",        10,   "3UNS/360  S680239195-053",  979.753
"splr",        11,   "3UNS/360  S253750560-086",  435.467
"splr",        12,   "3UNS/360 S1028159446-096",  567.419
"splr",        13,   "[SAT] SR2015/m283,  3553",   73.865
"splr",        14,   "[SAT] SR2015/38b,    448",   66.248
"splr",        15,   "[SAT] SR2015/44b,    609",  662.542
"splr",        16,   "[SAT] SC21/b04_s_unknown",  177.507
"splr",        17,   "[SAT] SC21/quad_r21_m22 ",  310.893
"splr",        18,   "[SAT] SC21/toughsat_895s",  430.461
"splr",        19,   "[UNS] SC21/assoc_mult_e3",  315.812
"splr",        20,   "[UNS] SC21/dist4.c      ",  707.444
"splr",        21,   "[UNS] SC21/p01_lb_05    ",  201.520
"splr",        22,   "[UNS] SC21/shift1add    ",   89.615
med:   328.995, max:  1522.816,           total: 9409.236
# ~/Repositories/splr@10-25T09:18:20 95c84985@20221025-stage*
```
span = cycle * unit_size
```
# 0.14.2, timeout:2000 on demorgan @ 2022-10-25T09:23:07
# ~/.cargo/bin/splr (0.17.0-alpha.2) @ 2022-10-25T09:22:50
solver,       num,                       target,     time
"splr",         1,                 "UF250(100)",   63.695
"splr",         2,                "UUF250(100)",  196.825
"splr",         3,   "3SAT/360  S722433227-030",    1.534
"splr",         4,   "3SAT/360 S2032263657-035",    2.167
"splr",         5,   "3SAT/360  S368632549-051",    2.920
"splr",         6,   "3SAT/360 S1684547485-073",   13.246
"splr",         7,   "3SAT/360 S1711406314-093",    0.647
"splr",         8,   "3UNS/360 S1369720750-015",  229.095
"splr",         9,   "3UNS/360  S367138237-029",  759.178
"splr",        10,   "3UNS/360  S680239195-053",  536.598
"splr",        11,   "3UNS/360  S253750560-086",  220.148
"splr",        12,   "3UNS/360 S1028159446-096",  218.861
"splr",        13,   "[SAT] SR2015/m283,  3553",   40.178
"splr",        14,   "[SAT] SR2015/38b,    448",   62.078
"splr",        15,   "[SAT] SR2015/44b,    609",  381.644
"splr",        16,   "[SAT] SC21/b04_s_unknown",   91.094
"splr",        17,   "[SAT] SC21/quad_r21_m22 ",  413.824
"splr",        18,   "[SAT] SC21/toughsat_895s",  725.761
"splr",        19,   "[UNS] SC21/assoc_mult_e3",  184.871
"splr",        20,   "[UNS] SC21/dist4.c      ",  450.362
"splr",        21,   "[UNS] SC21/p01_lb_05    ",  461.179
"splr",        22,   "[UNS] SC21/shift1add    ",   41.235
med:   190.848, max:   759.178,           total: 5097.140
# ~/Repositories/splr@10-25T09:50:11 8343ee95@20221025-stage*
```

reduce after each cycle
```
# 0.14.2, timeout:2000 on demorgan @ 2022-10-25T12:31:28
# ~/.cargo/bin/splr (0.17.0-alpha.2) @ 2022-10-25T12:30:59
solver,       num,                       target,     time
"splr",         1,                 "UF250(100)",   59.641
"splr",         2,                "UUF250(100)",  203.715
"splr",         3,   "3SAT/360  S722433227-030",  180.392
"splr",         4,   "3SAT/360 S2032263657-035",    1.711
"splr",         5,   "3SAT/360  S368632549-051",    9.851
"splr",         6,   "3SAT/360 S1684547485-073",    4.195
"splr",         7,   "3SAT/360 S1711406314-093",   43.423
"splr",         8,   "3UNS/360 S1369720750-015",  179.291
"splr",         9,   "3UNS/360  S367138237-029", 1061.941
"splr",        10,   "3UNS/360  S680239195-053",  302.331
"splr",        11,   "3UNS/360  S253750560-086",  314.654
"splr",        12,   "3UNS/360 S1028159446-096",  223.238
"splr",        13,   "[SAT] SR2015/m283,  3553",   38.495
"splr",        14,   "[SAT] SR2015/38b,    448",   41.667
"splr",        15,   "[SAT] SR2015/44b,    609",  399.190
"splr",        16,   "[SAT] SC21/b04_s_unknown",   94.695
"splr",        17,   "[SAT] SC21/quad_r21_m22 ",   75.345
"splr",        18,   "[SAT] SC21/toughsat_895s",  835.184
"splr",        19,   "[UNS] SC21/assoc_mult_e3",  292.353
"splr",        20,   "[UNS] SC21/dist4.c      ",  360.757
"splr",        21,   "[UNS] SC21/p01_lb_05    ",  290.662
"splr",        22,   "[UNS] SC21/shift1add    ",   21.582
med:   179.841, max:  1061.941,           total: 5034.313
# ~/Repositories/splr@10-25T12:58:29 dfdce322@20221025-stage*
```

The best: fix `segment` numbering

```
# 0.14.2, timeout:2000 on demorgan @ 2022-10-25T15:13:45
# ~/.cargo/bin/splr (0.17.0-alpha.2) @ 2022-10-25T15:13:38
solver,       num,                       target,     time
"splr",         1,                 "UF250(100)",   60.993
"splr",         2,                "UUF250(100)",  195.920
"splr",         3,   "3SAT/360  S722433227-030",  162.914
"splr",         4,   "3SAT/360 S2032263657-035",    2.364
"splr",         5,   "3SAT/360  S368632549-051",    2.394
"splr",         6,   "3SAT/360 S1684547485-073",   12.058
"splr",         7,   "3SAT/360 S1711406314-093",   19.094
"splr",         8,   "3UNS/360 S1369720750-015",  167.310
"splr",         9,   "3UNS/360  S367138237-029",  586.400
"splr",        10,   "3UNS/360  S680239195-053",  253.276
"splr",        11,   "3UNS/360  S253750560-086",  187.391
"splr",        12,   "3UNS/360 S1028159446-096",  244.538
"splr",        13,   "[SAT] SR2015/m283,  3553",   45.903
"splr",        14,   "[SAT] SR2015/38b,    448",   53.635
"splr",        15,   "[SAT] SR2015/44b,    609",   85.056
"splr",        16,   "[SAT] SC21/b04_s_unknown",   89.165
"splr",        17,   "[SAT] SC21/quad_r21_m22 ",   48.509
"splr",        18,   "[SAT] SC21/toughsat_895s",  135.829
"splr",        19,   "[UNS] SC21/assoc_mult_e3",  213.219
"splr",        20,   "[UNS] SC21/dist4.c      ",  267.422
"splr",        21,   "[UNS] SC21/p01_lb_05    ",  235.661
"splr",        22,   "[UNS] SC21/shift1add    ",   21.883
med:   112.497, max:   586.400,           total: 3090.934
# ~/Repositories/splr@10-25T15:31:29 dfdce322@20221025-stage*
```