### PR TITLE
20240922 harmonic reduction

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,4 +1,2 @@
-if ! has nix_direnv_version || ! nix_direnv_version 3.0.5; then
-    source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.0.5/direnvrc" "sha256-RuwIS+QKFj/T9M2TFXScjBsLR6V3A17YVoEW/Q6AZ1w="
-fi
+source $HOME/.config/direnv/envrc
 use flake

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,9 +125,15 @@ checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
 
 [[package]]
 name = "hashbrown"
+<<<<<<< HEAD
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+=======
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
+>>>>>>> 0a8bb833 (Update toolchain)
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -200,9 +206,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
+<<<<<<< HEAD
 version = "0.2.161"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
+=======
+version = "0.2.162"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d287de67fe55fd7e1581fe933d965a5a9477b38e949cfa9f8574ef01506398"
+>>>>>>> 0a8bb833 (Update toolchain)
 
 [[package]]
 name = "linux-raw-sys"
@@ -355,9 +367,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.37"
+version = "0.38.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
+checksum = "375116bee2be9ed569afe2154ea6a99dfdffd257f533f187498c2a8f5feaf4ee"
 dependencies = [
  "bitflags",
  "errno",
@@ -386,18 +398,30 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
+<<<<<<< HEAD
 version = "1.0.213"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ea7893ff5e2466df8d720bb615088341b295f849602c6956047f8f80f0e9bc1"
+=======
+version = "1.0.214"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f55c3193aca71c12ad7890f1785d2b73e1b9f63a0bbc353c08ef26fe03fc56b5"
+>>>>>>> 0a8bb833 (Update toolchain)
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
+<<<<<<< HEAD
 version = "1.0.213"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e85ad2009c50b58e87caa8cd6dac16bdf511bbfb7af6c33df902396aa480fa5"
+=======
+version = "1.0.214"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766"
+>>>>>>> 0a8bb833 (Update toolchain)
 dependencies = [
  "proc-macro2",
  "quote",
@@ -480,9 +504,15 @@ dependencies = [
 
 [[package]]
 name = "syn"
+<<<<<<< HEAD
 version = "2.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5023162dfcd14ef8f32034d8bcd4cc5ddc61ef7a247c024a33e24e1f24d21b56"
+=======
+version = "2.0.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
+>>>>>>> 0a8bb833 (Update toolchain)
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,15 +125,9 @@ checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
 
 [[package]]
 name = "hashbrown"
-<<<<<<< HEAD
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
-=======
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
->>>>>>> 0a8bb833 (Update toolchain)
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -206,15 +200,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-<<<<<<< HEAD
-version = "0.2.161"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
-=======
 version = "0.2.162"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18d287de67fe55fd7e1581fe933d965a5a9477b38e949cfa9f8574ef01506398"
->>>>>>> 0a8bb833 (Update toolchain)
 
 [[package]]
 name = "linux-raw-sys"
@@ -398,30 +386,18 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-<<<<<<< HEAD
-version = "1.0.213"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ea7893ff5e2466df8d720bb615088341b295f849602c6956047f8f80f0e9bc1"
-=======
 version = "1.0.214"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f55c3193aca71c12ad7890f1785d2b73e1b9f63a0bbc353c08ef26fe03fc56b5"
->>>>>>> 0a8bb833 (Update toolchain)
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-<<<<<<< HEAD
-version = "1.0.213"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e85ad2009c50b58e87caa8cd6dac16bdf511bbfb7af6c33df902396aa480fa5"
-=======
 version = "1.0.214"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766"
->>>>>>> 0a8bb833 (Update toolchain)
 dependencies = [
  "proc-macro2",
  "quote",
@@ -504,15 +480,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-<<<<<<< HEAD
-version = "2.0.85"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5023162dfcd14ef8f32034d8bcd4cc5ddc61ef7a247c024a33e24e1f24d21b56"
-=======
 version = "2.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
->>>>>>> 0a8bb833 (Update toolchain)
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.18"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
+checksum = "45862d1c77f2228b9e10bc609d5bc203d86ebc9b87ad8d5d5167a6c9abf739d9"
 
 [[package]]
 name = "autocfg"
@@ -87,6 +87,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -94,6 +129,12 @@ checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
 ]
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "either"
@@ -116,6 +157,12 @@ dependencies = [
  "libc",
  "windows-sys",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -147,6 +194,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "indoc"
 version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -154,10 +207,14 @@ checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
 
 [[package]]
 name = "instability"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b23a0c8dfe501baac4adf6ebbfa6eddf8f0c07f56b058cc1288017e32397846c"
+checksum = "b829f37dead9dc39df40c2d3376c179fdfd2ac771f53f55d3c30dc096a3c0c6e"
 dependencies = [
+ "darling",
+ "indoc",
+ "pretty_assertions",
+ "proc-macro2",
  "quote",
  "syn",
 ]
@@ -305,6 +362,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -355,9 +422,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.39"
+version = "0.38.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375116bee2be9ed569afe2154ea6a99dfdffd257f533f187498c2a8f5feaf4ee"
+checksum = "99e4ea3e1cdc4b559b8e5650f9c8e5998e3e5c1343b4eaf034565f32318d63c0"
 dependencies = [
  "bitflags",
  "errno",
@@ -386,18 +453,18 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.214"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55c3193aca71c12ad7890f1785d2b73e1b9f63a0bbc353c08ef26fe03fc56b5"
+checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.214"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766"
+checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -455,6 +522,12 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
@@ -710,3 +783,9 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,18 +3,6 @@
 version = 3
 
 [[package]]
-name = "ahash"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "allocator-api2"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -22,9 +10,9 @@ checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "bitflags"
@@ -114,6 +102,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
 name = "errno"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -124,13 +118,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.14.5"
+name = "foldhash"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
 dependencies = [
- "ahash",
  "allocator-api2",
+ "equivalent",
+ "foldhash",
 ]
 
 [[package]]
@@ -144,6 +145,12 @@ name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "indoc"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
 
 [[package]]
 name = "instability"
@@ -184,18 +191,18 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "js-sys"
-version = "0.3.70"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
+checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
 dependencies = [
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.158"
+version = "0.2.161"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
 
 [[package]]
 name = "linux-raw-sys"
@@ -221,9 +228,9 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "lru"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ee39891760e7d94734f6f63fedc29a2e4a152f836120753a72503f09fcf904"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
  "hashbrown",
 ]
@@ -258,9 +265,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "parking_lot"
@@ -299,9 +306,9 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
 dependencies = [
  "unicode-ident",
 ]
@@ -317,31 +324,31 @@ dependencies = [
 
 [[package]]
 name = "ratatui"
-version = "0.28.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdef7f9be5c0122f890d58bdf4d964349ba6a6161f705907526d891efabba57d"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
 dependencies = [
  "bitflags",
  "cassowary",
  "compact_str",
  "crossterm",
+ "indoc",
  "instability",
  "itertools",
  "lru",
  "paste",
  "strum",
- "strum_macros",
  "time",
  "unicode-segmentation",
  "unicode-truncate",
- "unicode-width",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.4"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0884ad60e090bf1345b93da0a5de8923c93884cd03f40dfcfddd3b4bee661853"
+checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
 dependencies = [
  "bitflags",
 ]
@@ -361,9 +368,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
+checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
 
 [[package]]
 name = "ryu"
@@ -379,18 +386,18 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.210"
+version = "1.0.213"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
+checksum = "3ea7893ff5e2466df8d720bb615088341b295f849602c6956047f8f80f0e9bc1"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.210"
+version = "1.0.213"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+checksum = "7e85ad2009c50b58e87caa8cd6dac16bdf511bbfb7af6c33df902396aa480fa5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -473,9 +480,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.77"
+version = "2.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
+checksum = "5023162dfcd14ef8f32034d8bcd4cc5ddc61ef7a247c024a33e24e1f24d21b56"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -523,7 +530,7 @@ checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
 dependencies = [
  "itertools",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -533,10 +540,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
-name = "version_check"
-version = "0.9.5"
+name = "unicode-width"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "wasi"
@@ -546,9 +553,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
+checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -557,9 +564,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
+checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
 dependencies = [
  "bumpalo",
  "log",
@@ -572,9 +579,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
+checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -582,9 +589,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
+checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -595,15 +602,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
 
 [[package]]
 name = "web-sys"
-version = "0.3.70"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
+checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -703,23 +710,3 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "zerocopy"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,9 +528,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-width"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ bitflags = "^2.6"
 instant = { version = "0.1", features = ["wasm-bindgen"], optional = true }
 
 crossterm = { version = "^0.28", optional = true }
-ratatui = { version = "^0.28", features = ["all-widgets"], optional = true }
+ratatui = { version = "^0.29", features = ["all-widgets"], optional = true }
 
 [features]
 default = [

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1726227518,
-        "narHash": "sha256-i4b4IcHBiukSgUP875FLe9x/wrWns7AJuj8+8VuqpFU=",
+        "lastModified": 1730989260,
+        "narHash": "sha256-5R9m921OhgOUNHVIxTS8+jZJokkZRsH7UOecxlchqZ8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "da8415506ffd6c72680825595bfee80ebbe06128",
+        "rev": "3aea494127aae5d08c4c501ea4ba27e6c185b822",
         "type": "github"
       },
       "original": {
@@ -17,11 +17,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1724467107,
-        "narHash": "sha256-oZW7ymnqv9yyd6Ey04j/fjp+X7kayKEpBUbnAHlcGU4=",
+        "lastModified": 1730988789,
+        "narHash": "sha256-Yx1f4uPcvel/iv9sbx60lVS8oihlgN+qeUuMZ3T4Vvc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0b6fa5ee40c14df33494d4ed9da1251e872fb0c2",
+        "rev": "c1612975107c932f1e903d8fab1636334402c6d2",
         "type": "github"
       },
       "original": {
@@ -41,11 +41,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1725558991,
-        "narHash": "sha256-4RcUUEq29/t0i+awEuUngPC2f4QuscVgAGeFDD5HM3s=",
+        "lastModified": 1730990089,
+        "narHash": "sha256-9E+GA8WYLSvfRughvLsz35mu1NkNvKD0RGw6X3OTgkw=",
         "owner": "shnarazk",
         "repo": "SAT-bench",
-        "rev": "1923148519d315228021fc015edd4e42394adcf2",
+        "rev": "30cddaa30105081ab0c0fb3713cea04eb82053f2",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -39,7 +39,6 @@
             value = mkShell {
                 packages = [
                   bashInteractive
-                  libiconv
                   samply
                   tokei
                   # cargo-watch

--- a/src/assign/ema.rs
+++ b/src/assign/ema.rs
@@ -1,18 +1,18 @@
 use crate::types::*;
 
-const ASG_EWA_LEN: usize = 16;
-const ASG_EWA_SLOW: usize = 8192;
+const ASG_EMA_LEN: usize = 16;
+const ASG_EMA_SLOW: usize = 8192;
 
 /// An assignment history used for blocking restart.
 #[derive(Clone, Debug)]
 pub struct ProgressASG {
-    ema: Ewa2<ASG_EWA_LEN>,
+    ema: Ema2,
 }
 
 impl Default for ProgressASG {
     fn default() -> ProgressASG {
         ProgressASG {
-            ema: Ewa2::<ASG_EWA_LEN>::new(0.0),
+            ema: Ema2::new(ASG_EMA_LEN).with_slow(ASG_EMA_SLOW),
         }
     }
 }
@@ -20,7 +20,7 @@ impl Default for ProgressASG {
 impl Instantiate for ProgressASG {
     fn instantiate(_config: &Config, _cnf: &CNFDescription) -> Self {
         ProgressASG {
-            ema: Ewa2::new(0.0).with_slow(ASG_EWA_SLOW),
+            ema: Ema2::new(ASG_EMA_LEN).with_slow(ASG_EMA_SLOW),
         }
     }
 }

--- a/src/assign/mod.rs
+++ b/src/assign/mod.rs
@@ -1,5 +1,5 @@
-/// Module `assign` implements Boolean Constraint Propagation and decision var selection.
-/// This version can handle Chronological and Non Chronological Backtrack.
+// Module `assign` implements Boolean Constraint Propagation and decision var selection.
+// This version can handle Chronological and Non Chronological Backtrack.
 
 /// Ema
 mod ema;

--- a/src/assign/propagate.rs
+++ b/src/assign/propagate.rs
@@ -377,7 +377,7 @@ impl PropagateIF for AssignStack {
                             debug_assert_eq!(self.assigned(other), None);
                             #[cfg(feature = "keep_just_used_clauses")]
                             {
-                                if !c.is(FlagClause::FORWD_LINK) {
+                                if 0 < len {
                                     let b = c.is(FlagClause::NEW_CLAUSE);
                                     self.clause_generation_shift.update(b as u8 as f64);
                                 }
@@ -417,6 +417,14 @@ impl PropagateIF for AssignStack {
                                 }
                             );
                             debug_assert_eq!(other, c[1 - false_index]);
+                            #[cfg(feature = "keep_just_used_clauses")]
+                            {
+                                if 0 < len {
+                                    let b = c.is(FlagClause::NEW_CLAUSE);
+                                    self.clause_generation_shift.update(b as u8 as f64);
+                                }
+                                c.turn_on(FlagClause::FORWD_LINK);
+                            }
                             conflict_path!(
                                 other,
                                 if len == 0 {

--- a/src/assign/propagate.rs
+++ b/src/assign/propagate.rs
@@ -376,7 +376,13 @@ impl PropagateIF for AssignStack {
 
                             debug_assert_eq!(self.assigned(other), None);
                             #[cfg(feature = "keep_just_used_clauses")]
-                            c.turn_on(FlagClause::USED);
+                            {
+                                if !c.is(FlagClause::FORWD_LINK) {
+                                    let b = c.is(FlagClause::NEW_CLAUSE);
+                                    self.clause_generation_shift.update(b as u8 as f64);
+                                }
+                                c.turn_on(FlagClause::FORWD_LINK);
+                            }
                             self.assign_by_implication(
                                 other,
                                 if len == 0 {

--- a/src/assign/stack.rs
+++ b/src/assign/stack.rs
@@ -47,6 +47,7 @@ pub struct AssignStack {
     //
     //## Stage
     //
+    pub clause_generation_shift: Ema,
     pub stage_scale: usize,
 
     //## Elimanated vars
@@ -125,6 +126,7 @@ impl Default for AssignStack {
             #[cfg(feature = "rephase")]
             phase_age: 0,
 
+            clause_generation_shift: Ema::new(12000),
             stage_scale: 1,
             eliminated: Vec::new(),
 

--- a/src/assign/stack.rs
+++ b/src/assign/stack.rs
@@ -47,7 +47,7 @@ pub struct AssignStack {
     //
     //## Stage
     //
-    pub clause_generation_shift: Ema,
+    pub clause_generation_shift: Ema2,
     pub stage_scale: usize,
 
     //## Elimanated vars
@@ -126,7 +126,7 @@ impl Default for AssignStack {
             #[cfg(feature = "rephase")]
             phase_age: 0,
 
-            clause_generation_shift: Ema::new(12000),
+            clause_generation_shift: Ema2::new(8 * 8192).with_slow(32 * 8192),
             stage_scale: 1,
             eliminated: Vec::new(),
 

--- a/src/cdb/clause.rs
+++ b/src/cdb/clause.rs
@@ -100,8 +100,8 @@ impl Default for Clause {
             ],
             lits: vec![Lit::default(), Lit::default()],
             flags: FlagClause::empty(),
-            rank: 0,
-            rank_old: 0,
+            rank: u32::MAX,
+            rank_old: u32::MAX,
             search_from: 2,
 
             #[cfg(any(feature = "boundary_check", feature = "clause_rewarding"))]
@@ -327,7 +327,10 @@ impl Clause {
                 cnt += 1;
             }
         }
-        self.rank = cnt;
-        cnt
+        if cnt < self.rank {
+            self.rank_old = self.rank;
+            self.rank = cnt;
+        }
+        self.rank
     }
 }

--- a/src/cdb/clause.rs
+++ b/src/cdb/clause.rs
@@ -333,4 +333,9 @@ impl Clause {
         }
         self.rank
     }
+    pub fn extended_lbd(&self) -> f64 {
+        let l: f64 = self.len() as f64;
+        let r: f64 = self.rank as f64;
+        r + (l - r) / (l - r + 1.0)
+    }
 }

--- a/src/cdb/db.rs
+++ b/src/cdb/db.rs
@@ -164,10 +164,7 @@ impl Instantiate for ClauseDB {
                 self.watch.push(WatchLiteralIndexRef::default());
                 self.lbd_temp.push(0);
             }
-            SolverEvent::Restart => {
-                // self.lbd.reset_to(self.lb_entanglement.get());
-                // self.lbd.reset_to(0.0);
-            }
+            SolverEvent::Restart => (),
             _ => (),
         }
     }

--- a/src/cdb/ema.rs
+++ b/src/cdb/ema.rs
@@ -1,12 +1,12 @@
 use crate::types::*;
 
-const LBD_EWA_LEN: usize = 16;
-const LBD_EWA_SLOW: usize = 8192;
+const LBD_EMA_LEN: usize = 16;
+const LBD_EMA_SLOW: usize = 8192;
 
 /// An EMA of learnt clauses' LBD, used for forcing restart.
 #[derive(Clone, Debug)]
 pub struct ProgressLBD {
-    ema: Ewa2<LBD_EWA_LEN>,
+    ema: Ema2,
     num: usize,
     sum: usize,
 }
@@ -14,7 +14,7 @@ pub struct ProgressLBD {
 impl Default for ProgressLBD {
     fn default() -> ProgressLBD {
         ProgressLBD {
-            ema: Ewa2::new(0.0),
+            ema: Ema2::new(LBD_EMA_LEN).with_slow(LBD_EMA_SLOW),
             num: 0,
             sum: 0,
         }
@@ -24,7 +24,7 @@ impl Default for ProgressLBD {
 impl Instantiate for ProgressLBD {
     fn instantiate(_config: &Config, _: &CNFDescription) -> Self {
         ProgressLBD {
-            ema: Ewa2::new(0.0).with_slow(LBD_EWA_SLOW),
+            ema: Ema2::new(LBD_EMA_LEN).with_slow(LBD_EMA_SLOW),
             ..ProgressLBD::default()
         }
     }

--- a/src/cdb/ema.rs
+++ b/src/cdb/ema.rs
@@ -14,7 +14,7 @@ pub struct ProgressLBD {
 impl Default for ProgressLBD {
     fn default() -> ProgressLBD {
         ProgressLBD {
-            ema: Ewa2::new(0.0).with_value(16.0),
+            ema: Ewa2::new(0.0),
             num: 0,
             sum: 0,
         }
@@ -24,7 +24,7 @@ impl Default for ProgressLBD {
 impl Instantiate for ProgressLBD {
     fn instantiate(_config: &Config, _: &CNFDescription) -> Self {
         ProgressLBD {
-            ema: Ewa2::new(0.0).with_slow(LBD_EWA_SLOW).with_value(16.0),
+            ema: Ewa2::new(0.0).with_slow(LBD_EWA_SLOW),
             ..ProgressLBD::default()
         }
     }

--- a/src/cdb/mod.rs
+++ b/src/cdb/mod.rs
@@ -543,7 +543,10 @@ impl ClauseDBIF for ClauseDB {
             }
             // alives += 1;
             // keep += 1;
-            self.clause[ci].turn_off(FlagClause::NEW_CLAUSE);
+            if self.clause[ci].is(FlagClause::NEW_CLAUSE) {
+                self.clause[ci].turn_off(FlagClause::NEW_CLAUSE);
+                // continue;
+            }
             // if self.clause[ci].is(FlagClause::FORWD_LINK)
             //     || self.clause[ci].is(FlagClause::BCKWD_LINK)
             // {

--- a/src/cdb/mod.rs
+++ b/src/cdb/mod.rs
@@ -521,13 +521,6 @@ impl ClauseDBIF for ClauseDB {
     /// reduce the number of 'learnt' or *removable* clauses.
     #[cfg(feature = "keep_just_used_clauses")]
     fn reduce(&mut self, asg: &mut impl AssignIF, threshold: f64) {
-        impl Clause {
-            fn extended_lbd(&self) -> f64 {
-                let l: f64 = self.len() as f64;
-                let r: f64 = self.rank as f64;
-                r + (l - r) / (l - r + 1.0)
-            }
-        }
         // let ClauseDB {
         //     ref mut clause,
         //     ref mut lbd_temp,

--- a/src/cdb/mod.rs
+++ b/src/cdb/mod.rs
@@ -291,7 +291,7 @@ impl ClauseDBIF for ClauseDB {
         }
         #[cfg(feature = "keep_just_used_clauses")]
         {
-            self.clause[ci].turn_on(FlagClause::USED);
+            self.clause[ci].turn_on(FlagClause::NEW_CLAUSE);
         }
         // assert_ne!(self.clause[ci].lit0(), self.clause[ci].lit1());
         RefClause::Clause(ci)
@@ -518,7 +518,7 @@ impl ClauseDBIF for ClauseDB {
         let learnt = c.is(FlagClause::LEARNT);
         if learnt {
             #[cfg(feature = "keep_just_used_clauses")]
-            c.turn_on(FlagClause::USED);
+            c.turn_on(FlagClause::NEW_CLAUSE);
             #[cfg(feature = "clause_rewarding")]
             self.reward_at_analysis(ci);
         }
@@ -1387,7 +1387,7 @@ mod tests {
         assert!(!c.is_dead());
         assert!(!c.is(FlagClause::LEARNT));
         #[cfg(feature = "keep_just_used_clauses")]
-        assert!(c.is(FlagClause::USED));
+        assert!(c.is(FlagClause::NEW_CLAUSE));
         let c2 = cdb
             .new_clause(&mut asg, &mut vec![lit(-1), lit(2), lit(3)], true)
             .as_ci();
@@ -1395,7 +1395,7 @@ mod tests {
         assert!(!c.is_dead());
         assert!(c.is(FlagClause::LEARNT));
         #[cfg(feature = "keep_just_used_clauses")]
-        assert!(c.is(FlagClause::USED));
+        assert!(c.is(FlagClause::NEW_CLAUSE));
     }
     #[test]
     fn test_clause_equality() {

--- a/src/cdb/mod.rs
+++ b/src/cdb/mod.rs
@@ -565,10 +565,31 @@ impl ClauseDBIF for ClauseDB {
             }
             // alives += 1;
             // keep += 1;
-            if self.clause[ci].is(FlagClause::USED) {
-                self.clause[ci].turn_off(FlagClause::USED);
+            self.clause[ci].turn_off(FlagClause::NEW_CLAUSE);
+            // if self.clause[ci].is(FlagClause::FORWD_LINK)
+            //     || self.clause[ci].is(FlagClause::BCKWD_LINK)
+            // {
+            //     self.clause[ci].turn_off(FlagClause::FORWD_LINK);
+            //     self.clause[ci].turn_off(FlagClause::BCKWD_LINK);
+            //     continue;
+            // }
+            /* let fwd: bool = self.clause[ci].is(FlagClause::FORWD_LINK);
+            self.clause[ci].turn_off(FlagClause::FORWD_LINK);
+            if self.clause[ci].is(FlagClause::BCKWD_LINK) {
+                self.clause[ci].turn_off(FlagClause::BCKWD_LINK);
+                continue;
+            } */
+            if self.clause[ci].is(FlagClause::FORWD_LINK)
+                || self.clause[ci].is(FlagClause::BCKWD_LINK)
+            {
+                self.clause[ci].turn_off(FlagClause::FORWD_LINK);
+                self.clause[ci].turn_off(FlagClause::BCKWD_LINK);
                 continue;
             }
+            /* let bwd: bool = self.clause[ci].is(FlagClause::BCKWD_LINK);
+            if bwd {
+                self.clause[ci].turn_off(FlagClause::BCKWD_LINK);
+            } */
             if self.clause[ci].is(FlagClause::LEARNT) {
                 let ClauseDB {
                     ref mut clause,

--- a/src/cdb/mod.rs
+++ b/src/cdb/mod.rs
@@ -575,6 +575,9 @@ impl ClauseDBIF for ClauseDB {
                     ref mut lbd_temp,
                     ..
                 } = self;
+                if clause[ci].rank < threshold as DecisionLevel {
+                    continue;
+                }
                 clause[ci].update_lbd(asg, lbd_temp);
                 if threshold < clause[ci].extended_lbd() {
                     // keep -= 1;

--- a/src/cdb/mod.rs
+++ b/src/cdb/mod.rs
@@ -527,7 +527,6 @@ impl ClauseDBIF for ClauseDB {
         if 1 < rank {
             self.lb_entanglement.update(rank as f64);
         }
-        learnt
     }
     /// reduce the number of 'learnt' or *removable* clauses.
     #[cfg(feature = "keep_just_used_clauses")]

--- a/src/cdb/mod.rs
+++ b/src/cdb/mod.rs
@@ -92,7 +92,7 @@ pub trait ClauseDBIF:
     fn reset(&mut self);
     /// update flags.
     /// return `true` if it's learnt.
-    fn update_at_analysis(&mut self, asg: &impl AssignIF, ci: ClauseIndex) -> bool;
+    fn update_entanglement(&mut self, asg: &impl AssignIF, ci: ClauseIndex);
     /// record an asserted literal to unsat certification.
     fn certificate_add_assertion(&mut self, lit: Lit);
     /// save the certification record to a file.
@@ -507,7 +507,9 @@ impl ClauseDBIF for ClauseDB {
         // self.check_weave(wli.as_ci(), &[0, 1]);
         ret
     }
-    fn update_at_analysis(&mut self, asg: &impl AssignIF, ci: ClauseIndex) -> bool {
+    /// This function is called only on the learnt clause which has the highest LBD in
+    /// an analysis.
+    fn update_entanglement(&mut self, asg: &impl AssignIF, ci: ClauseIndex) {
         let ClauseDB {
             ref mut clause,
             ref mut lbd_temp,

--- a/src/cdb/mod.rs
+++ b/src/cdb/mod.rs
@@ -270,7 +270,6 @@ impl ClauseDBIF for ClauseDB {
             debug_assert_eq!(l1, self[ci].lits[1]);
         }
         self.clause[ci].search_from = 0;
-        self.clause[ci].rank_old = self[ci].rank;
         self.lbd.update(self[ci].rank);
         self.num_clause += 1;
         if learnt {
@@ -1157,7 +1156,10 @@ impl ClauseWeaverIF for ClauseDB {
             );
             debug_assert_ne!(next, self.watch[FREE_LIT].next);
             debug_assert_ne!(0, next.as_ci());
-            next.as_ci()
+            let ci = next.as_ci();
+            self.clause[ci].rank = u32::MAX;
+            self.clause[ci].rank_old = u32::MAX;
+            ci
         }
     }
     // Check whether a zombi exists

--- a/src/cdb/vivify.rs
+++ b/src/cdb/vivify.rs
@@ -36,6 +36,7 @@ impl VivifyIF for ClauseDB {
         let display_step: usize = 1000;
         let mut num_checked: usize = 0;
         let mut num_shrink: usize = 0;
+        let mut num_subsumed: usize = 0;
         let mut num_assert: usize = 0;
         let mut to_display: usize = 0;
         'next_clause: while let Some(cp) = clauses.pop() {
@@ -59,7 +60,7 @@ impl VivifyIF for ClauseDB {
             if to_display <= num_checked {
                 state.flush("");
                 state.flush(format!(
-                    "clause vivifying(assert:{num_assert} shorten:{num_shrink}, check:{num_checked}/{num_target})..."
+                    "vivifying(assert:{num_assert} subsume:{num_subsumed}, shorten:{num_shrink}, check:{num_checked}/{num_target})..."
                 ));
                 to_display = num_checked + display_step;
             }
@@ -101,6 +102,18 @@ impl VivifyIF for ClauseDB {
                                 }
                             }
                             AssignReason::Implication(wli) => {
+                                if wli.as_ci() != ci
+                                    && is_learnt
+                                    && decisions.len() <= clits.len()
+                                    && self.clause[wli.as_ci()].len() <= clits.len()
+                                {
+                                    assert!(!self.clause[wli.as_ci()].is_dead());
+                                    assert!(!self.clause[ci].is_dead());
+                                    asg.backtrack_sandbox();
+                                    self.delete_clause(ci);
+                                    num_subsumed += 1;
+                                    continue 'next_clause;
+                                }
                                 if wli.as_ci() == ci && clits.len() == decisions.len() {
                                     // #[cfg(feature = "keep_just_used_clauses")]
                                     // self.clause[ci].turn_on(FlagClause::??);
@@ -163,7 +176,7 @@ impl VivifyIF for ClauseDB {
         debug_assert!(asg.stack_is_empty() || !asg.remains());
         state.flush("");
         state.flush(format!(
-            "vivification(assert:{num_assert} shorten:{num_shrink}), "
+            "vivified(assert:{num_assert}, subsume:{num_subsumed}, shorten:{num_shrink}), "
         ));
         // state.log(
         //     asg.num_conflict,
@@ -355,7 +368,7 @@ impl Clause {
             (!self.is_dead()
                 && self.rank * 2 <= self.rank_old
                 && (self.is(FlagClause::LEARNT) || self.is(FlagClause::DERIVE20)))
-            .then(|| -((self.rank_old - self.rank) as f64 / self.rank as f64))
+            .then(|| (self.rank_old - self.rank) as f64 / self.rank as f64)
         }
     }
     /// clear flags about vivification

--- a/src/cdb/vivify.rs
+++ b/src/cdb/vivify.rs
@@ -102,8 +102,8 @@ impl VivifyIF for ClauseDB {
                             }
                             AssignReason::Implication(wli) => {
                                 if wli.as_ci() == ci && clits.len() == decisions.len() {
-                                    #[cfg(feature = "keep_just_used_clauses")]
-                                    self.clause[wli.as_ci()].turn_on(FlagClause::USED);
+                                    // #[cfg(feature = "keep_just_used_clauses")]
+                                    // self.clause[ci].turn_on(FlagClause::??);
                                     asg.backtrack_sandbox();
                                     continue 'next_clause;
                                 } else {
@@ -280,8 +280,8 @@ impl AssignStack {
                     seen[bil.vi()] = key;
                 }
                 AssignReason::Implication(wli) => {
-                    #[cfg(feature = "keep_just_used_clauses")]
-                    cdb.clause[wli.as_ci()].turn_on(FlagClause::USED);
+                    // #[cfg(feature = "keep_just_used_clauses")]
+                    // cdb.clause[wli.as_ci()].turn_on(FlagClause::USED);
                     for (i, r) in cdb[wli.as_ci()].iter().enumerate() {
                         if i == wli.as_wi() {
                             continue;

--- a/src/cdb/vivify.rs
+++ b/src/cdb/vivify.rs
@@ -102,15 +102,17 @@ impl VivifyIF for ClauseDB {
                                 }
                             }
                             AssignReason::Implication(wli) => {
-                                if wli.as_ci() != ci
-                                    && is_learnt
-                                    && decisions.len() <= clits.len()
-                                    && self.clause[wli.as_ci()].len() <= clits.len()
+                                if wli.as_ci() != ci && decisions.len() <= clits.len()
+                                // && self.clause[wli.as_ci()].len() <= clits.len()
                                 {
-                                    assert!(!self.clause[wli.as_ci()].is_dead());
-                                    assert!(!self.clause[ci].is_dead());
+                                    debug_assert!(!self.clause[wli.as_ci()].is_dead());
+                                    debug_assert!(!self.clause[ci].is_dead());
                                     asg.backtrack_sandbox();
                                     self.delete_clause(ci);
+                                    if !is_learnt && self.clause[wli.as_ci()].is(FlagClause::LEARNT)
+                                    {
+                                        self.clause[wli.as_ci()].turn_off(FlagClause::LEARNT);
+                                    }
                                     num_subsumed += 1;
                                     continue 'next_clause;
                                 }

--- a/src/primitive/ema.rs
+++ b/src/primitive/ema.rs
@@ -17,13 +17,6 @@ pub trait EmaIF {
     }
 }
 
-pub trait EmaSingleIF: EmaIF {
-    /// return the current value.
-    fn get(&self) -> f64 {
-        self.get_fast()
-    }
-}
-
 /// API for Exponential Moving Average, EMA, like `get`, `reset`, `update` and so on.
 pub trait EmaMutIF: EmaIF {
     /// the type of the argument of `update`.
@@ -435,11 +428,6 @@ impl<const N: usize> Ewa2<N> {
     pub fn with_slow(mut self, s: usize) -> Self {
         self.se = 1.0 / (s as f64);
         self.sx = 1.0 - self.se;
-        self
-    }
-    pub fn with_value(mut self, val: f64) -> Self {
-        self.ema.fast = val;
-        self.ema.slow = val;
         self
     }
 }

--- a/src/primitive/ema.rs
+++ b/src/primitive/ema.rs
@@ -89,6 +89,12 @@ impl EmaIF for Ema {
 }
 
 impl EmaMutIF for Ema {
+    fn reset_to(&mut self, val: f64) {
+        self.val.fast = val;
+    }
+    fn reset_fast(&mut self) {
+        self.val.fast = 0.0;
+    }
     type Input = f64;
     #[cfg(not(feature = "EMA_calibration"))]
     fn update(&mut self, x: Self::Input) {
@@ -197,6 +203,7 @@ impl EmaMutIF for Ema2 {
     }
     fn reset_to(&mut self, val: f64) {
         self.ema.fast = val;
+        self.ema.slow = val;
     }
     #[cfg(not(feature = "EMA_calibration"))]
     fn reset_fast(&mut self) {
@@ -303,6 +310,7 @@ impl EmaSU {
     }
 }
 
+/*
 /// Equally-Weighted-Average, namely, Average
 #[derive(Clone, Debug)]
 pub struct Ewa<const N: usize = 32> {
@@ -386,6 +394,7 @@ impl<const N: usize> EmaMutIF for Ewa2<N> {
     }
     fn reset_to(&mut self, val: f64) {
         self.ema.fast = val;
+        self.ema.slow = val;
     }
     #[cfg(not(feature = "EMA_calibration"))]
     fn reset_fast(&mut self) {
@@ -431,3 +440,4 @@ impl<const N: usize> Ewa2<N> {
         self
     }
 }
+*/

--- a/src/processor/eliminate.rs
+++ b/src/processor/eliminate.rs
@@ -94,6 +94,15 @@ pub fn eliminate_var(
                             // the merged clause might be a duplicated clause.
                             elim.add_cid_occur(asg, ci, &mut cdb[ci], true);
 
+                            for flg in [
+                                FlagClause::NEW_CLAUSE,
+                                FlagClause::FORWD_LINK,
+                                FlagClause::BCKWD_LINK,
+                            ] {
+                                let val: bool = cdb[*p].is(flg) || cdb[*n].is(flg);
+                                cdb[ci].set(flg, val);
+                            }
+
                             #[cfg(feature = "trace_elimination")]
                             println!(
                                 " - eliminate_var {}: X {} from {} and {}",

--- a/src/processor/mod.rs
+++ b/src/processor/mod.rs
@@ -41,7 +41,7 @@ use {
 /// use crate::{splr::config::Config, splr::types::*};
 /// use crate::splr::processor::{Eliminator, EliminateIF};
 /// use crate::splr::solver::Solver;
-
+///
 /// let mut s = Solver::instantiate(&Config::default(), &CNFDescription::default());
 /// let mut elim = Eliminator::instantiate(&s.state.config, &s.state.cnf);
 /// assert_eq!(elim.is_running(), false);

--- a/src/processor/simplify.rs
+++ b/src/processor/simplify.rs
@@ -510,9 +510,9 @@ impl Eliminator {
         self.enqueue_var(asg, l.vi(), true);
     }
 
-    ///
-    /// clause queue operations
-    ///
+    //
+    // clause queue operations
+    //
 
     /// enqueue a clause into eliminator's clause queue.
     pub fn enqueue_clause(&mut self, ci: ClauseIndex, c: &mut Clause) {
@@ -537,9 +537,9 @@ impl Eliminator {
         self.clause_queue.len()
     }
 
-    ///
-    /// var queue operations
-    ///
+    //
+    // var queue operations
+    //
 
     /// clear eliminator's var queue
     fn clear_var_queue(&mut self, asg: &mut impl AssignIF) {

--- a/src/solver/conflict.rs
+++ b/src/solver/conflict.rs
@@ -114,7 +114,6 @@ pub fn handle_conflict(
                     unreachable!("handle_conflict::root_level_conflict_by_assertion");
                 }
                 let vi = l0.vi();
-                state.stm.handle(SolverEvent::Assert(vi));
                 cdb.handle(SolverEvent::Assert(vi));
                 return Ok(asg.root_level());
             }

--- a/src/solver/conflict.rs
+++ b/src/solver/conflict.rs
@@ -359,7 +359,6 @@ fn conflict_analyze(
                     p
                 );
                 debug_assert!(2 < cdb[wli.as_ci()].len());
-                // if !cdb.update_at_analysis(asg, cid) {
                 let (ci, skip) = wli.indices();
                 if !cdb[ci].is(FlagClause::LEARNT) {
                     state.derive20.push(ci);
@@ -375,7 +374,8 @@ fn conflict_analyze(
                         .update(cdb[ci].is(FlagClause::NEW_CLAUSE) as u8 as f64);
                     cdb[ci].turn_on(FlagClause::BCKWD_LINK);
                 }
-                if cdb[ci].is(FlagClause::LEARNT) && max_lbd < cdb[ci].rank {
+
+                if max_lbd < cdb[ci].rank {
                     max_lbd = cdb[ci].rank;
                     ci_with_max_lbd = Some(ci);
                 }

--- a/src/solver/conflict.rs
+++ b/src/solver/conflict.rs
@@ -153,11 +153,9 @@ pub fn handle_conflict(
                 let ci = wli.as_ci();
                 #[cfg(feature = "keep_just_used_clauses")]
                 {
-                    if !cdb[ci].is(FlagClause::BCKWD_LINK) {
-                        state
-                            .clause_generation_shift
-                            .update(cdb[ci].is(FlagClause::NEW_CLAUSE) as u8 as f64);
-                    }
+                    state
+                        .clause_generation_shift
+                        .update(cdb[ci].is(FlagClause::NEW_CLAUSE) as u8 as f64);
                     cdb[ci].turn_on(FlagClause::BCKWD_LINK);
                 }
                 for l in cdb[ci].iter() {
@@ -361,13 +359,14 @@ fn conflict_analyze(
                 let (ci, skip) = wli.indices();
                 if !cdb[ci].is(FlagClause::LEARNT) {
                     state.derive20.push(ci);
-                } else {
-                    #[cfg(feature = "keep_just_used_clauses")]
-                    cdb[ci].turn_on(FlagClause::FORWD_LINK);
                 }
-                state
-                    .clause_generation_shift
-                    .update(cdb[ci].is(FlagClause::FORWD_LINK) as u8 as f64);
+                #[cfg(feature = "keep_just_used_clauses")]
+                {
+                    state
+                        .clause_generation_shift
+                        .update(cdb[ci].is(FlagClause::NEW_CLAUSE) as u8 as f64);
+                    cdb[ci].turn_on(FlagClause::BCKWD_LINK);
+                }
                 if max_lbd < cdb[ci].rank {
                     max_lbd = cdb[ci].rank;
                     ci_with_max_lbd = Some(ci);

--- a/src/solver/conflict.rs
+++ b/src/solver/conflict.rs
@@ -353,8 +353,11 @@ fn conflict_analyze(
                     state.derive20.push(ci);
                 } else {
                     #[cfg(feature = "keep_just_used_clauses")]
-                    cdb[ci].turn_on(FlagClause::USED);
+                    cdb[ci].turn_on(FlagClause::FORWD_LINK);
                 }
+                state
+                    .clause_generation_shift
+                    .update(cdb[ci].is(FlagClause::FORWD_LINK) as u8 as f64);
                 if max_lbd < cdb[ci].rank {
                     max_lbd = cdb[ci].rank;
                     ci_with_max_lbd = Some(ci);

--- a/src/solver/conflict.rs
+++ b/src/solver/conflict.rs
@@ -98,12 +98,13 @@ pub fn handle_conflict(
         //
         //## A NEW ASSERTION by UNIT LEARNT CLAUSE GENERATION
         //
+        let root_level = asg.root_level();
         match asg.assigned(l0) {
-            Some(true) if asg.root_level() < asg.level(l0.vi()) => {
-                panic!("double assignment occured");
-                // asg.lift_to_asserted(l0.vi());
+            Some(true) if asg.level(l0.vi()) == root_level => {
+                // dbg!("double assignment occured");
+                return Ok(root_level);
             }
-            Some(false) if asg.level(l0.vi()) == asg.root_level() => {
+            Some(false) if asg.level(l0.vi()) == root_level => {
                 return Err(SolverError::RootLevelConflict((l0, asg.reason(l0.vi()))));
             }
             _ => {
@@ -115,7 +116,7 @@ pub fn handle_conflict(
                 let vi = l0.vi();
                 state.stm.handle(SolverEvent::Assert(vi));
                 cdb.handle(SolverEvent::Assert(vi));
-                return Ok(0);
+                return Ok(asg.root_level());
             }
         }
     }

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -552,6 +552,8 @@ impl SolveIF for Solver {
                     state
                         .stm
                         .set_span_base(state.c_lvl.get_slow() - state.b_lvl.get_slow());
+
+                    asg.clear_asserted_literals(cdb)?;
                     dump_stage(asg, cdb, state, &ss.previous_stage);
 
                     #[cfg(feature = "rephase")]

--- a/src/solver/stage.rs
+++ b/src/solver/stage.rs
@@ -49,10 +49,8 @@ impl Instantiate for StageManager {
             ..StageManager::default()
         }
     }
-    fn handle(&mut self, e: SolverEvent) {
-        if let SolverEvent::Assert(_) = e {
-            self.reset();
-        }
+    fn handle(&mut self, _: SolverEvent) {
+        unimplemented!();
     }
 }
 

--- a/src/solver/stage.rs
+++ b/src/solver/stage.rs
@@ -45,7 +45,7 @@ impl Instantiate for StageManager {
             scale: 1,
             end_of_stage: unit_size,
             next_is_new_segment: false,
-            span_ema: Ema::new(4).with_value(1.0),
+            span_ema: Ema::new(64).with_value(1.0),
             ..StageManager::default()
         }
     }
@@ -71,7 +71,7 @@ impl StageManager {
             segment_starting_stage: 0,
             segment_starting_cycle: 0,
             span_base: 0.0,
-            span_ema: Ema::new(4).with_value(1.0),
+            span_ema: Ema::new(64).with_value(1.0),
         }
     }
     pub fn initialize(&mut self, _unit_size: usize) {
@@ -103,7 +103,8 @@ impl StageManager {
         let mut new_cycle = false;
         let mut new_segment = false;
         self.scale = self.generator.next_number();
-        self.span_ema.update(4.0 + (self.scale as f64).powf(0.4));
+        // self.span_ema.update(4.0 + (self.scale as f64).powf(0.4));
+        self.span_ema.update(self.scale as f64);
         self.stage += 1;
         if self.scale == 1 {
             self.cycle += 1;
@@ -131,22 +132,29 @@ impl StageManager {
         self.end_of_stage as i32 - now as i32
     }
     /// returns the number of conflicts in the current stage
+    /// that was used as the number of conflicts that corresponds to the current stage
     /// Note: we need not to make a strong correlation between this value and
     /// scale defined by Luby series. So this is fine.
+    /// stage -> cycle -> segment
     pub fn current_span(&self) -> f64 {
         self.span_ema.get()
     }
-    pub fn current_stage(&self) -> usize {
-        self.stage
-    }
-    pub fn current_cycle(&self) -> usize {
-        self.cycle
-    }
-    /// returns the scaling factor used in the current span
+    /// returns the scaling factor, or length corresponding to the current stage
+    /// stage -> cycle -> segment
     pub fn current_scale(&self) -> usize {
         self.scale
     }
+    /// return the index of the current stage    /// stage -> cycle -> segment
+    pub fn current_stage(&self) -> usize {
+        self.stage
+    }
+    /// return the index of the current cycle
+    /// stage -> cycle -> segment
+    pub fn current_cycle(&self) -> usize {
+        self.cycle
+    }
     /// returns the current index for the level 2 segments
+    /// stage -> cycle -> segment
     pub fn current_segment(&self) -> usize {
         self.segment
     }

--- a/src/solver/stage.rs
+++ b/src/solver/stage.rs
@@ -152,19 +152,17 @@ impl StageManager {
     pub fn current_segment(&self) -> usize {
         self.segment
     }
-    /// returns a recommending number of redicible learnt clauses, based on
-    /// the length of span.
-    pub fn num_reducible(&self, reducing_factor: f64) -> usize {
-        let span: f64 = self.span_ema.get();
-        let keep = span.powf(1.0 - reducing_factor) as usize;
-        (span as usize).saturating_sub(keep)
-    }
     /// returns the maximum factor so far.
     /// None: `luby_iter.max_value` holds the maximum value so far.
     /// This means it is the value found at the last segment.
     /// So the current value should be the next value, which is the double.
     pub fn max_scale(&self) -> usize {
         self.max_scale_of_segment
+    }
+    /// returns (0, 1]
+    pub fn segment_progress_ratio(&self) -> f64 {
+        (2 * (self.cycle - self.segment_starting_cycle + 1)) as f64
+            / self.max_scale_of_segment as f64
     }
     pub fn cycle_starting_stage(&self) -> usize {
         self.cycle_starting_stage
@@ -180,5 +178,12 @@ impl StageManager {
     }
     pub fn set_span_base(&mut self, span_base: f64) {
         self.span_base = span_base;
+    }
+    /// returns a recommending number of redicible learnt clauses, based on
+    /// the length of span.
+    pub fn num_reducible(&self, reducing_factor: f64) -> usize {
+        let span: f64 = self.span_ema.get();
+        let keep = span.powf(1.0 - reducing_factor) as usize;
+        (span as usize).saturating_sub(keep)
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -89,8 +89,6 @@ pub struct State {
     pub stm: StageManager,
     /// problem description
     pub target: CNFDescription,
-    /// strategy adjustment interval in conflict
-    pub reflection_interval: usize,
 
     //
     //## MISC
@@ -113,7 +111,7 @@ pub struct State {
     pub chrono_bt_threshold: DecisionLevel,
 
     /// for clause reduction
-    pub clause_generation_shift: Ema,
+    pub clause_generation_shift: Ema2,
     /// hold the previous number of non-conflicting assignment
     pub last_asg: usize,
     /// working place to build learnt clauses
@@ -145,11 +143,10 @@ impl Default for State {
             // restart: RestartManager::default(),
             stm: StageManager::default(),
             target: CNFDescription::default(),
-            reflection_interval: 10_000,
 
-            b_lvl: Ema2::new(16).with_slow(4_000),
-            c_lvl: Ema2::new(16).with_slow(4_000),
-            e_mode: Ema2::new(40).with_slow(4_000).with_value(10.0),
+            b_lvl: Ema2::new(16).with_slow(4096),
+            c_lvl: Ema2::new(16).with_slow(4096),
+            e_mode: Ema2::new(32).with_slow(4096).with_value(10.0),
             e_mode_threshold: 1.20,
             exploration_rate_ema: Ema::new(1000),
 
@@ -159,7 +156,7 @@ impl Default for State {
             #[cfg(feature = "chrono_BT")]
             chrono_bt_threshold: 100,
 
-            clause_generation_shift: Ema::new(12000),
+            clause_generation_shift: Ema2::new(8 * 8192).with_slow(32 * 8129),
             last_asg: 0,
             new_learnt: Vec::new(),
             derive20: Vec::new(),

--- a/src/state.rs
+++ b/src/state.rs
@@ -112,6 +112,8 @@ pub struct State {
     /// chrono_BT threshold
     pub chrono_bt_threshold: DecisionLevel,
 
+    /// for clause reduction
+    pub clause_generation_shift: Ema,
     /// hold the previous number of non-conflicting assignment
     pub last_asg: usize,
     /// working place to build learnt clauses
@@ -157,6 +159,7 @@ impl Default for State {
             #[cfg(feature = "chrono_BT")]
             chrono_bt_threshold: 100,
 
+            clause_generation_shift: Ema::new(12000),
             last_asg: 0,
             new_learnt: Vec::new(),
             derive20: Vec::new(),
@@ -560,9 +563,9 @@ impl StateIF for State {
             // "\x1B[2K        misc|ccut:{}, vdcy:{}, core:{}, /ppc:{}",
             "\x1B[2K{:>12}|ccut:{}, vdcy:{}, core:{}, /ppc:{}",
             format!(
-                "Luby{},{:>4.2}",
+                "Luby{}.{:0>2}",
                 self.stm.current_segment(),
-                self.stm.segment_progress_ratio(),
+                ((self.stm.segment_progress_ratio() * 100.0) as usize - 1).clamp(0, 99),
             ),
             fm!(
                 "{:>9.4}",

--- a/src/state.rs
+++ b/src/state.rs
@@ -559,7 +559,11 @@ impl StateIF for State {
         println!(
             // "\x1B[2K        misc|ccut:{}, vdcy:{}, core:{}, /ppc:{}",
             "\x1B[2K{:>12}|ccut:{}, vdcy:{}, core:{}, /ppc:{}",
-            format!("Luby{}", self.stm.current_segment(),),
+            format!(
+                "Luby{},{:>4.2}",
+                self.stm.current_segment(),
+                self.stm.segment_progress_ratio(),
+            ),
             fm!(
                 "{:>9.4}",
                 self,

--- a/src/state.rs
+++ b/src/state.rs
@@ -560,9 +560,9 @@ impl StateIF for State {
             // "\x1B[2K        misc|ccut:{}, vdcy:{}, core:{}, /ppc:{}",
             "\x1B[2K{:>12}|ccut:{}, vdcy:{}, core:{}, /ppc:{}",
             format!(
-                "Luby{}.{:0>2}",
+                "Luby{:>2}.{:0>2}",
                 self.stm.current_segment(),
-                ((self.stm.segment_progress_ratio() * 100.0) as usize - 1).clamp(0, 99),
+                ((self.stm.segment_progress_ratio() * 100.0) as usize).clamp(0, 99),
             ),
             fm!(
                 "{:>9.4}",

--- a/src/types.rs
+++ b/src/types.rs
@@ -558,18 +558,22 @@ pub trait FlagIF {
 
 bitflags! {
     /// Misc flags used by [`Clause`](`crate::cdb::Clause`).
-    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
     pub struct FlagClause: u8 {
         /// a clause is a generated clause by conflict analysis and is removable.
         const LEARNT       = 0b0000_0001;
-        /// used in conflict analyze
-        const USED         = 0b0000_0010;
+        /// used as unit propagation
+        const NEW_CLAUSE   = 0b0000_0010;
+        /// used as unit propagation
+        const FORWD_LINK   = 0b0000_0100;
+        /// used in conflict analysis
+        const BCKWD_LINK   = 0b0000_1000;
         /// a clause or var is enqueued for eliminator.
-        const ENQUEUED     = 0b0000_0100;
+        const ENQUEUED     = 0b0001_0000;
         /// a clause is registered in vars' occurrence list.
-        const OCCUR_LINKED = 0b0000_1000;
+        const OCCUR_LINKED = 0b0010_0000;
         /// a given clause derived a learnt which LBD is smaller than 20.
-        const DERIVE20     = 0b0001_0000;
+        const DERIVE20     = 0b0100_0000;
     }
 }
 


### PR DESCRIPTION
### Salvage good ideas from #273 
- [ ] revise some term definitions

----

- Add/rename `FlagClause::{NEW_CLAUSE|FORWD_LINK|BCKWD_LINK}` in order to categorize clauses more correctly
- call `AssignStack::clear_asserted_literals` before starting the next cycle to show the current status correctly.
- The occurrence rate of newly generated clauses in unit propagation controls`ClauseDB::reduce`, while the Luby sequence controls `vivify` and `simplify` differently.
- Remove `Ewa`s
- Implement `Ema::reset_to`
- **Being struggled so far** 🫨 
- Stop "vibrated reduction" temporarily