### PR TITLE
Fix crash due to sorting with non-transitive order

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -660,12 +660,10 @@ impl<T: Clone + Default + PartialEq + Ord> PartialOrd for OrderedProxy<T> {
 
 impl<T: Clone + Default + PartialEq + Ord> Ord for OrderedProxy<T> {
     fn cmp(&self, other: &OrderedProxy<T>) -> Ordering {
-        if (self.index - other.index).abs() < f64::EPSILON {
+        if self.index == other.index {
             self.body.cmp(&other.body)
-        } else if self.index < other.index {
-            Ordering::Less
         } else {
-            Ordering::Greater
+            self.index.total_cmp(&other.index)
         }
     }
 }


### PR DESCRIPTION
If given a [certain difficult UNSAT instance](https://github.com/user-attachments/files/18230484/book_thickness_unsat.cnf.txt) as input, splr reliably crashes with "user-provided comparison function does not correctly implement a total order" after 20 minutes because comparing floats with epsilon tolerance is not transitive. To see this, consider the relation $\approx$ defined as $x \approx y \iff |x-y| \le 1$. Then $2 \approx 1$ and $1 \approx 0$ but **not** $2 \approx 0$.
