### PR TITLE
20241115 orthogonal restart

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,9 +242,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+checksum = "7a73e9fe3c49d7afb2ace819fa181a287ce54a0983eda4e0eb05c22f82ffe534"
 
 [[package]]
 name = "js-sys"
@@ -422,9 +422,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.40"
+version = "0.38.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99e4ea3e1cdc4b559b8e5650f9c8e5998e3e5c1343b4eaf034565f32318d63c0"
+checksum = "d7f649912bc1495e167a6edee79151c84b1bad49748cb4f1f1167f459f6224f6"
 dependencies = [
  "bitflags",
  "errno",
@@ -585,9 +585,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 
 [[package]]
 name = "unicode-segmentation"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,9 +257,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.162"
+version = "0.2.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d287de67fe55fd7e1581fe933d965a5a9477b38e949cfa9f8574ef01506398"
+checksum = "433bfe06b8c75da9b2e3fbea6e5329ff87748f0b144ef75306e674c3f6f7c13f"
 
 [[package]]
 name = "linux-raw-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,12 +150,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -172,9 +172,9 @@ checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -242,9 +242,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.12"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a73e9fe3c49d7afb2ace819fa181a287ce54a0983eda4e0eb05c22f82ffe534"
+checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "js-sys"
@@ -257,9 +257,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.164"
+version = "0.2.166"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "433bfe06b8c75da9b2e3fbea6e5329ff87748f0b144ef75306e674c3f6f7c13f"
+checksum = "c2ccc108bbc0b1331bd061864e7cd823c0cab660bbe6970e66e2c0614decde36"
 
 [[package]]
 name = "linux-raw-sys"
@@ -302,7 +302,7 @@ dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -373,9 +373,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.89"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
+checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
 ]
@@ -430,7 +430,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -553,9 +553,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.87"
+version = "2.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
+checksum = "44d46482f1c1c87acd84dea20c1bf5ebff4c757009ed6bf19cfd36fb10e92c4e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -716,6 +716,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ default = [
         "keep_just_used_clauses",
         "LRB_rewarding",
         "reason_side_rewarding",
