### PR TITLE
20221101 SLS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "splr"
-version = "0.17.0-alpha.5"
+version = "0.17.0-alpha.6"
 authors = ["Narazaki Shuji <shujinarazaki@protonmail.com>"]
 description = "A modern CDCL SAT solver in Rust"
 edition = "2021"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ default = [
         "reason_side_rewarding",
         "rephase",
         # "reward_annealing",
+        "stochastic_local_search",
         # "suppress_reason_chain",
         "trail_saving",
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ default = [
         "reason_side_rewarding",
         "rephase",
         # "reward_annealing",
-        "stochastic_local_search",
+        # "stochastic_local_search",
         # "suppress_reason_chain",
         "trail_saving",
 
@@ -66,7 +66,7 @@ rephase = [                     # search around the best-so-far candidate repeat
         ]
 reward_annealing = []           # use bigger and smaller decay rates cycliclly
 stochastic_local_search = [     # since 0.17
-        "reward_annealing"
+        # "reward_annealing"
          ]
 support_user_assumption = []    # NOT WORK (defined in Glucose)
 suppress_reason_chain = []      # make direct links between a dicision var and its implications

--- a/src/assign/mod.rs
+++ b/src/assign/mod.rs
@@ -76,6 +76,8 @@ pub trait AssignIF:
     /// return a reference to `level`.
     fn level_ref(&self) -> &[DecisionLevel];
     fn best_assigned(&mut self) -> Option<usize>;
+    /// return `true` if no best_phases
+    fn best_phases_invalid(&self) -> bool;
     /// inject assignments for eliminated vars.
     fn extend_model(&mut self, c: &mut impl ClauseDBIF) -> Vec<Option<bool>>;
     /// return `true` if the set of literals is satisfiable under the current assignment.

--- a/src/assign/select.rs
+++ b/src/assign/select.rs
@@ -6,6 +6,7 @@ use super::property;
 use {
     super::{AssignStack, VarHeapIF},
     crate::types::*,
+    std::collections::HashMap,
 };
 
 /// ```ignore
@@ -26,6 +27,10 @@ macro_rules! var_assign {
 
 /// API for var selection, depending on an internal heap.
 pub trait VarSelectIF {
+    /// return best phases
+    fn best_phases_ref(&mut self, default_value: Option<bool>) -> HashMap<VarId, bool>;
+    /// force an assignment obtained by SLS
+    fn override_rephasing_target(&mut self, assignment: &HashMap<VarId, bool>) -> usize;
     #[cfg(feature = "rephase")]
     /// select rephasing target
     fn select_rephasing_target(&mut self);
@@ -41,6 +46,44 @@ pub trait VarSelectIF {
 }
 
 impl VarSelectIF for AssignStack {
+    fn best_phases_ref(&mut self, default_value: Option<bool>) -> HashMap<VarId, bool> {
+        self.var
+            .iter()
+            .enumerate()
+            .filter_map(|(vi, v)| {
+                if self.level[vi] == self.root_level || self.var[vi].is(FlagVar::ELIMINATED) {
+                    default_value.map(|b| (vi, b))
+                } else {
+                    Some((
+                        vi,
+                        self.best_phases.get(&vi).map_or(
+                            self.assign[vi].unwrap_or_else(|| v.is(FlagVar::PHASE)),
+                            |(b, _)| *b,
+                        ),
+                    ))
+                }
+            })
+            .collect::<HashMap<VarId, bool>>()
+    }
+    fn override_rephasing_target(&mut self, assignment: &HashMap<VarId, bool>) -> usize {
+        let mut num_flipped = 0;
+        for (vi, b) in assignment.iter() {
+            // let v = &mut self.var[*vi];
+            // if v.is(FlagVar::PHASE) != *b {
+            //     num_flipped += 1;
+            //     v.set(FlagVar::PHASE, *b);
+            //     // v.reward *= self.activity_decay;
+            //     // v.reward += self.activity_anti_decay;
+            //     // self.update_heap(*vi);
+            // }
+            if !self.best_phases.get(vi).map_or(false, |(p, _)| *p == *b) {
+                num_flipped += 1;
+                self.best_phases.insert(*vi, (*b, AssignReason::None));
+            }
+        }
+        // self.num_best_assign = self.num_asserted_vars + self.num_eliminated_vars;
+        num_flipped
+    }
     #[cfg(feature = "rephase")]
     fn select_rephasing_target(&mut self) {
         if self.best_phases.is_empty() {

--- a/src/assign/stack.rs
+++ b/src/assign/stack.rs
@@ -196,6 +196,9 @@ impl AssignIF for AssignStack {
     fn best_assigned(&mut self) -> Option<usize> {
         (self.build_best_at == self.num_propagation).then_some(self.num_vars - self.num_best_assign)
     }
+    fn best_phases_invalid(&self) -> bool {
+        self.best_phases.is_empty()
+    }
     #[allow(unused_variables)]
     fn extend_model(&mut self, cdb: &mut impl ClauseDBIF) -> Vec<Option<bool>> {
         let lits = &self.eliminated;

--- a/src/cdb/mod.rs
+++ b/src/cdb/mod.rs
@@ -10,6 +10,8 @@ mod clause;
 mod db;
 /// EMA
 mod ema;
+/// methods for Stochastic Local Search
+mod sls;
 /// methods for UNSAT certification
 mod unsat_certificate;
 /// implementation of clause vivification
@@ -21,9 +23,11 @@ pub use self::{
     binary::{BinaryLinkDB, BinaryLinkList},
     cid::ClauseIdIF,
     property::*,
+    sls::StochasticLocalSearchIF,
     unsat_certificate::CertificationStore,
     vivify::VivifyIF,
 };
+
 use {
     self::ema::ProgressLBD,
     crate::{assign::AssignIF, types::*},

--- a/src/cdb/sls.rs
+++ b/src/cdb/sls.rs
@@ -1,0 +1,116 @@
+/// Implementation of Stochastic Local Search
+use {
+    crate::{assign::AssignIF, types::*},
+    std::collections::HashMap,
+};
+
+pub trait StochasticLocalSearchIF {
+    /// returns the decision level of the given assignment and the one of the final assignment.
+    /// Note: the lower level a set of clauses make a conflict at,
+    /// the higher learning rate a solver can keep and the better learnt clauses we will have.
+    /// This would be a better criteria that can be used in CDCL solvers.
+    fn stochastic_local_search(
+        &mut self,
+        asg: &impl AssignIF,
+        start: &mut HashMap<VarId, bool>,
+        limit: usize,
+    ) -> (usize, usize);
+}
+
+impl StochasticLocalSearchIF for ClauseDB {
+    fn stochastic_local_search(
+        &mut self,
+        _asg: &impl AssignIF,
+        assignment: &mut HashMap<VarId, bool>,
+        limit: usize,
+    ) -> (usize, usize) {
+        let mut returns: (usize, usize) = (0, 0);
+        let mut last_flip = self.num_clause;
+        let mut seed = 721_109;
+        for step in 1..=limit {
+            let mut unsat_clauses = 0;
+            // let mut level: DecisionLevel = 0;
+            // CONSIDER: counting only given (permanent) clauses.
+            let mut flip_target: HashMap<VarId, usize> = HashMap::new();
+            let mut target_clause: Option<&Clause> = None;
+            for c in self.clause.iter().skip(1).filter(|c| !c.is_dead()) {
+                // let mut cls_lvl: DecisionLevel = 0;
+                if c.is_falsified(assignment, &mut flip_target) {
+                    unsat_clauses += 1;
+                    // for l in c.lits.iter() {
+                    //     cls_lvl = cls_lvl.max(asg.level(l.vi()));
+                    // }
+                    // level = level.max(cls_lvl);
+                    if target_clause.is_none() || unsat_clauses == step {
+                        target_clause = Some(c);
+                        for l in c.lits.iter() {
+                            flip_target.entry(l.vi()).or_insert(0);
+                        }
+                    }
+                }
+            }
+            if step == 1 {
+                returns.0 = unsat_clauses;
+                // returns.0 = level as usize;
+            }
+            returns.1 = unsat_clauses;
+            // returns.1 = level as usize;
+            if unsat_clauses == 0 || step == limit {
+                break;
+            }
+            seed = ((((!seed & 0x0000_0000_ffff_ffff) * 1_304_003) % 2_003_819)
+                ^ ((!last_flip & 0x0000_0000_ffff_ffff) * seed))
+                % 3_754_873;
+            if let Some(c) = target_clause {
+                let beta: f64 = 3.2 - 2.1 / (1.0 + unsat_clauses as f64).log(2.0);
+                // let beta: f64 = if unsat_clauses <= 3 { 1.0 } else { 3.0 };
+                let factor = |vi| beta.powf(-(*flip_target.get(vi).unwrap() as f64));
+                let vars = c.lits.iter().map(|l| l.vi()).collect::<Vec<_>>();
+                let index = ((seed % 100) as f64 / 100.0) * vars.iter().map(factor).sum::<f64>();
+                let mut sum: f64 = 0.0;
+                for vi in vars.iter() {
+                    sum += factor(vi);
+                    if index <= sum {
+                        assignment.entry(*vi).and_modify(|e| *e = !*e);
+                        last_flip = *vi;
+                        break;
+                    }
+                }
+            } else {
+                break;
+            }
+        }
+        returns
+    }
+}
+
+impl Clause {
+    fn is_falsified(
+        &self,
+        assignment: &HashMap<VarId, bool>,
+        flip_target: &mut HashMap<VarId, usize>,
+    ) -> bool {
+        let mut num_sat = 0;
+        let mut sat_vi = 0;
+        for l in self.iter() {
+            let vi = l.vi();
+            match assignment.get(&vi) {
+                Some(b) if *b == l.as_bool() => {
+                    if num_sat == 1 {
+                        return false;
+                    }
+                    num_sat += 1;
+                    sat_vi = vi;
+                }
+                None => unreachable!(),
+                _ => (),
+            }
+        }
+        if num_sat == 0 {
+            true
+        } else {
+            *flip_target.entry(sat_vi).or_insert(0) += 1;
+            false
+        }
+    }
+}

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -329,8 +329,8 @@ fn search(
                                     ));
                                     let cls =
                                         cdb.stochastic_local_search(asg, &mut $assign, $limit);
+                                    asg.reward_by_sls(&$assign);
                                     if $improved(cls) {
-                                        // state.sls_index = stats.1;
                                         asg.override_rephasing_target(&$assign);
                                     }
                                     sls_core = sls_core.min(cls.1);

--- a/src/state.rs
+++ b/src/state.rs
@@ -51,6 +51,8 @@ pub enum Stat {
     Simplify,
     /// the number of subsumed clause by processor
     SubsumedClause,
+    /// for SLS
+    SLS,
     /// don't use this dummy (sentinel at the tail).
     EndOfStatIndex,
 }
@@ -124,6 +126,8 @@ pub struct State {
     pub progress_cnt: usize,
     /// keep the previous statistics values
     pub record: ProgressRecord,
+    /// progress of SLS
+    pub sls_index: usize,
     /// start clock for timeout handling
     pub start: Instant,
     /// upper limit for timeout handling
@@ -157,6 +161,7 @@ impl Default for State {
             derive20: Vec::new(),
             progress_cnt: 0,
             record: ProgressRecord::default(),
+            sls_index: 0,
             start: Instant::now(),
             time_limit: 0.0,
             log_messages: Vec::new(),
@@ -517,19 +522,14 @@ impl StateIF for State {
             ),
         );
         println!(
-            "\x1B[2K        misc|vivC:{}, subC:{}, core:{}, /ppc:{}",
+            "\x1B[2K        misc|vivC:{}, !SLS:{}, core:{}, /ppc:{}",
             im!(
                 "{:>9}",
                 self,
                 LogUsizeId::VivifiedClause,
                 self[Stat::VivifiedClause]
             ),
-            im!(
-                "{:>9}",
-                self,
-                LogUsizeId::SubsumedClause,
-                self[Stat::SubsumedClause]
-            ),
+            im!("{:>9}", self, LogUsizeId::SLS, self.sls_index),
             im!(
                 "{:>9}",
                 self,
@@ -840,6 +840,11 @@ pub enum LogUsizeId {
     VivifiedVar,
     Vivify,
 
+    //
+    //## Stochastic Local Search
+    //
+    SLS,
+
     // the sentinel
     End,
 }
@@ -861,6 +866,7 @@ pub enum LogF64Id {
     PropagationPerConflict,
     LiteralBlockEntanglement,
     RestartEnergy,
+
     End,
 }
 


### PR DESCRIPTION
comparison base
```
# 0.14.2, timeout:2000 on demorgan @ 2022-11-01T13:01:26
# ~/.cargo/bin/splr (0.17.0-alpha.6) @ 2022-11-01T12:59:54
solver,       num,                       target,     time
"splr",         1,                 "UF250(100)",   56.756
"splr",         2,                "UUF250(100)",  166.428
"splr",         3,   "3SAT/360  S722433227-030",    4.683
"splr",         4,   "3SAT/360 S2032263657-035",    0.543
"splr",         5,   "3SAT/360  S368632549-051",   36.373
"splr",         6,   "3SAT/360 S1684547485-073",   39.858
"splr",         7,   "3SAT/360 S1711406314-093",    1.168
"splr",         8,   "3UNS/360 S1369720750-015",  132.931
"splr",         9,   "3UNS/360  S367138237-029",  330.074
"splr",        10,   "3UNS/360  S680239195-053",  213.169
"splr",        11,   "3UNS/360  S253750560-086",  149.884
"splr",        12,   "3UNS/360 S1028159446-096",  120.603
"splr",        13,   "[SAT] SR2015/m283,  3553",   40.026
"splr",        14,   "[SAT] SR2015/38b,    448",   29.852
"splr",        15,   "[SAT] SR2015/44b,    609",  209.106
"splr",        16,   "[SAT] SC21/b04_s_unknown",  107.759
"splr",        17,   "[SAT] SC21/quad_r21_m22 ",  120.527
"splr",        18,   "[SAT] SC21/toughsat_895s",  104.666
"splr",        19,   "[UNS] SC21/assoc_mult_e3",  122.418
"splr",        20,   "[UNS] SC21/dist4.c      ",  195.857
"splr",        21,   "[UNS] SC21/p01_lb_05    ",  135.964
"splr",        22,   "[UNS] SC21/shift1add    ",   21.044
med:   114.143, max:   330.074,           total: 2339.689
# ~/Repositories/splr@11-01T13:14:46 90c83949@20221101-sls*
```