### PR TITLE
20221119 two_mode_reduction

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ default = [
         ### Heuristics
         # "bi_clause_completion",
         # "clause_rewarding",
-        # "directional_reduction",
+        "directional_reduction",
         "dynamic_restart_threshold",
         "LRB_rewarding",
         "reason_side_rewarding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ default = [
         ### Heuristics
         # "bi_clause_completion",
         # "clause_rewarding",
-        "directional_reduction",
         "dynamic_restart_threshold",
         "LRB_rewarding",
         "reason_side_rewarding",
@@ -33,6 +32,7 @@ default = [
         "reward_annealing",
         # "stochastic_local_search",
         # "suppress_reason_chain",
+        "two_mode_reduction",
         "trail_saving",
 
         ### Logic formula processor
@@ -52,7 +52,6 @@ no_clause_elimination = []      # pre(in)-processor setting
 clause_rewarding = []           # clauses have activities w/ decay rate
 clause_vivification = []        # pre(in)-processor setting
 debug_propagation = []          # for debug
-directional_reduction = []      # since 0.17
 dynamic_restart_threshold = []  # control restart spans like Glucose
 EMA_calibration = []            # each exponential moving average has a calbration value
 EVSIDS = []                     # Eponential Variable State Independent Decaying Sum
@@ -78,6 +77,7 @@ trace_analysis = []             # for debug
 trace_elimination = []          # for debug
 trace_equivalency = []          # for debug
 trail_saving = []               # reduce propagation cost by reusing propagation chain
+two_mode_reduction = []         # exploration mode and exploitation mode since 0.17
 unsafe_access = []              # access elements of vectors without boundary checking
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ no_clause_elimination = []      # pre(in)-processor setting
 clause_rewarding = []           # clauses have activities w/ decay rate
 clause_vivification = []        # pre(in)-processor setting
 debug_propagation = []          # for debug
+directional_reduction = []      # since 0.17
 dynamic_restart_threshold = []  # control restart spans like Glucose
 EMA_calibration = []            # each exponential moving average has a calbration value
 EVSIDS = []                     # Eponential Variable State Independent Decaying Sum

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ default = [
         ### Heuristics
         # "bi_clause_completion",
         # "clause_rewarding",
+        # "directional_reduction",
         "dynamic_restart_threshold",
         "LRB_rewarding",
         "reason_side_rewarding",

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,4 @@
-## 0.17.0, 2022-??-??
+## 0.17.0, 2022-12-??
 
 - (Breaking change) `Certificate::try_from` returns `Ok` values even if a given vector
   contains empty clauses. All expressions corresponding to valid CNFs should be
@@ -9,6 +9,7 @@
 - Fix build errors without feature 'trial_saving' or 'rephase' (#202, #205)
 - clause reduction uses revised parameters matching a Luby series based parameter shifting
   model (#195)
+- add feature 'two_mode_reduction'
 
 ## 0.16.3, 2022-09-16
 

--- a/src/assign/heap.rs
+++ b/src/assign/heap.rs
@@ -198,6 +198,7 @@ impl VarOrderIF for VarIdHeap {
     fn len(&self) -> usize {
         self.idxs[0] as usize
     }
+    #[allow(clippy::unnecessary_cast)]
     fn insert(&mut self, vi: VarId) -> usize {
         if self.contains(vi) {
             return self.idxs[vi as usize] as usize;

--- a/src/assign/learning_rate.rs
+++ b/src/assign/learning_rate.rs
@@ -57,6 +57,7 @@ impl Var {
             self.reward += reward;
             self.turn_off(FlagVar::USED);
         }
+        self.reward_ema.update(self.reward);
         self.reward
     }
 }

--- a/src/assign/learning_rate.rs
+++ b/src/assign/learning_rate.rs
@@ -9,6 +9,9 @@ impl ActivityIF<VarId> for AssignStack {
     fn activity(&self, vi: VarId) -> f64 {
         self.var[vi].reward
     }
+    // fn activity_slow(&self, vi: VarId) -> f64 {
+    //     self.var[vi].reward_ema.get()
+    // }
     fn set_activity(&mut self, vi: VarId, val: f64) {
         self.var[vi].reward = val;
     }
@@ -40,6 +43,27 @@ impl AssignStack {
             v.reward *= scaling;
         }
     }
+    // pub fn set_activity_trend(&mut self) -> f64 {
+    //     let mut nv = 0;
+    //     let mut inc = 0;
+    //     let mut activity_sum: f64 = 0.0;
+    //     // let mut dec = 1;
+    //     for (vi, v) in self.var.iter_mut().enumerate().skip(1) {
+    //         if v.is(FlagVar::ELIMINATED) || self.level[vi] == self.root_level {
+    //             continue;
+    //         }
+    //         nv += 1;
+    //         activity_sum += v.reward;
+    //         let trend = v.reward_ema.trend();
+    //         if 1.0 < trend {
+    //             inc += 1;
+    //         }
+    //     }
+    //     self.activity_averaged = activity_sum / nv as f64;
+    //     self.cwss = inc as f64 / nv as f64;
+    //     // println!("inc rate:{:>6.4}", self.cwss);
+    //     self.cwss
+    // }
 }
 
 impl Var {
@@ -57,7 +81,7 @@ impl Var {
             self.reward += reward;
             self.turn_off(FlagVar::USED);
         }
-        self.reward_ema.update(self.reward);
+        // self.reward_ema.update(self.reward);
         self.reward
     }
 }

--- a/src/assign/mod.rs
+++ b/src/assign/mod.rs
@@ -118,6 +118,7 @@ pub struct Var {
     flags: FlagVar,
     /// a dynamic evaluation criterion like EVSIDS or ACID.
     reward: f64,
+    reward_ema: Ema2,
 
     #[cfg(feature = "boundary_check")]
     pub propagated_at: usize,

--- a/src/assign/mod.rs
+++ b/src/assign/mod.rs
@@ -118,8 +118,7 @@ pub struct Var {
     flags: FlagVar,
     /// a dynamic evaluation criterion like EVSIDS or ACID.
     reward: f64,
-    reward_ema: Ema2,
-
+    // reward_ema: Ema2,
     #[cfg(feature = "boundary_check")]
     pub propagated_at: usize,
     #[cfg(feature = "boundary_check")]
@@ -359,15 +358,25 @@ pub mod property {
 
     #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     pub enum Tf64 {
+        AverageVarActivity,
+        CurrentWorkingSetSize,
         VarDecayRate,
     }
 
-    pub const F64S: [Tf64; 1] = [Tf64::VarDecayRate];
+    pub const F64S: [Tf64; 3] = [
+        Tf64::AverageVarActivity,
+        Tf64::CurrentWorkingSetSize,
+        Tf64::VarDecayRate,
+    ];
 
     impl PropertyDereference<Tf64, f64> for AssignStack {
         #[inline]
-        fn derefer(&self, _k: Tf64) -> f64 {
-            self.activity_decay
+        fn derefer(&self, k: Tf64) -> f64 {
+            match k {
+                Tf64::AverageVarActivity => 0.0,    // self.activity_averaged,
+                Tf64::CurrentWorkingSetSize => 0.0, // self.cwss,
+                Tf64::VarDecayRate => self.activity_decay,
+            }
         }
     }
 

--- a/src/assign/var.rs
+++ b/src/assign/var.rs
@@ -11,8 +11,9 @@ use {
 impl Default for Var {
     fn default() -> Var {
         Var {
-            reward: 0.0,
             flags: FlagVar::empty(),
+            reward: 0.0,
+            reward_ema: Ema2::new(100).with_slow(1000),
 
             #[cfg(feature = "boundary_check")]
             propagated_at: 0,

--- a/src/assign/var.rs
+++ b/src/assign/var.rs
@@ -13,8 +13,7 @@ impl Default for Var {
         Var {
             flags: FlagVar::empty(),
             reward: 0.0,
-            reward_ema: Ema2::new(100).with_slow(1000),
-
+            // reward_ema: Ema2::new(200).with_slow(4_000),
             #[cfg(feature = "boundary_check")]
             propagated_at: 0,
             #[cfg(feature = "boundary_check")]

--- a/src/cdb/db.rs
+++ b/src/cdb/db.rs
@@ -1021,10 +1021,10 @@ impl ClauseDBIF for ClauseDB {
                         perm.push(OrderedProxy::new(i, value));
                     }
                 }
-                ReductionType::LSBIncremental(_) => {
+                ReductionType::LBDIncremental(_) => {
                     perm.push(OrderedProxy::new(i, c.rank as f64));
                 }
-                ReductionType::LSBTotal(lbd, _) => {
+                ReductionType::LBDTotal(lbd, _) => {
                     if lbd < c.rank {
                         perm.push(OrderedProxy::new(i, c.rank as f64));
                     }
@@ -1034,8 +1034,8 @@ impl ClauseDBIF for ClauseDB {
         let keep = match setting {
             ReductionType::ActivityIncremental(size) => perm.len().saturating_sub(size),
             ReductionType::ActivityTotal(_, scale) => (perm.len() as f64).powf(scale) as usize,
-            ReductionType::LSBIncremental(size) => perm.len().saturating_sub(size),
-            ReductionType::LSBTotal(_, scale) => (perm.len() as f64).powf(scale) as usize,
+            ReductionType::LBDIncremental(size) => perm.len().saturating_sub(size),
+            ReductionType::LBDTotal(_, scale) => (perm.len() as f64).powf(scale) as usize,
         };
         self.reduction_threshold = keep as f64 / alives as f64;
         perm.sort();

--- a/src/cdb/db.rs
+++ b/src/cdb/db.rs
@@ -1080,6 +1080,7 @@ impl ClauseDBIF for ClauseDB {
         }
         None
     }
+    #[allow(clippy::unnecessary_cast)]
     fn minimize_with_bi_clauses(&mut self, asg: &impl AssignIF, vec: &mut Vec<Lit>) {
         if vec.len() <= 1 {
             return;

--- a/src/cdb/mod.rs
+++ b/src/cdb/mod.rs
@@ -138,7 +138,7 @@ pub trait ClauseDBIF:
     /// reduce learnt clauses
     /// # CAVEAT
     /// *precondition*: decision level == 0.
-    fn reduce(&mut self, asg: &mut impl AssignIF, portion: usize);
+    fn reduce(&mut self, asg: &mut impl AssignIF, setting: ReductionType);
     /// remove all learnt clauses.
     fn reset(&mut self);
     /// update flags.
@@ -297,6 +297,14 @@ pub struct ClauseDB {
     //## incremental solving
     //
     pub eliminated_permanent: Vec<Vec<Lit>>,
+}
+
+#[derive(Clone, Debug)]
+pub enum ReductionType {
+    ActivityIncremental(usize),
+    ActivityTotal(f64, f64),
+    LSBIncremental(usize),
+    LSBTotal(u16, f64),
 }
 
 pub mod property {

--- a/src/cdb/mod.rs
+++ b/src/cdb/mod.rs
@@ -303,6 +303,8 @@ pub struct ClauseDB {
 pub enum ReductionType {
     ActivityIncremental(usize),
     ActivityTotal(f64, f64),
+    LiteralWeightIncremental(usize),
+    LiteralWeightTotal(f64, f64),
     LBDIncremental(usize),
     LBDTotal(u16, f64),
 }

--- a/src/cdb/mod.rs
+++ b/src/cdb/mod.rs
@@ -303,8 +303,8 @@ pub struct ClauseDB {
 pub enum ReductionType {
     ActivityIncremental(usize),
     ActivityTotal(f64, f64),
-    LSBIncremental(usize),
-    LSBTotal(u16, f64),
+    LBDIncremental(usize),
+    LBDTotal(u16, f64),
 }
 
 pub mod property {

--- a/src/cdb/mod.rs
+++ b/src/cdb/mod.rs
@@ -301,12 +301,14 @@ pub struct ClauseDB {
 
 #[derive(Clone, Debug)]
 pub enum ReductionType {
-    ActivityIncremental(usize),
-    ActivityTotal(f64, f64),
-    LiteralWeightIncremental(usize),
-    LiteralWeightTotal(f64, f64),
-    LBDIncremental(usize),
-    LBDTotal(u16, f64),
+    /// weight by Reverse Activity Sum over the added clauses
+    RASonADD(usize),
+    /// weight by Reverse Activito Sum over all learnt clauses
+    RASonALL(f64, f64),
+    /// weight by Literal Block Distance over the added clauses
+    LBDonADD(usize),
+    /// weight by Literal Block Distance over all learnt clauses
+    LBDonALL(f64, f64),
 }
 
 pub mod property {

--- a/src/solver/conflict.rs
+++ b/src/solver/conflict.rs
@@ -240,6 +240,9 @@ pub fn handle_conflict(
     }
     state.c_lvl.update(conflicting_level as f64);
     state.b_lvl.update(assign_level as f64);
+    state
+        .e_mode
+        .update(conflicting_level as f64 - assign_level as f64);
     state.derive20.clear();
     Ok(rank)
 }

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -272,16 +272,19 @@ fn search(
             RESTART!(asg, cdb, state);
             asg.clear_asserted_literals(cdb)?;
             {
+                let factor: f64 = 0.5;
                 cdb.reduce(
                     asg,
                     if cfg!(feature = "two_mode_reduction") {
                         if state.e_mode.trend() <= state.e_mode_threshold {
-                            ReductionType::RASonADD(state.stm.num_reducible())
+                            state.exploration_rate_ema.update(0.0);
+                            ReductionType::RASonADD(state.stm.num_reducible(factor))
                         } else {
-                            ReductionType::LBDonALL(7.0, 0.75)
+                            state.exploration_rate_ema.update(1.0);
+                            ReductionType::LBDonALL(7.0, 1.0 - factor.powf(2.0))
                         }
                     } else {
-                        ReductionType::RASonADD(state.stm.num_reducible())
+                        ReductionType::RASonADD(state.stm.num_reducible(factor))
                     },
                 );
             }

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -280,24 +280,17 @@ fn search(
                     if cfg!(feature = "directional_reduction") {
                         #[allow(clippy::if_same_then_else)]
                         if cutoff.trend() < 1.0 {
-                            ReductionType::ActivityIncremental(state.stm.num_reducible())
-                            // cdb.reduce(
-                            //     asg,
-                            //     ReductionType::ActivityIncremental(state.stm.num_reducible()),
-                            // );
-                            // ReductionType::ActivityIncremental(state.stm.current_span() / 2)
+                            ReductionType::RASonADD(state.stm.num_reducible())
+                            // ReductionType::RASonADD(state.stm.current_span() / 2)
                         } else {
-                            // cdb.reduce(
-                            //     asg,
-                            //     ReductionType::ActivityIncremental(state.stm.num_reducible()),
-                            // );
-                            // cdb.reduce(asg, ReductionType::LSBIncremental(state.stm.current_span()));
-                            // cdb.reduce(asg, ReductionType::LSBTotal(3, 0.5));
-                            // ReductionType::LSBIncremental(state.stm.current_span() / 2)
-                            ReductionType::LBDIncremental(state.stm.num_reducible())
+                            // ReductionType::RASonADD(state.stm.num_reducible())
+                            // ReductionType::LSBonADD(state.stm.current_span())
+                            // ReductionType::LSBonALL(3, 0.5)
+                            // ReductionType::LSBonADD(state.stm.current_span() / 2)
+                            ReductionType::LBDonADD(state.stm.num_reducible())
                         }
                     } else {
-                        ReductionType::ActivityIncremental(state.stm.num_reducible())
+                        ReductionType::RASonADD(state.stm.num_reducible())
                     },
                 );
             }

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -280,11 +280,12 @@ fn search(
                     if cfg!(feature = "directional_reduction") {
                         #[allow(clippy::if_same_then_else)]
                         if cutoff.trend() < 1.0 {
+                            ReductionType::ActivityIncremental(state.stm.num_reducible())
                             // cdb.reduce(
                             //     asg,
                             //     ReductionType::ActivityIncremental(state.stm.num_reducible()),
                             // );
-                            ReductionType::ActivityIncremental(state.stm.current_span() / 2)
+                            // ReductionType::ActivityIncremental(state.stm.current_span() / 2)
                         } else {
                             // cdb.reduce(
                             //     asg,
@@ -292,7 +293,8 @@ fn search(
                             // );
                             // cdb.reduce(asg, ReductionType::LSBIncremental(state.stm.current_span()));
                             // cdb.reduce(asg, ReductionType::LSBTotal(3, 0.5));
-                            ReductionType::LSBIncremental(state.stm.current_span() / 2)
+                            // ReductionType::LSBIncremental(state.stm.current_span() / 2)
+                            ReductionType::LBDIncremental(state.stm.num_reducible())
                         }
                     } else {
                         ReductionType::ActivityIncremental(state.stm.num_reducible())
@@ -445,7 +447,7 @@ fn dump_stage(asg: &AssignStack, cdb: &mut ClauseDB, state: &mut State, shift: O
             Some(true) => Some((Some(segment), Some(cycle), stage)),
         },
         format!(
-            "{:>7}, fuel:{:>9.2}, cpr:{:>8.2}, vdr:{:>3.2}, cdt:{:>3.2}",
+            "{:>7}, fuel:{:>9.2}, cpr:{:>8.2}, vdr:{:>3.2}, cdt:{:>5.2}",
             span, fuel, cpr, vdr, cdt
         ),
     );

--- a/src/solver/stage.rs
+++ b/src/solver/stage.rs
@@ -121,11 +121,12 @@ impl StageManager {
     }
     /// returns a recommending number of redicible learnt clauses, based on
     /// the length of span.
-    pub fn num_reducible(&self) -> usize {
+    pub fn num_reducible(&self, factor: f64) -> usize {
         let span = self.current_span();
-        let scale = (self.current_scale() as f64).powf(0.6);
-        let keep = scale * self.unit_size as f64;
-        span.saturating_sub(keep as usize)
+        // let scale = (self.current_scale() as f64).powf(0.6);
+        // let keep = scale * self.unit_size as f64;
+        let keep = (span as f64).powf(factor) as usize;
+        span.saturating_sub(keep)
     }
     /// returns the maximum factor so far.
     /// None: `luby_iter.max_value` holds the maximum value so far.

--- a/src/state.rs
+++ b/src/state.rs
@@ -27,6 +27,7 @@ pub trait StateIF {
     fn progress<A, C>(&mut self, asg: &A, cdb: &C)
     where
         A: PropertyDereference<assign::property::Tusize, usize>
+            + PropertyDereference<assign::property::Tf64, f64>
             + PropertyReference<assign::property::TEma, EmaView>,
         C: PropertyDereference<cdb::property::Tusize, usize>
             + PropertyDereference<cdb::property::Tf64, f64>
@@ -378,6 +379,7 @@ impl StateIF for State {
     fn progress<A, C>(&mut self, asg: &A, cdb: &C)
     where
         A: PropertyDereference<assign::property::Tusize, usize>
+            + PropertyDereference<assign::property::Tf64, f64>
             + PropertyReference<assign::property::TEma, EmaView>,
         C: PropertyDereference<cdb::property::Tusize, usize>
             + PropertyDereference<cdb::property::Tf64, f64>
@@ -401,7 +403,7 @@ impl StateIF for State {
         let asg_num_conflict = asg.derefer(assign::property::Tusize::NumConflict);
         let asg_num_decision = asg.derefer(assign::property::Tusize::NumDecision);
         let asg_num_propagation = asg.derefer(assign::property::Tusize::NumPropagation);
-
+        // let asg_cwss: f64 = asg.derefer(assign::property::Tf64::CurrentWorkingSetSize);
         let asg_dpc_ema = asg.refer(assign::property::TEma::DecisionPerConflict);
         let asg_ppc_ema = asg.refer(assign::property::TEma::PropagationPerConflict);
         let asg_cpr_ema = asg.refer(assign::property::TEma::ConflictPerRestart);

--- a/src/state.rs
+++ b/src/state.rs
@@ -155,7 +155,7 @@ impl Default for State {
             b_lvl: Ema::new(5_000),
             c_lvl: Ema::new(5_000),
             e_mode: Ema2::new(40).with_slow(4_000).with_value(10.0),
-            e_mode_threshold: 1.25,
+            e_mode_threshold: 1.20,
             exploration_rate_ema: Ema::new(1000),
 
             #[cfg(feature = "support_user_assumption")]

--- a/src/state.rs
+++ b/src/state.rs
@@ -111,6 +111,7 @@ pub struct State {
     /// EMA of c_lbd - b_lbd, or Exploration vs. Eploitation
     pub e_mode: Ema2,
     pub e_mode_threshold: f64,
+    pub exploration_rate_ema: Ema,
 
     #[cfg(feature = "support_user_assumption")]
     /// hold conflicting user-defined *assumed* literals for UNSAT problems
@@ -154,7 +155,8 @@ impl Default for State {
             b_lvl: Ema::new(5_000),
             c_lvl: Ema::new(5_000),
             e_mode: Ema2::new(40).with_slow(4_000).with_value(10.0),
-            e_mode_threshold: 4.0,
+            e_mode_threshold: 1.25,
+            exploration_rate_ema: Ema::new(1000),
 
             #[cfg(feature = "support_user_assumption")]
             conflicts: Vec::new(),
@@ -582,8 +584,8 @@ impl StateIF for State {
                 "{:>9.4}",
                 self,
                 LogF64Id::ExExTrend,
-                self.e_mode.trend(),
-                self.e_mode_threshold
+                // self.e_mode.trend(),
+                self.exploration_rate_ema.get() // , self.e_mode_threshold
             ),
             im!(
                 "{:>9}",


### PR DESCRIPTION
The last train for Splr-0.17
- [ ] What do we need to switch, criteria or local/global?
- [ ] documentation

Actually, this shows too bad performance now...

expensive 500 sec TO

```                                                         
     1  13   SC21/20-100-lambda100-65_sat.cnf                     29.19
     2  16   SC21/20-100-p100-55_sat.cnf                          300.69
     3  40   SC21/ER_500_40_2.apx_0.cnf                           486.96
     4  49   SC21/HCP-522-105.cnf                                 482.76
     5  57   SC21/Kakuro-easy-089-ext.xml.hg_4.cnf                315.5
     6  58   SC21/Kakuro-easy-104-ext.xml.hg_6.cnf                481.81
     7  59   SC21/Kakuro-easy-112-ext.xml.hg_7.cnf                241.89
     8  60   SC21/Kakuro-easy-115-ext.xml.hg_5.cnf                385.47
     9  61   SC21/Kakuro-easy-118-ext.xml.hg_4.cnf                340.21
     10 62   SC21/Kakuro-easy-127-ext.xml.hg_7.cnf                216.4
     11 65   SC21/Kakuro-easy-150-ext.xml.hg_9.cnf                291.98
     12 66   SC21/Kakuro-easy-156-ext.xml.hg_7.cnf                174.56
     13 72   SC21/MVD_ADS_S10_5_6.cnf                             9.26
     14 73   SC21/MVD_ADS_S10_6_6.cnf                             14.13
     15 74   SC21/MVD_ADS_S11_6_7.cnf                             13.06
     16 75   SC21/MVD_ADS_S11_7_7.cnf                             14.58
     17 76   SC21/MVD_ADS_S11_8_7.cnf                             0.57
     18 77   SC21/MVD_ADS_S1_5_5.cnf                              9.43
     19 78   SC21/MVD_ADS_S3_5_5.cnf                              12.68
     20 79   SC21/MVD_ADS_S4_5_5.cnf                              9.29
     21 80   SC21/MVD_ADS_S5_6_6.cnf                              27.1
     22 81   SC21/MVD_ADS_S6_6_5.cnf                              3.07
     23 82   SC21/MVD_ADS_S6_6_6.cnf                              24
     24 83   SC21/MVD_ADS_S7_6_6.cnf                              18.17
     25 84   SC21/MVD_ADS_S9_6_6.cnf                              28.11
     26 85   SC21/Mycielski-10-hints-10.cnf                       133.25
     27 104  SC21/SC21_Timetable_C_466_E_62_Cl_31_S_30.cnf        410.64
     28 106  SC21/SC21_Timetable_C_527_E_71_Cl_35_S_35.cnf        133.71
     29 107  SC21/SC21_Timetable_C_542_E_71_Cl_36_S_35.cnf        292.43
     30 115  SC21/WS_300_24_90_10.apx_0.cnf                       293.38
     31 134  SC21/at-least-two-vmpc_26.cnf                        124.67
     32 135  SC21/at-least-two-vmpc_28.cnf                        48.45
     33 136  SC21/b04_s_unknown_pre.cnf                           202.64
     34 150  SC21/barman-pfile10-039.sas.ex.15.cnf                252
     35 151  SC21/barman-pfile10-040.sas.ex.15.cnf                284.18
     36 153  SC21/battleship-14-26-sat.cnf                        182.45
     37 154  SC21/blocks-blocks-36-0.180-SAT.cnf                  93.92
     38 200  SC21/ex175_20.cnf                                    126.94
     39 201  SC21/huck.col.11.cnf                                 187.24
     40 216  SC21/maximum_constrained_partition_14_bits_n200.cnf  169.8
     41 235  SC21/mp1-squ_ali_s10x10_c39_abio_SAT.cnf             180.29
     42 239  SC21/n320p5q2_n.apx_16.cnf                           428.21
     43 243  SC21/pb_300_05_lb_16.cnf                             320.24
     44 245  SC21/pb_300_06_lb_02.cnf                             148.62
     45 249  SC21/prime_a20_b20.cnf                               167.42
     46 250  SC21/prime_a22_b22.cnf                               43.95
     47 276  SC21/randomG-B-Mix-n15-d05.cnf                       342.93
     48 304  SC21/scc_1213_40_10_3.apx_0.cnf                      72.2
     49 305  SC21/shift1add.26949.cnf                             51.46
     50 311  SC21/snw_13_9_pre.cnf                                318.57
     51 322  SC21/sp5-21-15-bin-stri-flat-noid.cnf                77.66
     52 324  SC21/sp5-21-15-one-nons-tree-noid.cnf                55.63
     53 344  SC21/stb_531_83.apx_0.cnf                            26.93
     54 345  SC21/stb_531_83.apx_1.cnf                            172.64
     55 388  SC21/vlsat2_111_1186.cnf                             14
     56 390  SC21/vlsat2_113_1150.cnf                             5.19
     57 396  SC21/vlsat2_37758_5364539.dimacs.cnf                 141.06
     58 400  SC21/vlsat2_702_14170.cnf                            69.92
```