-        # "rephase",
+        "rephase",
         "reward_annealing",
         # "stochastic_local_search",
         "trail_saving",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ default = [
         "keep_just_used_clauses",
         "LRB_rewarding",
         "reason_side_rewarding",
-        "rephase",
+        # "rephase",
         "reward_annealing",
         # "stochastic_local_search",
         "trail_saving",

--- a/src/assign/mod.rs
+++ b/src/assign/mod.rs
@@ -1,6 +1,6 @@
 /// Module `assign` implements Boolean Constraint Propagation and decision var selection.
 /// This version can handle Chronological and Non Chronological Backtrack.
-
+///
 /// Ema
 mod ema;
 /// Heap
@@ -54,7 +54,7 @@ pub trait AssignIF:
 {
     /// return root level.
     fn root_level(&self) -> DecisionLevel;
-    /// return a literal in the stack.
+    /// return the `i`-th literal in the stack.
     fn stack(&self, i: usize) -> Lit;
     /// return literals in the range of stack.
     fn stack_range(&self, r: Range<usize>) -> &[Lit];

--- a/src/assign/stack.rs
+++ b/src/assign/stack.rs
@@ -212,6 +212,10 @@ impl Instantiate for AssignStack {
             SolverEvent::Eliminate(vi) => {
                 self.make_var_eliminated(vi);
             }
+            SolverEvent::Restart => {
+                #[cfg(feature = "trail_saving")]
+                self.clear_saved_trail();
+            }
             SolverEvent::Stage(scale) => {
                 self.stage_scale = scale;
                 #[cfg(feature = "trail_saving")]

--- a/src/cdb/db.rs
+++ b/src/cdb/db.rs
@@ -164,7 +164,9 @@ impl Instantiate for ClauseDB {
                 self.watch.push(WatchLiteralIndexRef::default());
                 self.lbd_temp.push(0);
             }
-            SolverEvent::Restart => (),
+            SolverEvent::Restart => {
+                self.lbd.reset_fast();
+            }
             _ => (),
         }
     }

--- a/src/cdb/ema.rs
+++ b/src/cdb/ema.rs
@@ -49,6 +49,9 @@ impl EmaMutIF for ProgressLBD {
         self.sum += d as usize;
         self.ema.update(d as f64);
     }
+    fn reset_fast(&mut self) {
+        self.ema.reset_fast();
+    }
     fn reset_to(&mut self, val: f64) {
         self.ema.reset_to(val);
     }

--- a/src/cdb/mod.rs
+++ b/src/cdb/mod.rs
@@ -569,7 +569,7 @@ impl ClauseDBIF for ClauseDB {
             if new {
                 self.clause[ci].turn_off(FlagClause::NEW_CLAUSE);
             }
-            if bck {
+            if fwd {
                 continue;
             }
             if new_assertion && self.clause[ci].is_satisfied_under(asg) {

--- a/src/cdb/mod.rs
+++ b/src/cdb/mod.rs
@@ -569,7 +569,7 @@ impl ClauseDBIF for ClauseDB {
             if new {
                 self.clause[ci].turn_off(FlagClause::NEW_CLAUSE);
             }
-            if bck {
+            if bck && new && self.clause[ci].rank <= (2 * threshold as DecisionLevel) / 3 {
                 continue;
             }
             if new_assertion && self.clause[ci].is_satisfied_under(asg) {

--- a/src/cdb/mod.rs
+++ b/src/cdb/mod.rs
@@ -569,7 +569,7 @@ impl ClauseDBIF for ClauseDB {
             if new {
                 self.clause[ci].turn_off(FlagClause::NEW_CLAUSE);
             }
-            if fwd {
+            if bck {
                 continue;
             }
             if new_assertion && self.clause[ci].is_satisfied_under(asg) {

--- a/src/cdb/vivify.rs
+++ b/src/cdb/vivify.rs
@@ -145,6 +145,7 @@ impl VivifyIF for ClauseDB {
                             1 => {
                                 self.certificate_add_assertion(vec[0]);
                                 asg.assign_at_root_level(vec[0])?;
+                                state.stm.handle(SolverEvent::Assert(vec[0].vi()));
                                 num_assert += 1;
                             }
                             _ => {

--- a/src/cdb/vivify.rs
+++ b/src/cdb/vivify.rs
@@ -102,18 +102,21 @@ impl VivifyIF for ClauseDB {
                                 }
                             }
                             AssignReason::Implication(wli) => {
-                                if wli.as_ci() != ci && decisions.len() <= clits.len()
-                                // && self.clause[wli.as_ci()].len() <= clits.len()
-                                {
-                                    debug_assert!(!self.clause[wli.as_ci()].is_dead());
-                                    debug_assert!(!self.clause[ci].is_dead());
+                                if wli.as_ci() != ci {
                                     asg.backtrack_sandbox();
-                                    self.delete_clause(ci);
-                                    if !is_learnt && self.clause[wli.as_ci()].is(FlagClause::LEARNT)
+                                    if decisions.len() < clits.len()
+                                        && self.clause[wli.as_ci()]
+                                            .iter()
+                                            .all(|l| decisions.contains(l))
                                     {
-                                        self.clause[wli.as_ci()].turn_off(FlagClause::LEARNT);
+                                        self.delete_clause(ci);
+                                        if !is_learnt
+                                            && self.clause[wli.as_ci()].is(FlagClause::LEARNT)
+                                        {
+                                            self.clause[wli.as_ci()].turn_off(FlagClause::LEARNT);
+                                        }
+                                        num_subsumed += 1;
                                     }
-                                    num_subsumed += 1;
                                     continue 'next_clause;
                                 }
                                 if wli.as_ci() == ci && clits.len() == decisions.len() {
@@ -156,7 +159,7 @@ impl VivifyIF for ClauseDB {
                                 }
                                 #[cfg(not(feature = "clause_rewarding"))]
                                 self.new_clause(asg, &mut vec, is_learnt);
-                                // propage_sandbox can't handle dead watchers correctly
+                                // propagate_sandbox can't handle dead watchers correctly
                                 self.delete_clause(ci);
                                 num_shrink += 1;
                             }

--- a/src/cdb/vivify.rs
+++ b/src/cdb/vivify.rs
@@ -36,7 +36,7 @@ impl VivifyIF for ClauseDB {
         let display_step: usize = 1000;
         let mut num_checked: usize = 0;
         let mut num_shrink: usize = 0;
-        let mut num_subsumed: usize = 0;
+        // let mut num_subsumed: usize = 0;
         let mut num_assert: usize = 0;
         let mut to_display: usize = 0;
         'next_clause: while let Some(cp) = clauses.pop() {
@@ -60,7 +60,7 @@ impl VivifyIF for ClauseDB {
             if to_display <= num_checked {
                 state.flush("");
                 state.flush(format!(
-                    "vivifying(assert:{num_assert} subsume:{num_subsumed}, shorten:{num_shrink}, check:{num_checked}/{num_target})..."
+                    "vivifying(assert:{num_assert}, shorten:{num_shrink}, check:{num_checked}/{num_target})..."
                 ));
                 to_display = num_checked + display_step;
             }
@@ -104,7 +104,7 @@ impl VivifyIF for ClauseDB {
                             AssignReason::Implication(wli) => {
                                 if wli.as_ci() != ci {
                                     asg.backtrack_sandbox();
-                                    if decisions.len() < clits.len()
+                                    /* if decisions.len() < clits.len()
                                         && self.clause[wli.as_ci()]
                                             .iter()
                                             .all(|l| decisions.contains(l))
@@ -116,7 +116,7 @@ impl VivifyIF for ClauseDB {
                                             self.clause[wli.as_ci()].turn_off(FlagClause::LEARNT);
                                         }
                                         num_subsumed += 1;
-                                    }
+                                    } */
                                     continue 'next_clause;
                                 }
                                 if wli.as_ci() == ci && clits.len() == decisions.len() {
@@ -182,7 +182,7 @@ impl VivifyIF for ClauseDB {
         debug_assert!(asg.stack_is_empty() || !asg.remains());
         state.flush("");
         state.flush(format!(
-            "vivified(assert:{num_assert}, subsume:{num_subsumed}, shorten:{num_shrink}), "
+            "vivified(assert:{num_assert}, shorten:{num_shrink}), "
         ));
         // state.log(
         //     asg.num_conflict,

--- a/src/processor/eliminate.rs
+++ b/src/processor/eliminate.rs
@@ -167,6 +167,7 @@ pub fn eliminate_var(
     */
     elim[vi].clear();
     asg.handle(SolverEvent::Eliminate(vi));
+    state.stm.handle(SolverEvent::Eliminate(vi));
     elim.backward_subsumption_check(asg, cdb)
 }
 

--- a/src/processor/mod.rs
+++ b/src/processor/mod.rs
@@ -41,7 +41,7 @@ use {
 /// use crate::{splr::config::Config, splr::types::*};
 /// use crate::splr::processor::{Eliminator, EliminateIF};
 /// use crate::splr::solver::Solver;
-
+///
 /// let mut s = Solver::instantiate(&Config::default(), &CNFDescription::default());
 /// let mut elim = Eliminator::instantiate(&s.state.config, &s.state.cnf);
 /// assert_eq!(elim.is_running(), false);

--- a/src/processor/simplify.rs
+++ b/src/processor/simplify.rs
@@ -513,7 +513,7 @@ impl Eliminator {
     ///
     /// clause queue operations
     ///
-
+    ///
     /// enqueue a clause into eliminator's clause queue.
     pub fn enqueue_clause(&mut self, ci: ClauseIndex, c: &mut Clause) {
         if self.mode != EliminatorMode::Running
@@ -540,7 +540,7 @@ impl Eliminator {
     ///
     /// var queue operations
     ///
-
+    ///
     /// clear eliminator's var queue
     fn clear_var_queue(&mut self, asg: &mut impl AssignIF) {
         self.var_queue.clear(asg);

--- a/src/solver/conflict.rs
+++ b/src/solver/conflict.rs
@@ -376,8 +376,11 @@ fn conflict_analyze(
                 }
 
                 if max_lbd < cdb[ci].rank {
-                    max_lbd = cdb[ci].rank;
-                    ci_with_max_lbd = Some(ci);
+                    let r = cdb.update_lbd(asg, ci);
+                    if max_lbd < r {
+                        max_lbd = r;
+                        ci_with_max_lbd = Some(ci);
+                    }
                 }
                 assert_eq!(
                     p,

--- a/src/solver/conflict.rs
+++ b/src/solver/conflict.rs
@@ -102,7 +102,7 @@ pub fn handle_conflict(
         match asg.assigned(l0) {
             Some(true) if asg.level(l0.vi()) == root_level => {
                 // dbg!("double assignment occured");
-                return Ok(root_level);
+                return Ok(0);
             }
             Some(false) if asg.level(l0.vi()) == root_level => {
                 return Err(SolverError::RootLevelConflict((l0, asg.reason(l0.vi()))));
@@ -115,7 +115,7 @@ pub fn handle_conflict(
                 }
                 let vi = l0.vi();
                 cdb.handle(SolverEvent::Assert(vi));
-                return Ok(asg.root_level());
+                return Ok(0);
             }
         }
     }

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -476,12 +476,12 @@ impl SolveIF for Solver {
                 _ => (),
             }
             let num_conflict = asg.derefer(assign::Tusize::NumConflict);
-            let with_restart = ss.next_restart <= num_conflict
-                && 1.0 <= cdb.refer(cdb::property::TEma::LBD).trend();
+            let with_restart = /* ss.next_restart <= num_conflict
+                && */ 1.2 <= cdb.refer(cdb::property::TEma::LBD).trend();
             if with_restart {
                 RESTART!(asg, cdb, state);
                 asg.clear_asserted_literals(cdb)?;
-                ss.next_restart = num_conflict + 12;
+                // ss.next_restart = num_conflict + 12;
                 #[cfg(feature = "trace_equivalency")]
                 cdb.check_consistency(asg, "before simplify");
             } else if ss.next_restart <= num_conflict
@@ -519,7 +519,7 @@ impl SolveIF for Solver {
                         ss.num_reduction += 1;
                         ss.reduce_step += ss.current_core.ilog2() as usize;
                         ss.next_reduce = ss.reduce_step + num_restart;
-                        if cfg!(feature = "clause_vivification") && ss.num_reduction % 8 == 0 {
+                        if cfg!(feature = "clause_vivification") && ss.num_reduction % 6 == 0 {
                             cdb.vivify(asg, state)?;
                         }
                         if cfg!(feature = "clause_elimination")
@@ -543,7 +543,7 @@ impl SolveIF for Solver {
                         // let k: f64 = (stm.current_segment() as f64).log2();
                         let k: f64 = (stm.current_segment() as f64).sqrt();
                         let ratio: f64 = stm.segment_progress_ratio();
-                        const R: (f64, f64) = (0.94, 0.97);
+                        const R: (f64, f64) = (0.95, 0.99);
                         let x: f64 = k * (2.0 * ratio - 1.0);
                         let r = {
                             let sgm = 1.0 / (1.0 + (-x).exp());

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -17,6 +17,7 @@ pub struct SearchState {
     num_reduction: usize,
     new_assertion: bool,
     reduce_step: usize,
+    restart_span: usize,
     next_restart: usize,
     next_reduce: usize,
     current_core: usize,
@@ -427,6 +428,7 @@ impl SolveIF for Solver {
             num_reduction: 0,
             new_assertion: false,
             reduce_step: (nv + nc) as usize,
+            restart_span: 4,
             next_reduce: 64,
             next_restart: 1024,
             from_segment_beginning: 0,
@@ -477,7 +479,7 @@ impl SolveIF for Solver {
             }
             let num_conflict = asg.derefer(assign::Tusize::NumConflict);
             let with_restart = ss.next_restart <= num_conflict
-                && 1.0 <= cdb.refer(cdb::property::TEma::LBD).trend();
+                && 0.8 <= cdb.refer(cdb::property::TEma::LBD).trend();
             if with_restart {
                 RESTART!(asg, cdb, state);
                 asg.clear_asserted_literals(cdb)?;
@@ -488,9 +490,15 @@ impl SolveIF for Solver {
                 // let x: f64 = k * (2.0 * ratio - 1.0);
                 // let sgm = |x: f64| 1.0 / (1.0 + (-x).exp());
                 // ss.next_restart = num_conflict + (((ent + lbd) * sgm(x)) as usize).max(6);
-                ss.next_restart = num_conflict + 9;
+                ss.restart_span = 8;
+                ss.next_restart = num_conflict + ss.restart_span;
                 #[cfg(feature = "trace_equivalency")]
                 cdb.check_consistency(asg, "before simplify");
+            } else if ss.next_restart <= num_conflict
+                && cdb.refer(cdb::property::TEma::LBD).trend() <= 0.5
+            {
+                ss.restart_span *= 2;
+                ss.next_restart = num_conflict + ss.restart_span;
             }
             ss.from_segment_beginning += 1;
             if ss.current_span <= ss.from_segment_beginning {
@@ -545,13 +553,11 @@ impl SolveIF for Solver {
                     if cfg!(feature = "reward_annealing") {
                         let k: f64 = (stm.current_segment() as f64).log2();
                         let ratio: f64 = stm.segment_progress_ratio();
-                        const SLOP: f64 = 8.0;
-                        const R: (f64, f64) = (0.88, 0.995);
-                        let d: f64 = R.1 - (R.1 - R.0) * SLOP / (k + SLOP);
+                        const R: (f64, f64) = (0.9, 0.98);
                         let x: f64 = k * (2.0 * ratio - 1.0);
                         let r = {
-                            let sgm = |x: f64| 1.0 / (1.0 + (-x).exp());
-                            d + sgm(x) * (1.0 - d)
+                            let sgm = 1.0 / (1.0 + (-x).exp());
+                            (1.0 - sgm) * R.0 + sgm * R.1
                         };
                         asg.update_activity_decay(r);
                     }

--- a/src/solver/stage.rs
+++ b/src/solver/stage.rs
@@ -49,8 +49,11 @@ impl Instantiate for StageManager {
             ..StageManager::default()
         }
     }
-    fn handle(&mut self, _: SolverEvent) {
-        unimplemented!();
+    fn handle(&mut self, e: SolverEvent) {
+        match e {
+            SolverEvent::Assert(_) | SolverEvent::Eliminate(_) => self.reset(),
+            _ => (),
+        }
     }
 }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -97,6 +97,8 @@ pub struct State {
     pub b_lvl: Ema2,
     /// EMA of conflicting levels
     pub c_lvl: Ema2,
+    /// EMA of a sort of refinement
+    pub refinement_ema: Ema2,
     /// EMA of c_lbd - b_lbd, or Exploration vs. Eploitation
     pub e_mode: Ema2,
     pub e_mode_threshold: f64,
@@ -146,6 +148,7 @@ impl Default for State {
 
             b_lvl: Ema2::new(16).with_slow(4096),
             c_lvl: Ema2::new(16).with_slow(4096),
+            refinement_ema: Ema2::new(16).with_slow(4096),
             e_mode: Ema2::new(32).with_slow(4096).with_value(10.0),
             e_mode_threshold: 1.20,
             exploration_rate_ema: Ema::new(1000),


### PR DESCRIPTION
- restart span = 4
```
# ~/.cargo/bin/splr (0.18.0-dev5) @ 2024-11-19T18:37:01
solver,       num,                       target,     time
"splr",         1,                 "UF250(100)",   62.663
"splr",         2,                "UUF250(100)",  186.430
"splr",         3,    "SC21/b04_s_unknown[SAT]",  177.211
"splr",         4,    "SC21/quad_r21_m22 [SAT]",  325.750
"splr",         5,    "SC21/toughsat_895s[SAT]",  TIMEOUT
"splr",         6,    "SC21/assoc_mult_e3[UNS]",  626.029
"splr",         7,    "SC21/dist4.c      [UNS]", 1213.395
"splr",         8,    "SC21/p01_lb_05    [UNS]",  199.022
"splr",         9,    "SC21/shift1add    [UNS]",  343.864
med:   199.022, max:  1213.395,total except 1 timeouts: 3134.364
```

- restart span = 6
```
# ~/.cargo/bin/splr (0.18.0-dev5) @ 2024-11-19T17:23:53
solver,       num,                       target,     time
"splr",         1,                 "UF250(100)",   39.120
"splr",         2,                "UUF250(100)",  186.421
"splr",         3,    "SC21/b04_s_unknown[SAT]",  192.165
"splr",         4,    "SC21/quad_r21_m22 [SAT]",   70.618
"splr",         5,    "SC21/toughsat_895s[SAT]",  TIMEOUT
"splr",         6,    "SC21/assoc_mult_e3[UNS]",  440.966
"splr",         7,    "SC21/dist4.c      [UNS]", 1210.931
"splr",         8,    "SC21/p01_lb_05    [UNS]",  429.104
"splr",         9,    "SC21/shift1add    [UNS]",  202.100
med:   192.165, max:  1210.931,total except 1 timeouts: 2771.425
```

- restart span = 8
```
# 0.16.1, timeout:2000 on iMac @ 2024-11-19T12:35:14
# ~/.cargo/bin/splr (0.18.0-dev5) @ 2024-11-19T12:35:06
solver,       num,                       target,     time
"splr",         1,                 "UF250(100)",   51.614
"splr",         2,                "UUF250(100)",  199.977
"splr",         3,    "SC21/b04_s_unknown[SAT]",  101.009
"splr",         4,    "SC21/quad_r21_m22 [SAT]",  241.493
"splr",         5,    "SC21/toughsat_895s[SAT]", 1217.653
"splr",         6,    "SC21/assoc_mult_e3[UNS]",  737.931
"splr",         7,    "SC21/dist4.c      [UNS]",  651.177
"splr",         8,    "SC21/p01_lb_05    [UNS]",  490.873
"splr",         9,    "SC21/shift1add    [UNS]",  154.313
med:   241.493, max:  1217.653,           total: 3846.040
```

- restart span = 12
```
# 0.16.1, timeout:2000 on iMac @ 2024-11-19T00:59:45
# ~/.cargo/bin/splr (0.18.0-dev5) @ 2024-11-18T20:35:37
solver,       num,                       target,     time
"splr",         1,                 "UF250(100)",   48.261
"splr",         2,                "UUF250(100)",  221.720
"splr",         3,    "SC21/b04_s_unknown[SAT]",   16.388
"splr",         4,    "SC21/quad_r21_m22 [SAT]",   48.049
"splr",         5,    "SC21/toughsat_895s[SAT]", 1270.072
"splr",         6,    "SC21/assoc_mult_e3[UNS]", 1324.138
"splr",         7,    "SC21/dist4.c      [UNS]", 1625.728
"splr",         8,    "SC21/p01_lb_05    [UNS]",  743.436
"splr",         9,    "SC21/shift1add    [UNS]",  144.954
med:   221.720, max:  1625.728,           total: 5442.746
```

- restart span = 16
```
# 0.16.1, timeout:2000 on iMac @ 2024-11-19T07:58:16
# ~/.cargo/bin/splr (0.18.0-dev5) @ 2024-11-19T07:57:56
solver,       num,                       target,     time
"splr",         1,                 "UF250(100)",   65.094
"splr",         2,                "UUF250(100)",  227.752
"splr",         3,    "SC21/b04_s_unknown[SAT]",   28.004
"splr",         4,    "SC21/quad_r21_m22 [SAT]",   88.015
"splr",         5,    "SC21/toughsat_895s[SAT]",    8.210
"splr",         6,    "SC21/assoc_mult_e3[UNS]", 1381.276
"splr",         7,    "SC21/dist4.c      [UNS]",  TIMEOUT
"splr",         8,    "SC21/p01_lb_05    [UNS]",  TIMEOUT
"splr",         9,    "SC21/shift1add    [UNS]",  170.912
med:    65.094, max:  1381.276,total except 2 timeouts: 1969.263
```

- restart span = 6, increment += 1
```
# 0.16.1, timeout:2000 on iMac @ 2024-11-20T07:55:10
# ~/.cargo/bin/splr (0.18.0-dev5) @ 2024-11-20T07:55:03
solver,       num,                       target,     time
"splr",         1,                 "UF250(100)",   45.015
"splr",         2,                "UUF250(100)",  178.295
"splr",         3,    "SC21/b04_s_unknown[SAT]",  259.311
"splr",         4,    "SC21/quad_r21_m22 [SAT]",  256.811
"splr",         5,    "SC21/toughsat_895s[SAT]",  394.653
"splr",         6,    "SC21/assoc_mult_e3[UNS]",  790.618
"splr",         7,    "SC21/dist4.c      [UNS]",  707.592
"splr",         8,    "SC21/p01_lb_05    [UNS]",  329.399
"splr",         9,    "SC21/shift1add    [UNS]",  496.958
med:   329.399, max:   790.618,           total: 3458.652
```

- restart span = 6, increment *= 2
```
# ~/.cargo/bin/splr (0.18.0-dev5) @ 2024-11-20T08:37:24
solver,       num,                       target,     time
"splr",         1,                 "UF250(100)",   47.353
"splr",         2,                "UUF250(100)",  178.425
"splr",         3,    "SC21/b04_s_unknown[SAT]",  164.337
"splr",         4,    "SC21/quad_r21_m22 [SAT]",  207.719
"splr",         5,    "SC21/toughsat_895s[SAT]",  699.033
"splr",         6,    "SC21/assoc_mult_e3[UNS]",  650.637
"splr",         7,    "SC21/dist4.c      [UNS]",  962.207
"splr",         8,    "SC21/p01_lb_05    [UNS]",  271.077
"splr",         9,    "SC21/shift1add    [UNS]",  215.512
med:   215.512, max:   962.207,           total: 3396.300
```

- restart span = 8, increment *= 2
```
# ~/.cargo/bin/splr (0.18.0-dev5) @ 2024-11-20T21:49:15
solver,       num,                       target,     time
"splr",         1,                 "UF250(100)",   50.620
"splr",         2,                "UUF250(100)",  192.404
"splr",         3,    "SC21/b04_s_unknown[SAT]",   95.941
"splr",         4,    "SC21/quad_r21_m22 [SAT]",   12.743
"splr",         5,    "SC21/toughsat_895s[SAT]",   12.234
"splr",         6,    "SC21/assoc_mult_e3[UNS]",  467.166
"splr",         7,    "SC21/dist4.c      [UNS]", 1116.000
"splr",         8,    "SC21/p01_lb_05    [UNS]",  458.875
"splr",         9,    "SC21/shift1add    [UNS]",  207.324
med:   192.404, max:  1116.000,           total: 2613.307
```

- restart span = 8, increment += 2
```
# ~/.cargo/bin/splr (0.18.0-dev5) @ 2024-11-21T00:07:45
solver,       num,                       target,     time
"splr",         1,                 "UF250(100)",   52.730
"splr",         2,                "UUF250(100)",  186.040
"splr",         3,    "SC21/b04_s_unknown[SAT]",  246.389
"splr",         4,    "SC21/quad_r21_m22 [SAT]",   13.443
"splr",         5,    "SC21/toughsat_895s[SAT]",   12.250
"splr",         6,    "SC21/assoc_mult_e3[UNS]",  276.079
"splr",         7,    "SC21/dist4.c      [UNS]",  725.938
"splr",         8,    "SC21/p01_lb_05    [UNS]",  440.490
"splr",         9,    "SC21/shift1add    [UNS]",  347.931
med:   246.389, max:   725.938,           total: 2301.290
```

- restart span = 6, increment += 2

```
t:2000 on iMac @ 2024-11-21T01:59:05
# ~/.cargo/bin/splr (0.18.0-dev5) @ 2024-11-21T01:58:55
solver,       num,                       target,     time
"splr",         1,                 "UF250(100)",   53.199
"splr",         2,                "UUF250(100)",  196.206
"splr",         3,    "SC21/b04_s_unknown[SAT]",  146.486
"splr",         4,    "SC21/quad_r21_m22 [SAT]",  757.678
"splr",         5,    "SC21/toughsat_895s[SAT]",  785.769
"splr",         6,    "SC21/assoc_mult_e3[UNS]", 1756.252
"splr",         7,    "SC21/dist4.c      [UNS]",  TIMEOUT
"splr",         8,    "SC21/p01_lb_05    [UNS]",  991.998
"splr",         9,    "SC21/shift1add    [UNS]",  587.630
med:   587.630, max:  1756.252,total except 1 timeouts: 5275.218
```

- restart span = 8, extend = 4, extend *= 2
```
│# 0.16.1, timeout:2000 on localhost @ 2024-11-21T10:30:06
│# ~/.cargo/bin/splr (0.18.0-dev5) @ 2024-11-21T09:04:28
│solver,       num,                       target,     time
│"splr",         1,                 "UF250(100)",   45.916
│"splr",         2,                "UUF250(100)",  200.608
│"splr",         3,    "SC21/b04_s_unknown[SAT]",   43.699
│"splr",         4,    "SC21/quad_r21_m22 [SAT]",   87.292
│"splr",         5,    "SC21/toughsat_895s[SAT]",  567.858
│"splr",         6,    "SC21/assoc_mult_e3[UNS]",  378.486
│"splr",         7,    "SC21/dist4.c      [UNS]",  TIMEOUT
│"splr",         8,    "SC21/p01_lb_05    [UNS]", 1062.719
│"splr",         9,    "SC21/shift1add    [UNS]",  511.639
med:   200.608, max:  1062.719,total except 1 timeouts: 2898.217
```