### PR TITLE
20230415 rayon parallel propagation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ default-run = "splr"
 rust-version = "1.65"
 
 [dependencies]
-bitflags = "^2.1"
+bitflags = "^2.2"
 rayon = "^1.7"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "splr"
-version = "0.18.0-alpha.1"
+version = "0.18.0-alpha.2"
 authors = ["Narazaki Shuji <shujinarazaki@protonmail.com>"]
 description = "A modern CDCL SAT solver in Rust"
 edition = "2021"
@@ -15,6 +15,7 @@ rust-version = "1.65"
 
 [dependencies]
 bitflags = "^2.1"
+rayon = "^1.7"
 
 [features]
 default = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ rust-version = "1.65"
 [dependencies]
 bitflags = "^2.2"
 rayon = "^1.7"
+futures = { version ="^0.3"}
+tokio = { version = "^1.27", features = ["full"]}
 
 [features]
 default = [

--- a/src/assign/propagate.rs
+++ b/src/assign/propagate.rs
@@ -878,12 +878,22 @@ impl AssignStack {
             //## normal clause loop
             //
             let mut source = cdb.watch_cache_iter(propagating);
-            while let Some((cid, cached)) = source
-                .next()
+            let transformers = source
+                .clone()
                 .map(|index| cdb.fetch_watch_cache_entry(propagating, index))
-            {
-                let c = &cdb[cid];
-                match self.build_propagatation_context(false_lit, cid, c, cached) {
+                .map(|(cid, cached)| {
+                    self.build_propagatation_context(false_lit, cid, &cdb[cid], cached)
+                })
+                .collect::<Vec<PropagationContext>>();
+            // let mut source = cdb.watch_cache_iter(propagating);
+            // while let Some((cid, cached)) = source
+            //     .current()
+            //     .map(|index| cdb.fetch_watch_cache_entry(propagating, index))
+            // {
+            for context in transformers.iter() {
+                match *context {
+                    // let cls = &cdb[cid];
+                    // match self.build_propagatation_context(false_lit, cid, cls, cached) {
                     PropagationContext::Conflict(cid, cached, flip_watches, cache) => {
                         if flip_watches {
                             cdb.swap_watch(cid);

--- a/src/assign/propagate.rs
+++ b/src/assign/propagate.rs
@@ -446,7 +446,7 @@ impl PropagateIF for AssignStack {
             //
             let mut source = cdb.watch_cache_iter(propagating);
             'next_clause: while let Some((cid, mut cached)) = source
-                .next()
+                .current()
                 .map(|index| cdb.fetch_watch_cache_entry(propagating, index))
             {
                 #[cfg(feature = "boundary_check")]
@@ -522,7 +522,6 @@ impl PropagateIF for AssignStack {
                             let new_watch = !*lk;
                             cdb.detach_watch_cache(propagating, &mut source);
                             cdb.transform_by_updating_watch(cid, false_watch_pos, k, true);
-                            cdb[cid].search_from = (k + 1) as u16;
                             debug_assert_ne!(self.assigned(new_watch), Some(true));
                             check_in!(
                                 cid,
@@ -643,7 +642,7 @@ impl PropagateIF for AssignStack {
             //
             let mut source = cdb.watch_cache_iter(propagating);
             'next_clause: while let Some((cid, mut cached)) = source
-                .next()
+                .current()
                 .map(|index| cdb.fetch_watch_cache_entry(propagating, index))
             {
                 if cdb[cid].is_dead() {
@@ -696,7 +695,6 @@ impl PropagateIF for AssignStack {
                             let new_watch = !*lk;
                             cdb.detach_watch_cache(propagating, &mut source);
                             cdb.transform_by_updating_watch(cid, false_watch_pos, k, true);
-                            cdb[cid].search_from = (k as u16).saturating_add(1);
                             debug_assert!(
                                 self.assigned(!new_watch) == Some(true)
                                     || self.assigned(!new_watch).is_none()
@@ -913,7 +911,6 @@ impl AssignStack {
                     PropagationContext::UpdateWatch(cid, new_watch, k, false_watch_pos) => {
                         cdb.detach_watch_cache(propagating, &mut source);
                         cdb.transform_by_updating_watch(cid, false_watch_pos, k, true);
-                        cdb[cid].search_from = (k + 1) as u16;
                         debug_assert_ne!(self.assigned(new_watch), Some(true));
                         check_in!(
                             cid,

--- a/src/cdb/db.rs
+++ b/src/cdb/db.rs
@@ -233,6 +233,10 @@ impl ClauseDBIF for ClauseDB {
     fn fetch_watch_cache_entry(&self, lit: Lit, wix: WatchCacheProxy) -> (ClauseId, Lit) {
         self.watch_cache[lit][wix]
     }
+    fn fetch_watch_cache_entry2(&self, lit: Lit, wix: WatchCacheProxy) -> (ClauseId, Lit, &Clause) {
+        let cl = self.watch_cache[lit][wix];
+        (cl.0, cl.1, &self[cl.0])
+    }
     #[inline]
     fn watch_cache_iter(&mut self, l: Lit) -> WatchCacheIterator {
         // let mut empty = WatchCache::new();

--- a/src/cdb/db.rs
+++ b/src/cdb/db.rs
@@ -922,7 +922,7 @@ impl ClauseDBIF for ClauseDB {
         }
 
         c.lits.swap(old, new);
-
+        c.search_from = (new + 1) as u16;
         // maintain_watch_literal \\ assert!(watch_cache[!c.lits[0]].iter().any(|wc| wc.0 == cid && wc.1 == c.lits[1]));
         // maintain_watch_literal \\ assert!(watch_cache[!c.lits[1]].iter().any(|wc| wc.0 == cid && wc.1 == c.lits[0]));
     }

--- a/src/cdb/db.rs
+++ b/src/cdb/db.rs
@@ -551,17 +551,24 @@ impl ClauseDBIF for ClauseDB {
         self.watch_cache[l][*to] = self.watch_cache[l][from];
 
         {
+            // // self.watch_cache[l][from].0 = ClauseId::default();
+            // let cid = self.watch_cache[l][*to].0;
             // self.watch_cache[l][from].0 = ClauseId::default();
-            let cid = self.watch_cache[l][*to].0;
-            let c = &self[cid];
-            let l0 = c.lits[0];
-            let l1 = c.lits[1];
-            debug_assert!(self.watch_cache[!l0]
-                .iter()
-                .any(|wc| wc.0 == cid && wc.1 != l0));
-            debug_assert!(self.watch_cache[!l1]
-                .iter()
-                .any(|wc| wc.0 == cid && wc.1 != l1));
+            // let c = &self[cid];
+            // let l0 = c.lits[0];
+            // let l1 = c.lits[1];
+            // debug_assert!(self.watch_cache[!l0]
+            //     .iter()
+            //     .any(|wc| wc.0 == cid && wc.1 == !l1));
+            // debug_assert!(self.watch_cache[!l0]
+            //     .iter()
+            //     .all(|wc| wc.0 == cid && wc.1 != !l0));
+            // debug_assert!(self.watch_cache[!l1]
+            //     .iter()
+            //     .any(|wc| wc.0 == cid && wc.1 == !l0));
+            // debug_assert!(self.watch_cache[!l1]
+            //     .iter()
+            //     .all(|wc| wc.0 == cid && wc.1 != !l1));
             // if !(self.watch_cache[!l0]
             //     .iter()
             //     .any(|wc| wc.0 == cid && wc.1 == l1))

--- a/src/cdb/mod.rs
+++ b/src/cdb/mod.rs
@@ -95,6 +95,8 @@ pub trait ClauseDBIF:
     //## abstraction to watch_cache
     //
 
+    // return the number of clause watching `lit`
+    fn watcher_list_len(&self, lit: Lit) -> usize;
     // get mutable reference to a watch_cache
     fn fetch_watch_cache_entry(&self, lit: Lit, index: WatchCacheProxy) -> (ClauseId, Lit);
     /// replace the mutable watcher list with an empty one, and return the list
@@ -135,6 +137,14 @@ pub trait ClauseDBIF:
     );
     /// FIXME:
     fn transform2_by_resizing_watch_cache_list(&mut self, l: Lit, to: usize);
+    /// FIXME:
+    fn transform2_by_folding_watch_cache_list(
+        &mut self,
+        propagating: Lit,
+        garbage_from: usize,
+        remain_from: usize,
+    );
+
     /// swap i-th watch with j-th literal then update watch caches correctly
     fn transform_by_updating_watch(&mut self, cid: ClauseId, old: usize, new: usize, removed: bool);
     /// allocate a new clause and return its id.

--- a/src/cdb/mod.rs
+++ b/src/cdb/mod.rs
@@ -74,6 +74,7 @@ pub trait ClauseDBIF:
     + IndexMut<ClauseId, Output = Clause>
     + PropertyDereference<property::Tusize, usize>
     + PropertyDereference<property::Tf64, f64>
+    + Sync
 {
     /// return the length of `clause`.
     fn len(&self) -> usize;

--- a/src/cdb/mod.rs
+++ b/src/cdb/mod.rs
@@ -117,6 +117,24 @@ pub trait ClauseDBIF:
         iter: &mut WatchCacheIterator,
         p: Option<Lit>,
     );
+    /// FIXME:
+    fn transform2_by_updating_watch_cache(
+        &mut self,
+        propagating_lit: Lit,
+        cid: ClauseId,
+        old_watch_index: usize,
+        new_watch_index: usize,
+    );
+    /// FIXME: rayon_propagate
+    fn transform2_by_pushing_watch_cache_back(
+        &mut self,
+        l: Lit,
+        from: usize,
+        to: &mut usize,
+        op: Option<Lit>,
+    );
+    /// FIXME:
+    fn transform2_by_resizing_watch_cache_list(&mut self, l: Lit, to: usize);
     /// swap i-th watch with j-th literal then update watch caches correctly
     fn transform_by_updating_watch(&mut self, cid: ClauseId, old: usize, new: usize, removed: bool);
     /// allocate a new clause and return its id.

--- a/src/cdb/mod.rs
+++ b/src/cdb/mod.rs
@@ -100,6 +100,11 @@ pub trait ClauseDBIF:
     fn watcher_list_len(&self, lit: Lit) -> usize;
     // get mutable reference to a watch_cache
     fn fetch_watch_cache_entry(&self, lit: Lit, index: WatchCacheProxy) -> (ClauseId, Lit);
+    fn fetch_watch_cache_entry2(
+        &self,
+        lit: Lit,
+        index: WatchCacheProxy,
+    ) -> (ClauseId, Lit, &Clause);
     /// replace the mutable watcher list with an empty one, and return the list
     fn watch_cache_iter(&mut self, l: Lit) -> WatchCacheIterator;
     /// detach the watch_cache referred by the head of a watch_cache iterator

--- a/src/cdb/watch_cache.rs
+++ b/src/cdb/watch_cache.rs
@@ -126,11 +126,7 @@ impl WatchCacheIterator {
         }
     }
     pub fn current(&mut self) -> Option<WatchCacheProxy> {
-        (self.index < self.end_at).then_some({
-            // assert!(0 < self.checksum);
-            // self.checksum -= 1;
-            self.index
-        })
+        (self.index < self.end_at).then_some(self.index)
     }
     pub fn restore_entry(&mut self) {
         self.index += 1;

--- a/src/cdb/watch_cache.rs
+++ b/src/cdb/watch_cache.rs
@@ -125,6 +125,14 @@ impl WatchCacheIterator {
             // checksum: len,
         }
     }
+    pub fn skip(mut self, start: usize) -> Self {
+        self.index = start;
+        self
+    }
+    pub fn take(mut self, count: usize) -> Self {
+        self.end_at = self.index + count;
+        self
+    }
     pub fn current(&mut self) -> Option<WatchCacheProxy> {
         (self.index < self.end_at).then_some(self.index)
     }

--- a/src/cdb/watch_cache.rs
+++ b/src/cdb/watch_cache.rs
@@ -96,6 +96,7 @@ impl IndexMut<Lit> for Vec<WatchCache> {
 
 pub type WatchCacheProxy = usize;
 
+#[derive(Clone, Debug)]
 pub struct WatchCacheIterator {
     pub index: usize,
     end_at: usize,
@@ -109,7 +110,9 @@ impl Iterator for WatchCacheIterator {
         (self.index < self.end_at).then_some({
             // assert!(0 < self.checksum);
             // self.checksum -= 1;
-            self.index
+            let current = self.index;
+            self.index += 1;
+            current
         })
     }
 }
@@ -121,6 +124,13 @@ impl WatchCacheIterator {
             end_at: len,
             // checksum: len,
         }
+    }
+    pub fn current(&mut self) -> Option<WatchCacheProxy> {
+        (self.index < self.end_at).then_some({
+            // assert!(0 < self.checksum);
+            // self.checksum -= 1;
+            self.index
+        })
     }
     pub fn restore_entry(&mut self) {
         self.index += 1;


### PR DESCRIPTION
- [x] separate check and perform
- [x] rename `PropagationContext` to `ClauseTransformer`; then we have to make an entry point to `ClauseDB` that takes a `ClauseTransformer`???
- [x] collect transformers in parallel, then execute them under an immutable context sequentially
- [ ] revise to the new IF
- [ ] refactor `check_in` debug codes

Wow!!! It's getting slow!

I found Rayon was not good for this. I need something better.

## The first idea

- current implementation
```rust
for watch in &mut watchlist {
  check_another_watcher()?;
}
```

- (watchlist-level) parallel propagate

```rust
let bucket = watchlist[lit].into_par_iter().map(|w| seek_another_watcher(self: &AssignStack));
if bucket.iter().any(conflicting) {
   return Conflict();
)
for (cid, to) in bucket.iter().map(|p| p.unwrap()) {
   watchlist[to].push(cid);
}
watchlist[lit].clear();
```

### a problem caused by inappropriate evaluation assumption

A new assignment (implication) modifies the checking context. We have to purge the remains and rebuild them.

```rust
'new_context: while start < watch_list.len() {
  // parallel part
  let transformers = watch_list[start..start+bucket_size].iter().map().collect();
  // sequential part
  let mut processed = 0;
  for (i, transformer) in transformers.iter() {
     processed += 1;
     ...
     if got_new_assign {
        start = i + 1;
        continue 'new_context;
     }
  }
  start += processed;
}
```

