### PR TITLE
20250112-lit-to-clause

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,14 +26,14 @@ default = [
         ### Heuristics
         # "bi_clause_completion",
         # "clause_rewarding",
-        "dynamic_restart_threshold",
+        # "dynamic_restart_threshold",
         "LRB_rewarding",
         "reason_side_rewarding",
         "rephase",
-        "reward_annealing",
+        # "reward_annealing",
         # "stochastic_local_search",
         # "suppress_reason_chain",
-        "two_mode_reduction",
+        # "two_mode_reduction",
         "trail_saving",
 
         ### Logic formula processor

--- a/src/assign/heap.rs
+++ b/src/assign/heap.rs
@@ -169,6 +169,7 @@ trait VarOrderIF {
     fn get_root(&mut self) -> VarId;
     fn len(&self) -> usize;
     fn insert(&mut self, vi: VarId) -> usize;
+    #[allow(dead_code)]
     fn is_empty(&self) -> bool;
     fn remove(&mut self, vi: VarId) -> Option<usize>;
 }

--- a/src/assign/propagate.rs
+++ b/src/assign/propagate.rs
@@ -433,6 +433,7 @@ impl PropagateIF for AssignStack {
             //
             //## normal clause loop
             //
+            // TODO: check whether dead clauses exists. If so, run `retain()` after propagation.
             let mut source = cdb.watch_cache_iter(propagating);
             'next_clause: while let Some((cid, mut cached)) = source
                 .next()
@@ -444,6 +445,9 @@ impl PropagateIF for AssignStack {
                     "dead clause in propagation: {:?}",
                     cdb.is_garbage_collected(cid),
                 );
+                if cdb[cid].watches(propagating) {
+                    continue;
+                }
                 debug_assert!(!self.var[cached.vi()].is(FlagVar::ELIMINATED));
                 #[cfg(feature = "maintain_watch_cache")]
                 debug_assert!(

--- a/src/assign/select.rs
+++ b/src/assign/select.rs
@@ -74,7 +74,7 @@ impl VarSelectIF for AssignStack {
     fn override_rephasing_target(&mut self, assignment: &HashMap<VarId, bool>) -> usize {
         let mut num_flipped = 0;
         for (vi, b) in assignment.iter() {
-            if !self.best_phases.get(vi).map_or(false, |(p, _)| *p == *b) {
+            if self.best_phases.get(vi).is_none_or(|(p, _)| *p != *b) {
                 num_flipped += 1;
                 self.best_phases.insert(*vi, (*b, AssignReason::None));
             }

--- a/src/assign/trail_saving.rs
+++ b/src/assign/trail_saving.rs
@@ -84,7 +84,7 @@ impl TrailSavingIF for AssignStack {
                     return self.truncate_trail_saved(i + 1);
                 }
                 (None, AssignReason::Implication(cid)) => {
-                    debug_assert_eq!(cdb[cid].lit0(), lit);
+                    debug_assert_eq!(cdb[cid].watch0(), lit);
                     debug_assert!(cdb[cid]
                         .iter()
                         .skip(1)
@@ -109,7 +109,7 @@ impl TrailSavingIF for AssignStack {
                     debug_assert!(cdb[cid].iter().all(|l| self.assigned(*l) == Some(false)));
                     let _ = self.truncate_trail_saved(i + 1); // reduce heap ops.
                     self.clear_saved_trail();
-                    return Err((cdb[cid].lit0(), AssignReason::Implication(cid)));
+                    return Err((cdb[cid].watch0(), AssignReason::Implication(cid)));
                 }
                 (_, AssignReason::Decision(lvl)) => {
                     debug_assert_ne!(0, lvl);

--- a/src/cdb/clause.rs
+++ b/src/cdb/clause.rs
@@ -219,17 +219,37 @@ impl ClauseIF for Clause {
         //     line!(),
         //     self
         // );
-        self.lits[0] == !lit || self.lits[self.watch1] == !lit
+        self.lits[0] == lit || self.lits[self.watch1] == lit
     }
     fn len(&self) -> usize {
         self.lits.len()
+    }
+    fn update_watches(&mut self, lit: Lit) -> Option<Lit> {
+        let w0 = self.lits[0];
+        let w1 = self.lits[self.watch1];
+        if w0 == lit {
+            self.lits.swap(0, self.watch1);
+            Some(w1)
+        } else if w1 == lit {
+            Some(w0)
+        } else {
+            None
+        }
     }
 
     fn transform_by_updating_watch(&mut self, watch_pos: usize) {
         // self.lits.swap(0, watch_pos);
         // self.lits.swap(self.watch1, watch_pos);
         debug_assert!(watch_pos < self.lits.len());
-        self.watch1 = watch_pos;
+        let w1 = self.watch1 + 1;
+        if w1 < watch_pos {
+            // let we = self.lits.len() - 1;
+            // self.lits.swap(w1, we);
+            self.lits.swap(w1, watch_pos);
+            self.watch1 = w1;
+        } else {
+            self.watch1 = watch_pos;
+        }
     }
 
     #[cfg(feature = "boundary_check")]

--- a/src/cdb/clause.rs
+++ b/src/cdb/clause.rs
@@ -204,6 +204,9 @@ impl ClauseIF for Clause {
         }
         false
     }
+    fn watches(&self, lit: Lit) -> bool {
+        self.lits[0] == lit || self.lits[1] == lit
+    }
     fn len(&self) -> usize {
         self.lits.len()
     }

--- a/src/cdb/clause_vector.rs
+++ b/src/cdb/clause_vector.rs
@@ -1,0 +1,87 @@
+use {
+    super::ClauseId,
+    crate::types::*,
+    std::ops::{Index, IndexMut},
+};
+
+pub struct ClauseIdVector(Vec<ClauseId>);
+
+pub trait ClauseIdVectorIF {
+    fn get(&self, i: usize) -> Option<ClauseId>;
+    fn remove_cid(&mut self, cid: ClauseId);
+    fn insert_cid(&mut self, cid: ClauseId);
+}
+
+impl ClauseIdVectorIF for ClauseIdVector {
+    fn get(&self, i: usize) -> Option<ClauseId> {
+        self.0.get(i).copied()
+    }
+    fn remove_cid(&mut self, cid: ClauseId) {
+        if let Some(i) = self.0.iter().position(|e| *e == cid) {
+            self.0.swap_remove(i);
+        }
+    }
+    fn insert_cid(&mut self, cid: ClauseId) {
+        self.0.push(cid);
+    }
+}
+
+impl Index<Lit> for Vec<ClauseIdVector> {
+    type Output = ClauseIdVector;
+    #[inline]
+    fn index(&self, l: Lit) -> &Self::Output {
+        #[cfg(feature = "unsafe_access")]
+        unsafe {
+            self.get_unchecked(usize::from(l))
+        }
+        #[cfg(not(feature = "unsafe_access"))]
+        &self[usize::from(l)]
+    }
+}
+
+impl IndexMut<Lit> for Vec<ClauseIdVector> {
+    #[inline]
+    fn index_mut(&mut self, l: Lit) -> &mut Self::Output {
+        #[cfg(feature = "unsafe_access")]
+        unsafe {
+            self.get_unchecked_mut(usize::from(l))
+        }
+        #[cfg(not(feature = "unsafe_access"))]
+        &mut self[usize::from(l)]
+    }
+}
+
+pub struct ClauseIdIterator {
+    pub index: usize,
+    end_at: usize,
+    // checksum: usize,
+}
+
+impl Iterator for ClauseIdIterator {
+    type Item = usize;
+    fn next(&mut self) -> Option<Self::Item> {
+        // assert!(self.checksum == self.end_at - self.index);
+        (self.index < self.end_at).then_some({
+            // assert!(0 < self.checksum);
+            // self.checksum -= 1;
+            self.index
+        })
+    }
+}
+
+impl ClauseIdIterator {
+    pub fn new(len: usize) -> Self {
+        ClauseIdIterator {
+            index: 0,
+            end_at: len,
+            // checksum: len,
+        }
+    }
+    pub fn restore_entry(&mut self) {
+        self.index += 1;
+    }
+    pub fn detach_entry(&mut self) {
+        // assert!(self.end_at != 0);
+        self.end_at -= 1;
+    }
+}

--- a/src/cdb/db.rs
+++ b/src/cdb/db.rs
@@ -3,9 +3,7 @@ use {
         binary::{BinaryLinkIF, BinaryLinkList},
         clause::{Clause, ClauseId},
         ema::ProgressLBD,
-        property,
-        watch_cache::*,
-        BinaryLinkDB, CertificationStore, ClauseDBIF, ReductionType, RefClause,
+        property, BinaryLinkDB, CertificationStore, ClauseDBIF, ReductionType, RefClause,
     },
     crate::{assign::AssignIF, types::*},
     std::{

--- a/src/cdb/db.rs
+++ b/src/cdb/db.rs
@@ -35,7 +35,7 @@ pub struct ClauseDB {
     ///
     pub(super) binary_link: BinaryLinkDB,
     /// container of watch literals
-    pub(crate) watch_cache: Vec<WatchCache>,
+    pub(crate) lit_to_clauses: Vec<Vec<ClauseId>>,
     /// collected free clause ids.
     pub(super) freelist: Vec<ClauseId>,
     /// see unsat_certificate.rs
@@ -103,7 +103,7 @@ impl Default for ClauseDB {
         ClauseDB {
             clause: Vec::new(),
             binary_link: BinaryLinkDB::default(),
-            watch_cache: Vec::new(),
+            lit_to_clauses: Vec::new(),
             freelist: Vec::new(),
             certification_store: CertificationStore::default(),
             soft_limit: 0, // 248_000_000
@@ -252,7 +252,7 @@ impl Instantiate for ClauseDB {
         ClauseDB {
             clause,
             binary_link: BinaryLinkDB::instantiate(config, cnf),
-            watch_cache: watcher,
+            lit_to_clauses: watcher,
             certification_store: CertificationStore::instantiate(config, cnf),
             soft_limit: config.c_cls_lim,
             lbd: ProgressLBD::instantiate(config, cnf),
@@ -275,9 +275,9 @@ impl Instantiate for ClauseDB {
             SolverEvent::NewVar => {
                 self.binary_link.add_new_var();
                 // for negated literal
-                self.watch_cache.push(WatchCache::new());
+                self.lit_to_clauses.push(WatchCache::new());
                 // for positive literal
-                self.watch_cache.push(WatchCache::new());
+                self.lit_to_clauses.push(WatchCache::new());
                 self.lbd_temp.push(0);
             }
             SolverEvent::Restart => {

--- a/src/cdb/mod.rs
+++ b/src/cdb/mod.rs
@@ -56,6 +56,8 @@ pub trait ClauseIF {
     fn contains(&self, lit: Lit) -> bool;
     /// check clause satisfiability
     fn is_satisfied_under(&self, asg: &impl AssignIF) -> bool;
+    /// return `true` if the clause is watching the literal
+    fn watches(&self, lit: Lit) -> bool;
     /// return an iterator over its literals.
     fn iter(&self) -> Iter<'_, Lit>;
     /// return the number of literals.

--- a/src/cdb/mod.rs
+++ b/src/cdb/mod.rs
@@ -68,6 +68,8 @@ pub trait ClauseIF {
     /// - `c[1,3,6].watches(6) == true`
     ///
     fn watches(&self, lit: Lit) -> bool;
+    /// update watches and return anohther watch.
+    fn update_watches(&mut self, lit: Lit) -> Option<Lit>;
     /// return an iterator over its literals.
     fn iter(&self) -> Iter<'_, Lit>;
     /// return the number of literals.
@@ -354,7 +356,8 @@ mod tests {
 
         asg.assign_by_decision(lit(-2)); // at level 1
         asg.assign_by_decision(lit(1)); // at level 2
-                                        // Now `asg.level` = [_, 2, 1, 3, 4, 5, 6].
+
+        // Now `asg.level` = [_, 2, 1, 3, 4, 5, 6].
         let c1 = cdb
             .new_clause(&mut asg, &mut vec![lit(1), lit(2), lit(3)], false)
             .as_cid();

--- a/src/cdb/mod.rs
+++ b/src/cdb/mod.rs
@@ -16,8 +16,6 @@ mod sls;
 mod unsat_certificate;
 /// implementation of clause vivification
 mod vivify;
-/// types about watching literal
-mod watch_cache;
 
 pub use self::{
     binary::{BinaryLinkDB, BinaryLinkList},
@@ -36,7 +34,6 @@ use {
         ops::IndexMut,
         slice::{Iter, IterMut},
     },
-    watch_cache::*,
 };
 
 #[cfg(not(feature = "no_IO"))]

--- a/src/cdb/vivify.rs
+++ b/src/cdb/vivify.rs
@@ -190,7 +190,7 @@ fn select_targets(
         let mut seen: Vec<Option<OrderedProxy<ClauseId>>> = vec![None; 2 * (asg.num_vars + 1)];
         for (i, c) in cdb.iter().enumerate().skip(1) {
             if let Some(rank) = c.to_vivify(true) {
-                let p = &mut seen[usize::from(c.lit0())];
+                let p = &mut seen[usize::from(c.watch0())];
                 if p.as_ref().map_or(0.0, |r| r.value()) < rank {
                     *p = Some(OrderedProxy::new(ClauseId::from(i), rank));
                 }

--- a/src/solver/conflict.rs
+++ b/src/solver/conflict.rs
@@ -178,8 +178,8 @@ pub fn handle_conflict(
             #[cfg(feature = "boundary_check")]
             cdb[cid].set_birth(asg.num_conflict);
 
-            debug_assert_eq!(l0, cdb[cid].lit0());
-            debug_assert_eq!(l1, cdb[cid].lit1());
+            debug_assert_eq!(l0, cdb[cid].watch0());
+            debug_assert_eq!(l1, cdb[cid].watch1());
             debug_assert_eq!(asg.assigned(l1), Some(false));
             debug_assert_eq!(asg.assigned(l0), None);
 
@@ -201,7 +201,7 @@ pub fn handle_conflict(
             #[cfg(feature = "boundary_check")]
             cdb[cid].set_birth(asg.num_conflict);
 
-            debug_assert_eq!(cdb[cid].lit0(), l0);
+            debug_assert_eq!(cdb[cid].watch0(), l0);
             debug_assert_eq!(asg.assigned(l0), None);
             asg.assign_by_implication(
                 l0,
@@ -220,8 +220,8 @@ pub fn handle_conflict(
         RefClause::RegisteredClause(cid) => {
             debug_assert_eq!(learnt_len, 2);
             debug_assert!(
-                (l0 == cdb[cid].lit0() && l1 == cdb[cid].lit1())
-                    || (l0 == cdb[cid].lit1() && l1 == cdb[cid].lit0())
+                (l0 == cdb[cid].watch0() && l1 == cdb[cid].watch1())
+                    || (l0 == cdb[cid].watch1() && l1 == cdb[cid].watch0())
             );
             debug_assert_eq!(asg.assigned(l1), Some(false));
             debug_assert_eq!(asg.assigned(l0), None);
@@ -594,10 +594,10 @@ fn lit_level(
         AssignReason::Decision(lvl) => lvl,
         AssignReason::Implication(cid) => {
             assert_eq!(
-                cdb[cid].lit0(),
+                cdb[cid].watch0(),
                 lit,
                 "lit0 {} != lit{}, cid {}, {}",
-                cdb[cid].lit0(),
+                cdb[cid].watch0(),
                 lit,
                 cid,
                 &cdb[cid]

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -272,6 +272,7 @@ fn search(
                 return Err(SolverError::UndescribedError);
             }
             RESTART!(asg, cdb, state);
+            #[cfg(feature = "rephase")]
             asg.select_rephasing_target();
             asg.clear_asserted_literals(cdb)?;
 


### PR DESCRIPTION
Remove `watch_list` in another way!

## Plan
- [ ] switch fields
- [ ] stop 'dancing ClauseId'
  - [ ] propagation
  - [ ] vivification
  - [ ] reduction
- [ ] rewrite `reduce` / `gc`

## Positions of watches
If we ditch watch literal proxy, we don't collect watch literals from including literals. By providing a method to access them in $$O(n)$$, any position can be used as watch literals. So, 
- 0
- the position of the last satisfied literal, namely `search_from` - 1 ❗ 