### PR TITLE
20230415 rayon propagation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "splr"
-version = "0.17.0"
+version = "0.18.0-alpha.1"
 authors = ["Narazaki Shuji <shujinarazaki@protonmail.com>"]
 description = "A modern CDCL SAT solver in Rust"
 edition = "2021"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ default-run = "splr"
 rust-version = "1.65"
 
 [dependencies]
-bitflags = "^2.0"
+bitflags = "^2.1"
 
 [features]
 default = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ default-run = "splr"
 rust-version = "1.65"
 
 [dependencies]
-bitflags = "^1.3"
+bitflags = "^2.0"
 
 [features]
 default = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "splr"
-version = "0.18.0-alpha.1"
+version = "0.18.0-alpha.2"
 authors = ["Narazaki Shuji <shujinarazaki@protonmail.com>"]
 description = "A modern CDCL SAT solver in Rust"
 edition = "2021"
@@ -15,6 +15,7 @@ rust-version = "1.65"
 
 [dependencies]
 bitflags = "^2.1"
+rayon = "^1.7"
 
 [features]
 default = [

--- a/README.md
+++ b/README.md
@@ -419,4 +419,4 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 ---
 
-2020-2022, Narazaki Shuji
+2020-2023, Narazaki Shuji

--- a/src/types.rs
+++ b/src/types.rs
@@ -398,20 +398,15 @@ impl fmt::Display for SolverError {
 pub type MaybeInconsistent = Result<(), SolverError>;
 
 /// CNF locator
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub enum CNFIndicator {
     /// not specified
+    #[default]
     Void,
     /// from a file
     File(String),
     /// embedded directly
     LitVec(usize),
-}
-
-impl Default for CNFIndicator {
-    fn default() -> Self {
-        CNFIndicator::Void
-    }
 }
 
 impl fmt::Display for CNFIndicator {
@@ -570,6 +565,7 @@ pub trait FlagIF {
 
 bitflags! {
     /// Misc flags used by [`Clause`](`crate::cdb::Clause`).
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
     pub struct FlagClause: u8 {
         /// a clause is a generated clause by conflict analysis and is removable.
         const LEARNT       = 0b0000_0001;
@@ -586,6 +582,7 @@ bitflags! {
 
 bitflags! {
     /// Misc flags used by [`Var`](`crate::assign::Var`).
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
     pub struct FlagVar: u8 {
         /// * the previous assigned value of a Var.
         const PHASE        = 0b0000_0001;


### PR DESCRIPTION
- current implementation
```rust
for watch in &mut watchlist {
  check_another_watcher()?;
}
```

- (watchlist-level) parallel propagate

```rust
let bucket = watchlist[lit].into_par_iter().map(|w| seek_another_watcher(self: &AssignStack));
if bucket.iter().any(coflicting) {
   return Conflict();
)
for (cid, to) in bucket.iter().map(|p| p.unwrap()) {
   watchlist[to].push(cid);
}
watchlist[lit].clear();
```
