### PR TITLE
Restart NG 20260317

### DIFF
--- a/src/assign/propagate.rs
+++ b/src/assign/propagate.rs
@@ -18,7 +18,7 @@ pub trait PropagateIF {
     /// # Errors
     ///
     /// emit `SolverError::Inconsistent` exception if solver becomes inconsistent.
-    fn assign_at_root_level(&mut self, l: Lit) -> MaybeInconsistent;
+    fn assign_at_root_level(&mut self, cdb: &mut impl ClauseDBIF, l: Lit) -> MaybeInconsistent;
     /// unsafe enqueue (assign by implication); doesn't emit an exception.
     ///
     /// ## Warning
@@ -29,7 +29,7 @@ pub trait PropagateIF {
     /// Callers have to assure the consistency after this assignment.
     fn assign_by_decision(&mut self, l: Lit);
     /// execute *backjump*.
-    fn cancel_until(&mut self, lv: DecisionLevel);
+    fn cancel_until(&mut self, cdb: &mut impl ClauseDBIF, lv: DecisionLevel);
     /// execute backjump in vivification sandbox
     fn backtrack_sandbox(&mut self);
     /// execute *boolean constraint propagation* or *unit propagation*.
@@ -106,8 +106,8 @@ macro_rules! unset_assign {
 }
 
 impl PropagateIF for AssignStack {
-    fn assign_at_root_level(&mut self, l: Lit) -> MaybeInconsistent {
-        self.cancel_until(self.root_level);
+    fn assign_at_root_level(&mut self, cdb: &mut impl ClauseDBIF, l: Lit) -> MaybeInconsistent {
+        self.cancel_until(cdb, self.root_level);
         let vi = l.vi();
         debug_assert!(vi < self.var.len());
         debug_assert!(!self.var[vi].is(FlagVar::ELIMINATED));
@@ -150,6 +150,7 @@ impl PropagateIF for AssignStack {
         );
         debug_assert_eq!(self.var[vi].assign, None);
         debug_assert_eq!(self.var[vi].reason, AssignReason::None);
+        debug_assert_ne!(self.var[vi].reason, reason);
         debug_assert!(self.trail.iter().all(|rl| *rl != l));
         set_assign!(self, l);
 
@@ -194,7 +195,7 @@ impl PropagateIF for AssignStack {
         self.num_decision += 1;
         debug_assert!(self.q_head < self.trail.len());
     }
-    fn cancel_until(&mut self, lv: DecisionLevel) {
+    fn cancel_until(&mut self, cdb: &mut impl ClauseDBIF, lv: DecisionLevel) {
         if self.trail_lim.len() as u32 <= lv {
             return;
         }
@@ -254,6 +255,9 @@ impl PropagateIF for AssignStack {
             }
 
             unset_assign!(self, vi);
+            if let AssignReason::Implication(cid) = self.var[vi].reason {
+                cdb[cid].turn_off(FlagClause::ASSIGN_REASON);
+            }
             self.var[vi].reason = AssignReason::None;
 
             #[cfg(not(feature = "trail_saving"))]
@@ -550,6 +554,7 @@ impl PropagateIF for AssignStack {
                         dl
                     },
                 );
+                cdb[cid].turn_on(FlagClause::ASSIGN_REASON);
                 check_in!(cid, Propagate::BecameUnit(self.num_conflict, cached));
             }
             from_saved_trail!();
@@ -738,6 +743,7 @@ impl PropagateIF for AssignStack {
                         dl
                     },
                 );
+                // no need to set FlagClause::ASSIGN_REASON
                 check_in!(cid, Propagate::SandboxBecameUnit(self.num_conflict));
             }
         }
@@ -795,7 +801,7 @@ impl AssignStack {
                     RefClause::UnitClause(lit) => {
                         debug_assert!(self.assigned(lit).is_none());
                         cdb.certificate_add_assertion(lit);
-                        self.assign_at_root_level(lit)?;
+                        self.assign_at_root_level(cdb, lit)?;
                         cdb.remove_clause(cid);
                     }
                 }

--- a/src/assign/stack.rs
+++ b/src/assign/stack.rs
@@ -1,6 +1,6 @@
 //! main struct AssignStack
 use {
-    super::{AssignIF, PropagateIF, Var, ema::ProgressASG, heap::VarHeapIF, heap::VarIdHeap},
+    super::{AssignIF, Var, ema::ProgressASG, heap::VarHeapIF, heap::VarIdHeap},
     crate::{cdb::ClauseDBIF, types::*},
     std::{
         fmt,
@@ -218,17 +218,6 @@ impl Instantiate for AssignStack {
                 self.num_vars += 1;
                 self.var.push(Var::default());
             }
-            SolverEvent::Reinitialize => {
-                self.cancel_until(self.root_level);
-                debug_assert_eq!(self.decision_level(), self.root_level);
-                #[cfg(feature = "trail_saving")]
-                self.clear_saved_trail();
-                // self.num_eliminated_vars = self
-                //     .var
-                //     .iter()
-                //     .filter(|v| v.is(FlagVar::ELIMINATED))
-                //     .count();
-            }
             e => panic!("don't call asg with {e:?}"),
         }
     }
@@ -381,7 +370,7 @@ impl fmt::Display for AssignStack {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::assign::PropagateIF;
+    use crate::{assign::PropagateIF, cdb::ClauseDB};
 
     fn lit(i: i32) -> Lit {
         Lit::from(i)
@@ -394,20 +383,21 @@ mod tests {
             ..CNFDescription::default()
         };
         let mut asg = AssignStack::instantiate(&config, &cnf);
+        let mut cdb = ClauseDB::instantiate(&config, &cnf);
         // [] + 1 => [1]
-        assert!(asg.assign_at_root_level(lit(1)).is_ok());
+        assert!(asg.assign_at_root_level(&mut cdb, lit(1)).is_ok());
         assert_eq!(asg.trail, vec![lit(1)]);
 
         // [1] + 1 => [1]
-        assert!(asg.assign_at_root_level(lit(1)).is_ok());
+        assert!(asg.assign_at_root_level(&mut cdb, lit(1)).is_ok());
         assert_eq!(asg.trail, vec![lit(1)]);
 
         // [1] + 2 => [1, 2]
-        assert!(asg.assign_at_root_level(lit(2)).is_ok());
+        assert!(asg.assign_at_root_level(&mut cdb, lit(2)).is_ok());
         assert_eq!(asg.trail, vec![lit(1), lit(2)]);
 
         // [1, 2] + -1 => ABORT & [1, 2]
-        assert!(asg.assign_at_root_level(lit(-1)).is_err());
+        assert!(asg.assign_at_root_level(&mut cdb, lit(-1)).is_err());
         assert_eq!(asg.decision_level(), 0);
         assert_eq!(asg.stack_len(), 2);
 
@@ -432,7 +422,7 @@ mod tests {
                 asg.var[l.vi()].turn_on(Flag::PROPAGATED);
             } // simulate propagation
         }
-        asg.cancel_until(1);
+        asg.cancel_until(&mut cdb, 1);
         assert_eq!(asg.trail, vec![lit(1), lit(2), lit(3)]);
         assert_eq!(asg.decision_level(), 1);
         assert_eq!(asg.stack_len(), 3);
@@ -448,7 +438,7 @@ mod tests {
         assert_eq!(asg.trail_lim, vec![2, 3]);
 
         // [1, 2, 3, 4] => [1, 2, -4]
-        asg.assign_at_root_level(Lit::from(-4i32))
+        asg.assign_at_root_level(&mut cdb, Lit::from(-4i32))
             .expect("impossible");
         assert_eq!(asg.trail, vec![lit(1), lit(2), lit(-4)]);
         assert_eq!(asg.decision_level(), 0);

--- a/src/assign/trail_saving.rs
+++ b/src/assign/trail_saving.rs
@@ -2,14 +2,14 @@
 /// implement boolean constraint propagation, backjump
 /// This version can handle Chronological and Non Chronological Backtrack.
 use {
-    super::{heap::VarHeapIF, AssignIF, AssignStack, PropagateIF, VarManipulateIF},
+    super::{AssignIF, AssignStack, PropagateIF, VarManipulateIF, heap::VarHeapIF},
     crate::{cdb::ClauseDBIF, types::*},
 };
 
 /// Methods on trail saving.
 pub trait TrailSavingIF {
     fn save_trail(&mut self, to_lvl: DecisionLevel);
-    fn reuse_saved_trail(&mut self, cdb: &impl ClauseDBIF) -> PropagationResult;
+    fn reuse_saved_trail(&mut self, cdb: &mut impl ClauseDBIF) -> PropagationResult;
     fn clear_saved_trail(&mut self);
 }
 
@@ -50,7 +50,7 @@ impl TrailSavingIF for AssignStack {
             self.insert_heap(vi);
         }
     }
-    fn reuse_saved_trail(&mut self, cdb: &impl ClauseDBIF) -> PropagationResult {
+    fn reuse_saved_trail(&mut self, cdb: &mut impl ClauseDBIF) -> PropagationResult {
         let q = self.stage_scale.trailing_zeros() as u16
             + (cdb.derefer(crate::cdb::property::Tf64::LiteralBlockEntanglement) as u16) / 2;
 
@@ -76,13 +76,16 @@ impl TrailSavingIF for AssignStack {
                 }
                 (None, AssignReason::Implication(cid)) => {
                     debug_assert_eq!(cdb[cid].lit0(), lit);
-                    debug_assert!(cdb[cid]
-                        .iter()
-                        .skip(1)
-                        .all(|l| self.assigned(*l) == Some(false)));
+                    debug_assert!(
+                        cdb[cid]
+                            .iter()
+                            .skip(1)
+                            .all(|l| self.assigned(*l) == Some(false))
+                    );
                     self.num_repropagation += 1;
 
                     self.assign_by_implication(lit, old_reason, dl);
+                    cdb[cid].turn_on(FlagClause::ASSIGN_REASON);
                 }
                 (Some(false), AssignReason::BinaryLink(link)) => {
                     debug_assert_ne!(link.vi(), lit.vi());

--- a/src/cdb/db.rs
+++ b/src/cdb/db.rs
@@ -1039,7 +1039,8 @@ impl ClauseDBIF for ClauseDB {
             ..
         } = self;
         *num_reduction += 1;
-        {
+
+        /* {
             let mut used: std::collections::HashSet<ClauseId> = std::collections::HashSet::new();
             for v in asg.var_iter() {
                 if let AssignReason::Implication(cid) = v.reason {
@@ -1067,7 +1068,7 @@ impl ClauseDBIF for ClauseDB {
                 //     used.contains(&ClauseId::from(cid))
                 // );
             }
-        }
+        } */
 
         let mut perm: Vec<OrderedProxy<usize>> = Vec::with_capacity(clause.len());
         self.leanrt_limit_ema

--- a/src/cdb/db.rs
+++ b/src/cdb/db.rs
@@ -1039,6 +1039,35 @@ impl ClauseDBIF for ClauseDB {
             ..
         } = self;
         *num_reduction += 1;
+        {
+            let mut used: std::collections::HashSet<ClauseId> = std::collections::HashSet::new();
+            for v in asg.var_iter() {
+                if let AssignReason::Implication(cid) = v.reason {
+                    used.insert(cid);
+                }
+            }
+            for (cid, c) in clause.iter().enumerate().skip(1) {
+                if c.is_dead() {
+                    continue;
+                }
+                if c.is(FlagClause::ASSIGN_REASON) != used.contains(&ClauseId::from(cid)) {
+                    dbg!(asg.decision_level());
+                    dbg!(cid, c);
+                    for (i, v) in asg.var_iter().enumerate() {
+                        if let AssignReason::Implication(c) = v.reason
+                            && c == ClauseId::from(cid)
+                        {
+                            dbg!(i, v);
+                        }
+                    }
+                    panic!("done");
+                }
+                // assert_eq!(
+                //     c.is(FlagClause::ASSIGN_REASON),
+                //     used.contains(&ClauseId::from(cid))
+                // );
+            }
+        }
 
         let mut perm: Vec<OrderedProxy<usize>> = Vec::with_capacity(clause.len());
         self.leanrt_limit_ema
@@ -1047,15 +1076,16 @@ impl ClauseDBIF for ClauseDB {
         if self.num_learnt < limit {
             return;
         }
-        for lit in asg.stack_iter() {
-            let Var { level, reason, .. } = asg.var(lit.vi());
-            if *level == asg.root_level() {
-                continue;
-            }
-            if let AssignReason::Implication(cid) = reason {
-                clause[NonZeroU32::get(cid.ordinal) as usize].turn_on(FlagClause::ASSIGN_REASON);
-            }
-        }
+        // for lit in asg.stack_iter() {
+        //     let Var { level, reason, .. } = asg.var(lit.vi());
+        //     if *level == asg.root_level() {
+        //         continue;
+        //     }
+        //     if let AssignReason::Implication(cid) = reason {
+        //         clause[NonZeroU32::get(cid.ordinal) as usize].turn_on(FlagClause::ASSIGN_REASON);
+        //         clause[NonZeroU32::get(cid.ordinal) as usize].turn_on(FlagClause::ASSIGN_REASON);
+        //     }
+        // }
         for (i, c) in clause
             .iter_mut()
             .enumerate()
@@ -1077,7 +1107,7 @@ impl ClauseDBIF for ClauseDB {
                 asg.decision_level(),
             );
             if c.is(FlagClause::ASSIGN_REASON) {
-                c.turn_off(FlagClause::ASSIGN_REASON);
+                // c.turn_off(FlagClause::ASSIGN_REASON);
                 c.used = 0;
                 continue;
             }

--- a/src/cdb/vivify.rs
+++ b/src/cdb/vivify.rs
@@ -127,7 +127,7 @@ impl VivifyIF for ClauseDB {
                                 }
                                 1 => {
                                     self.certificate_add_assertion(vec[0]);
-                                    asg.assign_at_root_level(vec[0])?;
+                                    asg.assign_at_root_level(self, vec[0])?;
                                     num_assert += 1;
                                 }
                                 _ => {

--- a/src/processor/eliminate.rs
+++ b/src/processor/eliminate.rs
@@ -368,7 +368,7 @@ mod tests {
             cdb.iter()
                 .skip(1)
                 .all(|c| c.iter().all(|l| *l != Lit::from((vi, false)))
-                    && c.iter().all(|l| *l != Lit::from((vi, false))))
+                    && c.iter().all(|l| *l != Lit::from((vi, true))))
         );
     }
 }

--- a/src/processor/eliminate.rs
+++ b/src/processor/eliminate.rs
@@ -84,7 +84,7 @@ pub fn eliminate_var(
                         None => {
                             debug_assert!(asg.assigned(lit).is_none());
                             cdb.certificate_add_assertion(lit);
-                            asg.assign_at_root_level(lit)?;
+                            asg.assign_at_root_level(cdb, lit)?;
                         }
                     }
                 }
@@ -358,15 +358,17 @@ mod tests {
         elim.prepare(asg, cdb, true);
         eliminate_var(asg, cdb, &mut elim, state, vi, &mut timedout).expect("panic");
         assert!(asg.var(vi).is(FlagVar::ELIMINATED));
-        assert!(cdb
-            .iter()
-            .skip(1)
-            .filter(|c| c.is_dead())
-            .all(|c| c.is_empty()));
-        assert!(cdb
-            .iter()
-            .skip(1)
-            .all(|c| c.iter().all(|l| *l != Lit::from((vi, false)))
-                && c.iter().all(|l| *l != Lit::from((vi, false)))));
+        assert!(
+            cdb.iter()
+                .skip(1)
+                .filter(|c| c.is_dead())
+                .all(|c| c.is_empty())
+        );
+        assert!(
+            cdb.iter()
+                .skip(1)
+                .all(|c| c.iter().all(|l| *l != Lit::from((vi, false)))
+                    && c.iter().all(|l| *l != Lit::from((vi, false))))
+        );
     }
 }

--- a/src/processor/simplify.rs
+++ b/src/processor/simplify.rs
@@ -1,8 +1,8 @@
 use {
     super::{
+        EliminateIF, Eliminator, EliminatorMode,
         eliminate::eliminate_var,
         heap::{LitOccurs, VarOccHeap, VarOrderIF},
-        EliminateIF, Eliminator, EliminatorMode,
     },
     crate::{
         assign::{self, AssignIF},
@@ -207,9 +207,6 @@ impl Instantiate for Eliminator {
                 self.var_queue.idxs.push(len as u32);
                 self.var_queue.idxs[0] = len as u32;
             }
-            SolverEvent::Reinitialize => {
-                self.elim_lits.clear();
-            }
             _ => (),
         }
     }
@@ -285,9 +282,10 @@ impl EliminateIF for Eliminator {
             self.eliminate_grow_limit = state.derefer(state::property::Tusize::IntervalScale) / 2;
             self.subsume_literal_limit = state.config.elm_cls_lim
                 + cdb.derefer(cdb::property::Tf64::LiteralBlockEntanglement) as usize;
-            debug_assert!(!cdb
-                .derefer(cdb::property::Tf64::LiteralBlockEntanglement)
-                .is_nan());
+            debug_assert!(
+                !cdb.derefer(cdb::property::Tf64::LiteralBlockEntanglement)
+                    .is_nan()
+            );
             // self.eliminate_combination_limit = cdb.derefer(cdb::property::Tf64::LiteralBlockEntanglement);
             self.eliminate(asg, cdb, state)?;
         } else {

--- a/src/processor/subsume.rs
+++ b/src/processor/subsume.rs
@@ -113,7 +113,7 @@ fn strengthen_clause(
             elim.remove_cid_occur(asg, cid, &mut cdb[cid]);
             cdb.remove_clause(cid);
             match asg.assigned(l0) {
-                None => asg.assign_at_root_level(l0),
+                None => asg.assign_at_root_level(cdb, l0),
                 Some(true) => Ok(()),
                 Some(false) => Err(SolverError::RootLevelConflict((l0, asg.reason(l0.vi())))),
             }

--- a/src/solver/build.rs
+++ b/src/solver/build.rs
@@ -174,18 +174,16 @@ impl TryFrom<&Path> for Solver {
 
 impl SatSolverIF for Solver {
     fn add_assignment(&mut self, val: i32) -> Result<&mut Solver, SolverError> {
-        if val == 0 || self.asg.num_vars < val.unsigned_abs() as usize {
+        let Solver { asg, cdb, .. } = self;
+        if val == 0 || asg.num_vars < val.unsigned_abs() as usize {
             return Err(SolverError::InvalidLiteral);
         }
         let lit = Lit::from(val);
-        self.cdb.certificate_add_assertion(lit);
-        match self.asg.assigned(lit) {
-            None => self.asg.assign_at_root_level(lit).map(|_| self),
+        cdb.certificate_add_assertion(lit);
+        match asg.assigned(lit) {
+            None => asg.assign_at_root_level(cdb, lit).map(|_| self),
             Some(true) => Ok(self),
-            Some(false) => Err(SolverError::RootLevelConflict((
-                lit,
-                self.asg.reason(lit.vi()),
-            ))),
+            Some(false) => Err(SolverError::RootLevelConflict((lit, asg.reason(lit.vi())))),
         }
     }
     fn add_clause<V>(&mut self, vec: V) -> Result<&mut Solver, SolverError>
@@ -275,7 +273,7 @@ impl Solver {
             1 => {
                 let l0 = lits[0];
                 cdb.certificate_add_assertion(l0);
-                asg.assign_at_root_level(l0)
+                asg.assign_at_root_level(cdb, l0)
                     .map_or(RefClause::EmptyClause, |_| RefClause::UnitClause(l0))
             }
             _ => cdb.new_clause(asg, lits, false),

--- a/src/solver/conflict.rs
+++ b/src/solver/conflict.rs
@@ -57,17 +57,16 @@ pub fn handle_conflict(
                 .iter()
                 .filter(|l| asg.level(l.vi()) == conflicting_level)
                 .count()
-            {
-                if let Some(second_level) = c
+                && let Some(second_level) = c
                     .iter()
                     .map(|l| asg.level(l.vi()))
                     .filter(|l| *l < conflicting_level)
                     .max()
-                {
-                    debug_assert!(0 < second_level);
-                    asg.cancel_until(second_level);
-                    return Ok(c.rank);
-                }
+            {
+                debug_assert!(0 < second_level);
+                let rank = c.rank;
+                asg.cancel_until(cdb, second_level);
+                return Ok(rank);
             }
         }
         _ => {

--- a/src/solver/conflict.rs
+++ b/src/solver/conflict.rs
@@ -74,7 +74,7 @@ pub fn handle_conflict(
             panic!();
         }
     }
-    asg.cancel_until(conflicting_level);
+    asg.cancel_until(cdb, conflicting_level);
     asg.handle(SolverEvent::Conflict);
 
     let assign_level = conflict_analyze(asg, cdb, state, cc).max(asg.root_level());
@@ -108,7 +108,7 @@ pub fn handle_conflict(
             _ => {
                 // dump to certified even if it's a literal.
                 cdb.certificate_add_assertion(l0);
-                if asg.assign_at_root_level(l0).is_err() {
+                if asg.assign_at_root_level(cdb, l0).is_err() {
                     unreachable!("handle_conflict::root_level_conflict_by_assertion");
                 }
                 let vi = l0.vi();
@@ -187,10 +187,10 @@ pub fn handle_conflict(
     };
     if let Some(b) = bt_drift {
         if b {
-            asg.cancel_until(conflicting_level - 1);
+            asg.cancel_until(cdb, conflicting_level - 1);
             state.bt_drift_average.update(1.0);
         } else {
-            asg.cancel_until(assign_level - 1);
+            asg.cancel_until(cdb, assign_level - 1);
             state.bt_drift_average.update(-1.0);
         }
         #[cfg(feature = "trail_saving")]
@@ -202,7 +202,7 @@ pub fn handle_conflict(
             state.num_chrono_bt += 1;
         }
     } else {
-        asg.cancel_until(assign_level);
+        asg.cancel_until(cdb, assign_level);
         state.bt_drift_average.update(0.0);
     }
     // debug_assert_eq!(asg.assigned(l0), None);
@@ -237,6 +237,7 @@ pub fn handle_conflict(
             if bt_drift.is_none_or(|up1| up1 && cdb[cid].is_unit_under(&*asg)) {
                 asg.assign_by_implication(l0, AssignReason::Implication(cid), assign_level);
                 cdb[cid].used = cdb[cid].used.saturating_add(1);
+                cdb[cid].turn_on(FlagClause::ASSIGN_REASON);
             }
             rank = cdb[cid].rank;
         }

--- a/src/solver/mod.rs
+++ b/src/solver/mod.rs
@@ -51,8 +51,6 @@ pub enum SolverEvent {
     Instantiate,
     /// increment the number of vars.
     NewVar,
-    /// re-initialization for incremental solving.
-    Reinitialize,
     /// restart
     Restart,
     /// start a new stage of Luby stabilization. It holds new scale.

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -25,7 +25,7 @@ pub trait SolveIF {
 
 macro_rules! RESTART {
     ($asg: expr, $cdb: expr, $state: expr) => {
-        $asg.cancel_until($asg.root_level());
+        $asg.cancel_until($cdb, $asg.root_level());
         $cdb.handle(SolverEvent::Restart);
         $state.handle(SolverEvent::Restart);
     };
@@ -103,14 +103,14 @@ impl SolveIF for Solver {
                             let l = Lit::from((vi, true));
                             debug_assert!(asg.assigned(l).is_none());
                             cdb.certificate_add_assertion(l);
-                            if asg.assign_at_root_level(l).is_err() {
+                            if asg.assign_at_root_level(cdb, l).is_err() {
                                 return Ok(Certificate::UNSAT);
                             }
                         } else if p == 0 {
                             let l = Lit::from((vi, false));
                             debug_assert!(asg.assigned(l).is_none());
                             cdb.certificate_add_assertion(l);
-                            if asg.assign_at_root_level(l).is_err() {
+                            if asg.assign_at_root_level(cdb, l).is_err() {
                                 return Ok(Certificate::UNSAT);
                             }
                         }

--- a/src/solver/validate.rs
+++ b/src/solver/validate.rs
@@ -40,8 +40,9 @@ impl ValidateIF for Solver {
         if vec.is_empty() {
             return Err(SolverError::Inconsistent);
         }
+        let Solver { asg, cdb, .. } = self;
         for i in vec {
-            self.asg.assign_at_root_level(Lit::from(*i))?;
+            asg.assign_at_root_level(cdb, Lit::from(*i))?;
         }
         Ok(())
     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -235,7 +235,6 @@ impl Instantiate for State {
             SolverEvent::Conflict => (),
             SolverEvent::Eliminate(_) => (),
             SolverEvent::Instantiate => (),
-            SolverEvent::Reinitialize => (),
             SolverEvent::Restart => {
                 self[Stat::Restart] += 1;
                 self.restart.handle(SolverEvent::Restart);


### PR DESCRIPTION
# The objective

Set `FlagClause::ASSIGN_REASON` just after `propagate_by_implication`.
Therefore `ClauseDBIF::reduce` has not to need to turn them on.