### PR TITLE
20221104 reward annealing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "splr"
-version = "0.17.0-alpha.6"
+version = "0.17.0-alpha.7"
 authors = ["Narazaki Shuji <shujinarazaki@protonmail.com>"]
 description = "A modern CDCL SAT solver in Rust"
 edition = "2021"
@@ -28,7 +28,7 @@ default = [
         "LRB_rewarding",
         "reason_side_rewarding",
         "rephase",
-        # "reward_annealing",
+        "reward_annealing",
         # "stochastic_local_search",
         # "suppress_reason_chain",
         "trail_saving",

--- a/src/assign/mod.rs
+++ b/src/assign/mod.rs
@@ -356,6 +356,20 @@ pub mod property {
     }
 
     #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    pub enum Tf64 {
+        VarDecayRate,
+    }
+
+    pub const F64S: [Tf64; 1] = [Tf64::VarDecayRate];
+
+    impl PropertyDereference<Tf64, f64> for AssignStack {
+        #[inline]
+        fn derefer(&self, _k: Tf64) -> f64 {
+            self.activity_decay
+        }
+    }
+
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     pub enum TEma {
         AssignRate,
         DecisionPerConflict,

--- a/src/assign/mod.rs
+++ b/src/assign/mod.rs
@@ -77,6 +77,7 @@ pub trait AssignIF:
     /// return a reference to `level`.
     fn level_ref(&self) -> &[DecisionLevel];
     fn best_assigned(&mut self) -> Option<usize>;
+    #[cfg(feature = "rephase")]
     /// return `true` if no best_phases
     fn best_phases_invalid(&self) -> bool;
     /// inject assignments for eliminated vars.

--- a/src/assign/select.rs
+++ b/src/assign/select.rs
@@ -27,9 +27,11 @@ macro_rules! var_assign {
 
 /// API for var selection, depending on an internal heap.
 pub trait VarSelectIF {
+    #[cfg(feature = "rephase")]
     /// return best phases
     fn best_phases_ref(&mut self, default_value: Option<bool>) -> HashMap<VarId, bool>;
     /// force an assignment obtained by SLS
+    #[cfg(feature = "rephase")]
     fn override_rephasing_target(&mut self, assignment: &HashMap<VarId, bool>) -> usize;
     /// give rewards to vars selected by SLS
     fn reward_by_sls(&mut self, assignment: &HashMap<VarId, bool>) -> usize;
@@ -48,6 +50,7 @@ pub trait VarSelectIF {
 }
 
 impl VarSelectIF for AssignStack {
+    #[cfg(feature = "rephase")]
     fn best_phases_ref(&mut self, default_value: Option<bool>) -> HashMap<VarId, bool> {
         self.var
             .iter()
@@ -67,6 +70,7 @@ impl VarSelectIF for AssignStack {
             })
             .collect::<HashMap<VarId, bool>>()
     }
+    #[cfg(feature = "rephase")]
     fn override_rephasing_target(&mut self, assignment: &HashMap<VarId, bool>) -> usize {
         let mut num_flipped = 0;
         for (vi, b) in assignment.iter() {

--- a/src/assign/stack.rs
+++ b/src/assign/stack.rs
@@ -201,6 +201,7 @@ impl AssignIF for AssignStack {
     fn best_assigned(&mut self) -> Option<usize> {
         (self.build_best_at == self.num_propagation).then_some(self.num_vars - self.num_best_assign)
     }
+    #[cfg(feature = "rephase")]
     fn best_phases_invalid(&self) -> bool {
         self.best_phases.is_empty()
     }

--- a/src/cdb/db.rs
+++ b/src/cdb/db.rs
@@ -952,7 +952,7 @@ impl ClauseDBIF for ClauseDB {
                     let sum: f64 = self.iter().map(|l| asg.activity(l.vi())).sum();
                     sum / self.len() as f64
                 };
-                self.rank as f64 * (1.0 - act_c)
+                (self.rank as f64).log2() * (1.0 - act_c)
             }
             #[cfg(feature = "just_used")]
             fn weight(&mut self, asg: &mut impl AssignIF) -> f64 {
@@ -1014,15 +1014,16 @@ impl ClauseDBIF for ClauseDB {
             return;
         }
         perm.sort();
+        let thr = 2.0; // self.lb_entanglement.get().sqrt().max(3.0);
         for i in &perm[keep..] {
-            // self.remove_clause(ClauseId::from(i.to()));
-            let c = &self.clause[i.to()];
-            let o = c.rank_old as f64;
-            let r = c.rank as f64;
-            // if 3 < c.rank.saturating_sub((c.rank_old - c.rank) / 2) {
-            if 3.0 < r * r / o {
-                self.remove_clause(ClauseId::from(i.to()));
-            }
+            self.remove_clause(ClauseId::from(i.to()));
+            // let c = &self.clause[i.to()];
+            // let o = c.rank_old as f64;
+            // let r = c.rank as f64;
+            // // if 3 < c.rank.saturating_sub((c.rank_old - c.rank) / 2) {
+            // if thr < r * r / o {
+            //     self.remove_clause(ClauseId::from(i.to()));
+            // }
         }
     }
     fn reset(&mut self) {

--- a/src/cdb/db.rs
+++ b/src/cdb/db.rs
@@ -1015,7 +1015,14 @@ impl ClauseDBIF for ClauseDB {
         }
         perm.sort();
         for i in &perm[keep..] {
-            self.remove_clause(ClauseId::from(i.to()));
+            // self.remove_clause(ClauseId::from(i.to()));
+            let c = &self.clause[i.to()];
+            let o = c.rank_old as f64;
+            let r = c.rank as f64;
+            // if 3 < c.rank.saturating_sub((c.rank_old - c.rank) / 2) {
+            if 3.0 < r * r / o {
+                self.remove_clause(ClauseId::from(i.to()));
+            }
         }
     }
     fn reset(&mut self) {

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -291,8 +291,8 @@ fn search(
                             state.stm.current_cycle() - (1 << (seg - 1))
                         }
                     };
-                    let decay_index: f64 = 1.25 + base as f64;
-                    let decay = (decay_index - 1.0) / decay_index;
+                    let decay: f64 = 1.0 - 0.05 * 0.975_f64.powi(base as i32);
+                    // dbg!(decay);
                     asg.update_activity_decay(decay);
                 }
                 if let Some(new_segment) = next_stage {


### PR DESCRIPTION
baseline
```
# 0.14.2, timeout:2000 on demorgan @ 2022-11-06T08:50:17
# ~/.cargo/bin/splr (0.17.0-alpha.7) @ 2022-11-06T08:45:54
solver,       num,                       target,     time
"splr",         1,                 "UF250(100)",   50.882
"splr",         2,                "UUF250(100)",  171.649
"splr",         3,   "3SAT/360  S722433227-030",   53.322
"splr",         4,   "3SAT/360 S2032263657-035",    4.257
"splr",         5,   "3SAT/360  S368632549-051",   69.905
"splr",         6,   "3SAT/360 S1684547485-073",   53.746
"splr",         7,   "3SAT/360 S1711406314-093",   11.159
"splr",         8,   "3UNS/360 S1369720750-015",  127.944
"splr",         9,   "3UNS/360  S367138237-029",  341.429
"splr",        10,   "3UNS/360  S680239195-053",  168.954
"splr",        11,   "3UNS/360  S253750560-086",  147.531
"splr",        12,   "3UNS/360 S1028159446-096",  144.794
"splr",        13,   "[SAT] SR2015/m283,  3553",   29.886
"splr",        14,   "[SAT] SR2015/38b,    448",   33.413
"splr",        15,   "[SAT] SR2015/44b,    609",  332.412
"splr",        16,   "[SAT] SC21/b04_s_unknown",  101.912
"splr",        17,   "[SAT] SC21/quad_r21_m22 ",   44.733
"splr",        18,   "[SAT] SC21/toughsat_895s",  378.463
"splr",        19,   "[UNS] SC21/assoc_mult_e3",  125.262
"splr",        20,   "[UNS] SC21/dist4.c      ",  241.953
"splr",        21,   "[UNS] SC21/p01_lb_05    ",  279.415
"splr",        22,   "[UNS] SC21/shift1add    ",   22.486
med:   113.587, max:   378.463,           total: 2935.507
# ~/Repositories/splr@11-06T09:06:43 1ede6e2e@20221104-reward-annealing*
```

```
# 0.14.2, timeout:2000 on demorgan @ 2022-11-04T01:29:54
# ~/.cargo/bin/splr (0.17.0-alpha.6) @ 2022-11-03T23:59:28
solver,       num,                       target,     time
"splr",         1,                 "UF250(100)",   43.726
"splr",         2,                "UUF250(100)",  168.946
"splr",         3,   "3SAT/360  S722433227-030",   20.584
"splr",         4,   "3SAT/360 S2032263657-035",    2.873
"splr",         5,   "3SAT/360  S368632549-051",   20.737
"splr",         6,   "3SAT/360 S1684547485-073",    1.388
"splr",         7,   "3SAT/360 S1711406314-093",    8.496
"splr",         8,   "3UNS/360 S1369720750-015",  104.054
"splr",         9,   "3UNS/360  S367138237-029",  281.436
"splr",        10,   "3UNS/360  S680239195-053",  139.652
"splr",        11,   "3UNS/360  S253750560-086",   94.837
"splr",        12,   "3UNS/360 S1028159446-096",  132.805
"splr",        13,   "[SAT] SR2015/m283,  3553",   37.486
"splr",        14,   "[SAT] SR2015/38b,    448",   38.060
"splr",        15,   "[SAT] SR2015/44b,    609",  109.457
"splr",        16,   "[SAT] SC21/b04_s_unknown",   94.577
"splr",        17,   "[SAT] SC21/quad_r21_m22 ",   43.189
"splr",        18,   "[SAT] SC21/toughsat_895s",  281.488
"splr",        19,   "[UNS] SC21/assoc_mult_e3",   91.942
"splr",        20,   "[UNS] SC21/dist4.c      ",  212.794
"splr",        21,   "[UNS] SC21/p01_lb_05    ", 1356.398
"splr",        22,   "[UNS] SC21/shift1add    ",   24.985
med:    93.260, max:  1356.398,           total: 3309.910
```