### PR TITLE
Add feature 'deterministic' to fix bugs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
+ "getrandom",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -111,6 +112,17 @@ name = "either"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
+
+[[package]]
+name = "getrandom"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
 
 [[package]]
 name = "hashbrown"
@@ -389,6 +401,7 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 name = "splr"
 version = "0.18.0-dev0"
 dependencies = [
+ "ahash",
  "bitflags",
  "crossterm",
  "instant",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,16 +16,18 @@ rust-version = "1.65"
 [dependencies]
 bitflags = "^2.5"
 
-instant = { version = "0.1", features = ["wasm-bindgen"], optional = true }
+instant = { version = "^0.1", features = ["wasm-bindgen"], optional = true }
 
 crossterm = { version = "^0.27", optional = true }
 ratatui = { version = "^0.26", features = ["all-widgets"], optional = true }
+ahash = { version = "^0.8", optional = true }
 
 [features]
 default = [
         ### Essential
         # "incremental_solver", # this requires "clause_elimination" is off
         "watch",
+        "deterministic",
 
         ### Heuristics
         # "bi_clause_completion",
@@ -33,7 +35,7 @@ default = [
         # "dynamic_restart_threshold",
         "LRB_rewarding",
         "reason_side_rewarding",
-        # "rephase",
+        "rephase",
         # "reward_annealing",
         # "stochastic_local_search",
         # "suppress_reason_chain",
@@ -60,6 +62,9 @@ clause_elimination = []         # pre(in)-processor setting
 clause_rewarding = []           # clauses have activities w/ decay rate
 clause_vivification = []        # pre(in)-processor setting
 debug_propagation = []          # for debug
+deterministic = [               # make Splr deterministic for debug
+        "ahash"
+]
 dynamic_restart_threshold = []  # control restart spans like Glucose
 EMA_calibration = []            # each exponential moving average has a calbration value
 EVSIDS = []                     # Eponential Variable State Independent Decaying Sum

--- a/src/assign/propagate.rs
+++ b/src/assign/propagate.rs
@@ -384,7 +384,7 @@ impl PropagateIF for AssignStack {
             //
             let mut prev = WatchLiteralIndex::default();
             let mut wli = cdb.get_watch_literal_index(propagating);
-            'next_clause: while !wli.is_none() {
+            'next_clause: while wli.is_some() {
                 let (ci, false_index) = wli.indices();
                 let c = &mut cdb[ci];
                 let other = *c.iter().nth(1 - false_index).unwrap();
@@ -531,7 +531,7 @@ impl PropagateIF for AssignStack {
             //
             let mut prev = WatchLiteralIndex::default();
             let mut wli = cdb.get_watch_literal_index(propagating);
-            'next_clause: while !wli.is_none() {
+            'next_clause: while wli.is_some() {
                 let (ci, false_index) = wli.indices();
                 let c = &mut cdb[ci];
                 // if c.is_dead() {

--- a/src/assign/propagate.rs
+++ b/src/assign/propagate.rs
@@ -9,6 +9,9 @@ use {
     std::collections::HashSet,
 };
 
+#[cfg(feature = "deterministic")]
+use {crate::config::RANDOM_STATE_SEED, ahash::RandomState};
+
 #[cfg(feature = "trail_saving")]
 use super::TrailSavingIF;
 
@@ -606,6 +609,10 @@ impl AssignStack {
     /// clear unpropagated literal as root_level
     fn propagate_at_root_level(&mut self, cdb: &mut impl ClauseDBIF) -> MaybeInconsistent {
         let mut num_propagated = 0;
+        #[cfg(feature = "deterministic")]
+        let mut deads: HashSet<Lit, RandomState> =
+            HashSet::with_hasher(RandomState::with_seed(RANDOM_STATE_SEED));
+        #[cfg(not(feature = "deterministic"))]
         let mut deads: HashSet<Lit> = HashSet::new();
         while num_propagated < self.trail.len() {
             num_propagated = self.trail.len();

--- a/src/assign/propagate.rs
+++ b/src/assign/propagate.rs
@@ -637,7 +637,7 @@ impl AssignStack {
                 }
             }
         }
-        cdb.collect(&deads);
+        cdb.reinitialize_frees(&mut deads);
         Ok(())
     }
     fn level_up(&mut self) {

--- a/src/bin/splw.rs
+++ b/src/bin/splw.rs
@@ -16,7 +16,7 @@ use {
         assign, cdb,
         config::{self, CERTIFICATION_DEFAULT_FILENAME},
         solver::Solver as Splr,
-        solver::{Certificate, SatSolverIF, SearchContext, SolveIF, SolverResult},
+        solver::{Certificate, SatSolverIF, SearchState, SolveIF, SolverResult},
         state::{self, LogF64Id, LogUsizeId},
         Config, EmaIF, PropertyDereference, PropertyReference, SolverError, VERSION,
     },
@@ -35,7 +35,7 @@ use {
 #[derive(Debug)]
 pub struct App {
     solver: Splr,
-    process: SearchContext,
+    process: SearchState,
     counter: i16,
     asg_stats: [u64; 4],
     #[allow(dead_code)]
@@ -43,7 +43,7 @@ pub struct App {
 }
 
 impl App {
-    fn solver(solver: Splr, process: SearchContext) -> Self {
+    fn solver(solver: Splr, process: SearchState) -> Self {
         App {
             solver,
             process,

--- a/src/cdb/binary.rs
+++ b/src/cdb/binary.rs
@@ -6,9 +6,6 @@ use {
     },
 };
 
-#[cfg(feature = "deterministic")]
-use {crate::config::RANDOM_STATE_SEED, ahash::RandomState};
-
 /// storage of binary links
 pub type BinaryLinkList = Vec<(Lit, ClauseIndex)>;
 
@@ -28,9 +25,6 @@ impl IndexMut<Lit> for Vec<BinaryLinkList> {
 /// storage with mapper to `ClauseIndex` of binary links
 #[derive(Clone, Debug, Default)]
 pub struct BinaryLinkDB {
-    #[cfg(feature = "deterministic")]
-    pub(super) hash: HashMap<(Lit, Lit), ClauseIndex, RandomState>,
-    #[cfg(not(feature = "deterministic"))]
     pub(super) hash: HashMap<(Lit, Lit), ClauseIndex>,
     pub(super) list: Vec<BinaryLinkList>,
 }
@@ -38,12 +32,7 @@ pub struct BinaryLinkDB {
 impl Instantiate for BinaryLinkDB {
     fn instantiate(_conf: &Config, cnf: &CNFDescription) -> Self {
         let num_lit = 2 * (cnf.num_of_variables + 1);
-        #[cfg(feature = "deterministic")]
-        let random_state = RandomState::with_seed(RANDOM_STATE_SEED);
         BinaryLinkDB {
-            #[cfg(feature = "deterministic")]
-            hash: HashMap::with_hasher(random_state),
-            #[cfg(not(feature = "deterministic"))]
             hash: HashMap::new(),
             list: vec![Vec::new(); num_lit],
         }

--- a/src/cdb/binary.rs
+++ b/src/cdb/binary.rs
@@ -6,6 +6,9 @@ use {
     },
 };
 
+#[cfg(feature = "deterministic")]
+use {crate::config::RANDOM_STATE_SEED, ahash::RandomState};
+
 /// storage of binary links
 pub type BinaryLinkList = Vec<(Lit, ClauseIndex)>;
 
@@ -25,6 +28,9 @@ impl IndexMut<Lit> for Vec<BinaryLinkList> {
 /// storage with mapper to `ClauseIndex` of binary links
 #[derive(Clone, Debug, Default)]
 pub struct BinaryLinkDB {
+    #[cfg(feature = "deterministic")]
+    pub(super) hash: HashMap<(Lit, Lit), ClauseIndex, RandomState>,
+    #[cfg(not(feature = "deterministic"))]
     pub(super) hash: HashMap<(Lit, Lit), ClauseIndex>,
     pub(super) list: Vec<BinaryLinkList>,
 }
@@ -32,7 +38,12 @@ pub struct BinaryLinkDB {
 impl Instantiate for BinaryLinkDB {
     fn instantiate(_conf: &Config, cnf: &CNFDescription) -> Self {
         let num_lit = 2 * (cnf.num_of_variables + 1);
+        #[cfg(feature = "deterministic")]
+        let random_state = RandomState::with_seed(RANDOM_STATE_SEED);
         BinaryLinkDB {
+            #[cfg(feature = "deterministic")]
+            hash: HashMap::with_hasher(random_state),
+            #[cfg(not(feature = "deterministic"))]
             hash: HashMap::new(),
             list: vec![Vec::new(); num_lit],
         }

--- a/src/cdb/mod.rs
+++ b/src/cdb/mod.rs
@@ -1094,7 +1094,9 @@ impl Clause {
     }
 }
 
+// encoded valid lits start from 1.
 const FREE_LIT: usize = 1;
+// Clauses have two watches, Free clauses point the next one by the 2nd watch.
 const FREE_WATCH_INDEX: usize = 1;
 
 impl ClauseWeaverIF for ClauseDB {

--- a/src/cdb/mod.rs
+++ b/src/cdb/mod.rs
@@ -651,7 +651,7 @@ impl ClauseDBIF for ClauseDB {
             }
         }
     }
-    // used in `propagate`, `propagate_sandbox`, and `handle_conflict` for chronoBT
+    /// called from `propagate`, `propagate_sandbox`, and `handle_conflict` for chronoBT
     #[inline]
     fn transform_by_updating_watch(
         &mut self,
@@ -673,13 +673,15 @@ impl ClauseDBIF for ClauseDB {
         // 2. insert a new watch                  [Step:2]
         // 3. update a blocker cach e             [Step:3]
 
+        // Note: since `propagate_sandbox` calls this function, we can't assume below.
+        // assert!(!self[wli.as_ci()].is_dead());
+
         debug_assert!(!wli.is_none());
         debug_assert!(1 < new);
         //## Step:1
         // let target: WatchLiteralIndex = self[prev.as_ci()].links[prev.as_wi()];
         let (ci, old) = wli.indices();
         debug_assert!(old < 2);
-        debug_assert!(!self[ci].is_dead()); // FIXME: assertion failed
         let ret: WatchLiteralIndex = self[ci].links[wli.as_wi()];
         // let target = self.remove_next_watch(prev);
         // watch_cache[!c.lits[old]].remove_watch(&ci);

--- a/src/cdb/mod.rs
+++ b/src/cdb/mod.rs
@@ -1255,9 +1255,16 @@ impl ClauseWeaverIF for ClauseDB {
         #[cfg(feature = "deterministic")] targets: &HashSet<Lit, RandomState>,
         #[cfg(not(feature = "deterministic"))] targets: &HashSet<Lit>,
     ) {
+        // I can't beleave but the iteration order on a HashSet with a fix seed
+        // isn't fixed. So I need sorting here.
+        // BUT, WHY DOES THE SWEEPING ORDER MATTER?
+        #[cfg(feature = "deterministic")]
+        let mut targets = targets.iter().copied().collect::<Vec<_>>();
+        #[cfg(feature = "deterministic")]
+        targets.sort();
         for lit in targets.iter() {
             let mut prev: WatchLiteralIndex = WatchLiteralIndex::default();
-            let mut wli = self.watch[usize::from(*lit)];
+            let mut wli: WatchLiteralIndex = self.watch[usize::from(*lit)];
             while !wli.is_none() {
                 let (ci, li) = wli.indices();
                 if self[ci].is_dead() {

--- a/src/cdb/sls.rs
+++ b/src/cdb/sls.rs
@@ -15,7 +15,8 @@ pub trait StochasticLocalSearchIF {
     fn stochastic_local_search(
         &mut self,
         asg: &impl AssignIF,
-        start: &mut HashMap<VarId, bool>,
+        #[cfg(feature = "deterministic")] start: &mut HashMap<VarId, bool, RandomState>,
+        #[cfg(not(feature = "deterministic"))] start: &mut HashMap<VarId, bool>,
         limit: usize,
     ) -> (usize, usize);
 }
@@ -24,7 +25,8 @@ impl StochasticLocalSearchIF for ClauseDB {
     fn stochastic_local_search(
         &mut self,
         _asg: &impl AssignIF,
-        assignment: &mut HashMap<VarId, bool>,
+        #[cfg(feature = "deterministic")] assignment: &mut HashMap<VarId, bool, RandomState>,
+        #[cfg(not(feature = "deterministic"))] assignment: &mut HashMap<VarId, bool>,
         limit: usize,
     ) -> (usize, usize) {
         let mut returns: (usize, usize) = (0, 0);
@@ -96,7 +98,8 @@ impl StochasticLocalSearchIF for ClauseDB {
 impl Clause {
     fn is_falsified(
         &self,
-        assignment: &HashMap<VarId, bool>,
+        #[cfg(feature = "deterministic")] assignment: &mut HashMap<VarId, bool, RandomState>,
+        #[cfg(not(feature = "deterministic"))] assignment: &mut HashMap<VarId, bool>,
         #[cfg(feature = "deterministic")] flip_target: &mut HashMap<VarId, usize, RandomState>,
         #[cfg(not(feature = "deterministic"))] flip_target: &mut HashMap<VarId, usize>,
     ) -> bool {

--- a/src/cdb/vivify.rs
+++ b/src/cdb/vivify.rs
@@ -10,6 +10,9 @@ use {
     std::collections::HashSet,
 };
 
+#[cfg(feature = "deterministic")]
+use {crate::config::RANDOM_STATE_SEED, ahash::RandomState};
+
 const VIVIFY_LIMIT: usize = 80_000;
 
 pub trait VivifyIF {
@@ -41,6 +44,10 @@ impl VivifyIF for ClauseDB {
         let mut num_shrink = 0;
         let mut num_assert = 0;
         let mut to_display = 0;
+        #[cfg(feature = "deterministic")]
+        let mut deads: HashSet<Lit, RandomState> =
+            HashSet::with_hasher(RandomState::with_seed(RANDOM_STATE_SEED));
+        #[cfg(not(feature = "deterministic"))]
         let mut deads: HashSet<Lit> = HashSet::new();
         'next_clause: while let Some(cp) = clauses.pop() {
             asg.backtrack_sandbox();

--- a/src/cdb/vivify.rs
+++ b/src/cdb/vivify.rs
@@ -153,8 +153,7 @@ impl VivifyIF for ClauseDB {
                                     self.new_clause(asg, &mut vec, is_learnt);
                                     // propage_sandbox can't handle dead watchers correctly
                                     self.nullify_clause(ci, &mut deads);
-                                    self.collect(&deads);
-                                    deads.clear();
+                                    self.reinitialize_frees(&mut deads);
                                     num_shrink += 1;
                                 }
                             }

--- a/src/cdb/weaver.rs
+++ b/src/cdb/weaver.rs
@@ -1,5 +1,8 @@
 use {crate::types::*, std::collections::HashSet};
 
+#[cfg(feature = "deterministic")]
+use ahash::RandomState;
+
 pub trait WatcherLinkIF {
     fn next_watch(&self, wi: usize) -> WatchLiteralIndex;
     fn next_watch_mut(&mut self, wi: usize) -> &mut WatchLiteralIndex;
@@ -24,11 +27,27 @@ pub trait ClauseWeaverIF {
     /// instantiate a list of watch lists
     fn make_watches(num_vars: usize, clauses: &mut [Clause]) -> Vec<WatchLiteralIndex>;
     /// un-register a clause `cid` from alive clause database and make the clause dead.
-    fn nullify_clause(&mut self, ci: ClauseIndex, deads: &mut HashSet<Lit>);
+    fn nullify_clause(
+        &mut self,
+        ci: ClauseIndex,
+        #[cfg(feature = "deterministic")] deads: &mut HashSet<Lit, RandomState>,
+        #[cfg(not(feature = "deterministic"))] deads: &mut HashSet<Lit>,
+    );
     /// un-register a clause `cid` from clause database and make the clause dead.
-    fn nullify_clause_sandbox(&mut self, ci: ClauseIndex, deads: &mut HashSet<Lit>);
+    fn nullify_clause_sandbox(
+        &mut self,
+        ci: ClauseIndex,
+        #[cfg(feature = "deterministic")] deads: &mut HashSet<Lit, RandomState>,
+        #[cfg(not(feature = "deterministic"))] deads: &mut HashSet<Lit>,
+    );
     /// update watches of the clause
-    fn collect(&mut self, targets: &HashSet<Lit>);
+    #[cfg(feature = "deterministic")]
+    fn collect(
+        &mut self,
+        #[cfg(feature = "deterministic")] targets: &HashSet<Lit, RandomState>,
+
+        #[cfg(not(feature = "deterministic"))] targets: &HashSet<Lit>,
+    );
 }
 
 // #[derive(Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]

--- a/src/cdb/weaver.rs
+++ b/src/cdb/weaver.rs
@@ -42,11 +42,11 @@ pub trait ClauseWeaverIF {
     );
     /// update watches of the clause
     #[cfg(feature = "deterministic")]
-    fn collect(
+    fn reinitialize_frees(
         &mut self,
-        #[cfg(feature = "deterministic")] targets: &HashSet<Lit, RandomState>,
+        #[cfg(feature = "deterministic")] targets: &mut HashSet<Lit, RandomState>,
 
-        #[cfg(not(feature = "deterministic"))] targets: &HashSet<Lit>,
+        #[cfg(not(feature = "deterministic"))] targets: &mut HashSet<Lit>,
     );
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,6 +3,9 @@ use {crate::types::DecisionLevel, std::path::PathBuf};
 
 pub const CERTIFICATION_DEFAULT_FILENAME: &str = "proof.drat";
 
+#[cfg(feature = "deterministic")]
+pub(crate) const RANDOM_STATE_SEED: usize = 2024_0622_1347_0181;
+
 /// Configuration built from command line options
 #[derive(Clone, Debug)]
 pub struct Config {

--- a/src/primitive/mod.rs
+++ b/src/primitive/mod.rs
@@ -1,5 +1,7 @@
 /// methods on clause activity
 pub mod ema;
+// a simple hash mapper to make splr deterministic
+// pub mod hash64;
 /// methods on binary link, namely binary clause
 pub mod luby;
 

--- a/src/processor/eliminate.rs
+++ b/src/processor/eliminate.rs
@@ -390,7 +390,7 @@ mod tests {
         #[cfg(not(feature = "deterministic"))]
         let mut deads: HashSet<Lit> = HashSet::new();
         eliminate_var(asg, cdb, &mut elim, state, vi, &mut timedout, &mut deads).expect("panic");
-        cdb.collect(&deads);
+        cdb.reinitialize_frees(&mut deads);
         assert!(asg.var(vi).is(FlagVar::ELIMINATED));
         assert!(cdb.iter().skip(1).all(|c| c.is_dead()
             || (c.iter().all(|l| *l != Lit::from((vi, false)))

--- a/src/processor/eliminate.rs
+++ b/src/processor/eliminate.rs
@@ -9,7 +9,7 @@ use {
 use ahash::RandomState;
 
 // Stop elimination if a generated resolvent is larger than this
-const COMBINATION_LIMIT: f64 = 32.0;
+const COMBINATION_LIMIT: f64 = 8.0;
 
 pub fn eliminate_var(
     asg: &mut impl AssignIF,
@@ -31,10 +31,10 @@ pub fn eliminate_var(
     // Note: it may contain the target literal somehow. So the following may be failed.
     // debug_assert!(w.pos_occurs.iter().all(|c| cdb[*c].is_dead() || cdb[*c].contains(Lit::from((vi, true)))));
     w.pos_occurs
-        .retain(|&c| cdb[c].contains(Lit::from((vi, true))));
+        .retain(|&c| !cdb[c].is_dead() && cdb[c].contains(Lit::from((vi, true))));
     // debug_assert!(w.pos_occurs.iter().all(|c| cdb[*c].is_dead() || cdb[*c].contains(Lit::from((vi, false)))));
     w.neg_occurs
-        .retain(|&c| cdb[c].contains(Lit::from((vi, false))));
+        .retain(|&c| !cdb[c].is_dead() && cdb[c].contains(Lit::from((vi, false))));
 
     let num_combination = w.pos_occurs.len() * w.neg_occurs.len();
 

--- a/src/processor/simplify.rs
+++ b/src/processor/simplify.rs
@@ -430,6 +430,7 @@ impl Eliminator {
             }
         }
         if asg.remains() {
+            // cdb.collect(&deads); // This change might take too long time.
             asg.propagate_sandbox(cdb)
                 .map_err(SolverError::RootLevelConflict)?;
         }

--- a/src/processor/simplify.rs
+++ b/src/processor/simplify.rs
@@ -239,7 +239,7 @@ impl EliminateIF for Eliminator {
         }
         self.var_queue.clear(asg);
         debug_assert!(self.clause_queue.is_empty());
-        cdb.collect(&deads);
+        cdb.reinitialize_frees(&mut deads);
         cdb.check_size().map(|_| ())
     }
     fn sorted_iterator(&self) -> Iter<'_, u32> {

--- a/src/processor/subsume.rs
+++ b/src/processor/subsume.rs
@@ -9,6 +9,9 @@ use {
     std::collections::HashSet,
 };
 
+#[cfg(feature = "deterministic")]
+use ahash::RandomState;
+
 #[derive(Clone, Eq, Debug, Ord, PartialEq, PartialOrd)]
 enum Subsumable {
     None,
@@ -23,7 +26,8 @@ impl Eliminator {
         cdb: &mut impl ClauseDBIF,
         ci: ClauseIndex,
         di: ClauseIndex,
-        deads: &mut HashSet<Lit>,
+        #[cfg(feature = "deterministic")] deads: &mut HashSet<Lit, RandomState>,
+        #[cfg(not(feature = "deterministic"))] deads: &mut HashSet<Lit>,
     ) -> MaybeInconsistent {
         match have_subsuming_lit(cdb, ci, di) {
             Subsumable::Success => {
@@ -101,7 +105,8 @@ fn strengthen_clause(
     elim: &mut Eliminator,
     ci: ClauseIndex,
     l: Lit,
-    deads: &mut HashSet<Lit>,
+    #[cfg(feature = "deterministic")] deads: &mut HashSet<Lit, RandomState>,
+    #[cfg(not(feature = "deterministic"))] deads: &mut HashSet<Lit>,
 ) -> MaybeInconsistent {
     debug_assert!(!cdb[ci].is_dead());
     debug_assert!(1 < cdb[ci].len());

--- a/src/solver/mod.rs
+++ b/src/solver/mod.rs
@@ -15,7 +15,7 @@ mod validate;
 pub use self::{
     build::SatSolverIF,
     restart::{RestartIF, RestartManager},
-    search::{SearchContext, SolveIF},
+    search::{SearchState, SolveIF},
     stage::StageManager,
     validate::ValidateIF,
 };

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -489,12 +489,12 @@ impl SolveIF for Solver {
                                     state.sls_index += 1;
                                     state.flush(format!(
                                         "SLS(#{}, core: {}, steps: {})",
-                                        state.sls_index, sls_core, $limit
+                                        state.sls_index, context.sls_core, $limit
                                     ));
                                     let cls =
                                         cdb.stochastic_local_search(asg, &mut $assign, $limit);
                                     asg.override_rephasing_target(&$assign);
-                                    sls_core = sls_core.min(cls.1);
+                                    context.sls_core = context.sls_core.min(cls.1);
                                 };
                                 ($assign: expr, $improved: expr, $limit: expr) => {
                                     state.sls_index += 1;
@@ -508,7 +508,7 @@ impl SolveIF for Solver {
                                     if $improved(cls) {
                                         asg.override_rephasing_target(&$assign);
                                     }
-                                    sls_core = sls_core.min(cls.1);
+                                    context.sls_core = sls_core.min(cls.1);
                                 };
                             }
                             macro_rules! scale {
@@ -521,8 +521,8 @@ impl SolveIF for Solver {
                             }
                             let ent = cdb.refer(cdb::property::TEma::Entanglement).get() as usize;
                             let n = cdb.derefer(cdb::property::Tusize::NumClause);
-                            if let Some(c) = core_was_rebuilt {
-                                core_was_rebuilt = None;
+                            if let Some(c) = context.core_was_rebuilt {
+                                context.core_was_rebuilt = None;
                                 if c < context.current_core {
                                     let steps = scale!(27_u32, c) * scale!(24_u32, n) / ent;
                                     let mut assignment = asg.best_phases_ref(Some(false));

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -16,7 +16,7 @@ use {
 const STAGE_SIZE: usize = 32;
 
 #[derive(Debug, Default, Eq, Ord, PartialEq, PartialOrd)]
-pub struct SearchContext {
+pub struct SearchState {
     num_learnt: usize,
     current_core: usize,
     core_was_rebuilt: Option<usize>,
@@ -25,7 +25,7 @@ pub struct SearchContext {
     sls_core: usize,
 }
 
-impl SearchContext {
+impl SearchState {
     pub fn current_core(&self) -> usize {
         self.current_core
     }
@@ -41,10 +41,10 @@ pub trait SolveIF {
     fn solve(&mut self) -> SolverResult;
     /// 1st part of solve
     /// returns `None' if solver can proceed to `step_search`
-    fn prepare(&mut self) -> Result<SearchContext, Result<Certificate, SolverError>>;
+    fn prepare(&mut self) -> Result<SearchState, Result<Certificate, SolverError>>;
     /// main part of solve
     /// returns `None' if solver can repeat `step_search`
-    fn search_stage(&mut self, context: &mut SearchContext) -> Result<Option<bool>, SolverError>;
+    fn search_stage(&mut self, ss: &mut SearchState) -> Result<Option<bool>, SolverError>;
     /// last part of solve
     fn postprocess(&mut self, result: Result<bool, SolverError>) -> SolverResult;
     /// standard logger
@@ -279,7 +279,7 @@ impl SolveIF for Solver {
             }
         }
     }
-    fn prepare(&mut self) -> Result<SearchContext, Result<Certificate, SolverError>> {
+    fn prepare(&mut self) -> Result<SearchState, Result<Certificate, SolverError>> {
         let Solver {
             ref mut asg,
             ref mut cdb,
@@ -405,7 +405,7 @@ impl SolveIF for Solver {
             state[Stat::SubsumedClause] = elim.num_subsumed;
         }
         state.stm.initialize(STAGE_SIZE);
-        Ok(SearchContext {
+        Ok(SearchState {
             num_learnt: 0,
             current_core: asg.derefer(assign::property::Tusize::NumUnassertedVar),
             core_was_rebuilt: None,
@@ -414,7 +414,7 @@ impl SolveIF for Solver {
             sls_core: cdb.derefer(cdb::property::Tusize::NumClause),
         })
     }
-    fn search_stage(&mut self, context: &mut SearchContext) -> Result<Option<bool>, SolverError> {
+    fn search_stage(&mut self, ss: &mut SearchState) -> Result<Option<bool>, SolverError> {
         // main loop; returns `Ok(true)` for SAT, `Ok(false)` for UNSAT.
         let Solver {
             ref mut asg,
@@ -438,10 +438,10 @@ impl SolveIF for Solver {
             cdb.update_activity_tick();
             match handle_conflict(asg, cdb, state, &cc) {
                 Err(e) => return Err(e),
-                Ok(n) if 1 < n => context.num_learnt += 1,
+                Ok(n) if 1 < n => ss.num_learnt += 1,
                 _ => (),
             }
-            if state.stm.stage_ended(context.num_learnt) {
+            if state.stm.stage_ended(ss.num_learnt) {
                 if let Some(p) = state.elapsed() {
                     if 1.0 <= p {
                         return Err(SolverError::TimeOut);
@@ -457,8 +457,8 @@ impl SolveIF for Solver {
                 #[cfg(feature = "trace_equivalency")]
                 cdb.check_consistency(asg, "before simplify");
 
-                dump_stage(asg, cdb, state, &context.previous_stage);
-                let next_stage: Option<bool> = state.stm.prepare_new_stage(context.num_learnt);
+                dump_stage(asg, cdb, state, &ss.previous_stage);
+                let next_stage: Option<bool> = state.stm.prepare_new_stage(ss.num_learnt);
                 let scale = state.stm.current_scale();
                 let max_scale = state.stm.max_scale();
                 if cfg!(feature = "reward_annealing") {
@@ -489,12 +489,12 @@ impl SolveIF for Solver {
                                     state.sls_index += 1;
                                     state.flush(format!(
                                         "SLS(#{}, core: {}, steps: {})",
-                                        state.sls_index, context.sls_core, $limit
+                                        state.sls_index, ss.sls_core, $limit
                                     ));
                                     let cls =
                                         cdb.stochastic_local_search(asg, &mut $assign, $limit);
                                     asg.override_rephasing_target(&$assign);
-                                    context.sls_core = context.sls_core.min(cls.1);
+                                    ss.sls_core = ss.sls_core.min(cls.1);
                                 };
                                 ($assign: expr, $improved: expr, $limit: expr) => {
                                     state.sls_index += 1;
@@ -508,7 +508,7 @@ impl SolveIF for Solver {
                                     if $improved(cls) {
                                         asg.override_rephasing_target(&$assign);
                                     }
-                                    context.sls_core = sls_core.min(cls.1);
+                                    ss.sls_core = sls_core.min(cls.1);
                                 };
                             }
                             macro_rules! scale {
@@ -521,9 +521,9 @@ impl SolveIF for Solver {
                             }
                             let ent = cdb.refer(cdb::property::TEma::Entanglement).get() as usize;
                             let n = cdb.derefer(cdb::property::Tusize::NumClause);
-                            if let Some(c) = context.core_was_rebuilt {
-                                context.core_was_rebuilt = None;
-                                if c < context.current_core {
+                            if let Some(c) = ss.core_was_rebuilt {
+                                ss.core_was_rebuilt = None;
+                                if c < ss.current_core {
                                     let steps = scale!(27_u32, c) * scale!(24_u32, n) / ent;
                                     let mut assignment = asg.best_phases_ref(Some(false));
                                     sls!(assignment, steps);
@@ -531,7 +531,7 @@ impl SolveIF for Solver {
                             } else if new_segment {
                                 let n = cdb.derefer(cdb::property::Tusize::NumClause);
                                 let steps =
-                                    scale!(27_u32, context.current_core) * scale!(24_u32, n) / ent;
+                                    scale!(27_u32, ss.current_core) * scale!(24_u32, n) / ent;
                                 let mut assignment = asg.best_phases_ref(Some(false));
                                 sls!(assignment, steps);
                             }
@@ -586,7 +586,7 @@ impl SolveIF for Solver {
                 state.progress(asg, cdb);
                 asg.handle(SolverEvent::Stage(scale));
                 state.restart.set_stage_parameters(scale);
-                context.previous_stage = next_stage;
+                ss.previous_stage = next_stage;
                 return Ok(None);
             } else if state.restart.restart(
                 cdb.refer(cdb::property::TEma::LBD),
@@ -595,10 +595,10 @@ impl SolveIF for Solver {
                 RESTART!(asg, cdb, state);
             }
             if let Some(na) = asg.best_assigned() {
-                if context.current_core < na && context.core_was_rebuilt.is_none() {
-                    context.core_was_rebuilt = Some(context.current_core);
+                if ss.current_core < na && ss.core_was_rebuilt.is_none() {
+                    ss.core_was_rebuilt = Some(ss.current_core);
                 }
-                context.current_core = na;
+                ss.current_core = na;
                 state.flush("");
                 state.flush(format!("unreachable core: {na} "));
             }

--- a/src/types.rs
+++ b/src/types.rs
@@ -296,6 +296,7 @@ pub trait WatchLiteralIndexIf {
     fn new(ci: ClauseIndex, wi: usize) -> Self;
     fn set(&mut self, ci: ClauseIndex, wi: usize);
     fn is_none(&self) -> bool;
+    fn is_some(&self) -> bool;
     fn indices(&self) -> (ClauseIndex, usize);
     fn as_ci(&self) -> ClauseIndex;
     fn as_wi(&self) -> usize;
@@ -310,6 +311,9 @@ impl WatchLiteralIndexIf for WatchLiteralIndex {
     }
     fn is_none(&self) -> bool {
         self.0 == 0
+    }
+    fn is_some(&self) -> bool {
+        self.0 != 0
     }
     fn indices(&self) -> (ClauseIndex, usize) {
         (self.0 >> 1, self.0 & 1)


### PR DESCRIPTION
# Closed

Experienced with this branch, the problem is just in 'garbage-collector`.
So let's roll back.

- [ ] make deterministic truly
- [ ] update Changelog.md
- [x] fix a dead error -> caused by a wrong assumption.

```
thread 'main' panicked at src/cdb/mod.rs:682:9:
assertion failed: !self[ci].is_dead()
stack backtrace:
   3: <splr::cdb::db::ClauseDB as splr::cdb::ClauseDBIF>::transform_by_updating_watch
             at ./src/cdb/mod.rs:682:9
   4: <splr::assign::stack::AssignStack as splr::assign::propagate::PropagateIF>::propagate_sandbox
             at ./src/assign/propagate.rs:552:36
   5: splr::processor::simplify::<impl splr::processor::Eliminator>::backward_subsumption_check
             at ./src/processor/simplify.rs:433:13
   6: splr::processor::eliminate::eliminate_var
             at ./src/processor/eliminate.rs:149:5
   7: splr::processor::simplify::<impl splr::processor::Eliminator>::eliminate_main
             at ./src/processor/simplify.rs:498:21
   8: splr::processor::simplify::<impl splr::processor::Eliminator>::eliminate
             at ./src/processor/simplify.rs:453:13
   9: splr::processor::simplify::<impl splr::processor::EliminateIF for splr::processor::Eliminator>::simplify
             at ./src/processor/simplify.rs:222:13
  10: <splr::solver::Solver as splr::solver::search::SolveIF>::prepare
             at ./src/solver/search.rs:373:24
  11: <splr::solver::Solver as splr::solver::search::SolveIF>::solve
             at ./src/solver/search.rs:263:28
```