### PR TITLE
Exp 20260326

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -181,11 +181,11 @@
     },
     "nixpkgs_11": {
       "locked": {
-        "lastModified": 1773961357,
-        "narHash": "sha256-1yKTuOe5v4m+NMjWtpu+8mXQQWPb1B1RYH510wee+hw=",
+        "lastModified": 1774532607,
+        "narHash": "sha256-koMw5uDa2TwQ3/lZ49Jiy4Qj1lNjv80YnCen11P+uKY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "27ba396fbbdd21fb39e12968c62b59df3b272f6b",
+        "rev": "c5f84fa27a537e6899c9f636f8810df05fc625cb",
         "type": "github"
       },
       "original": {
@@ -418,11 +418,11 @@
         "nixpkgs": "nixpkgs_12"
       },
       "locked": {
-        "lastModified": 1773961684,
-        "narHash": "sha256-dupR9QcZIDhvVCpatquFVtkQ6ID9jTXgXDIfbQVZ418=",
+        "lastModified": 1774087050,
+        "narHash": "sha256-HvPz08UXPV8A20ZcrRFoZVL6XcSPVQPMEwJ3H5BJUqg=",
         "owner": "shnarazk",
         "repo": "SAT-bench",
-        "rev": "070ef71eb30f37a5db0b5e90dece9ffe24071421",
+        "rev": "171cc8b82439024d67a824d17bfd478df2486706",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -181,11 +181,11 @@
     },
     "nixpkgs_11": {
       "locked": {
-        "lastModified": 1774532607,
-        "narHash": "sha256-koMw5uDa2TwQ3/lZ49Jiy4Qj1lNjv80YnCen11P+uKY=",
+        "lastModified": 1774599000,
+        "narHash": "sha256-D61jLPC5N2MybyNpntJ2h4kp7LLyN3HRpVXfopqi364=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c5f84fa27a537e6899c9f636f8810df05fc625cb",
+        "rev": "c9f25954819053a9229b270637ca37f5666af2be",
         "type": "github"
       },
       "original": {
@@ -196,11 +196,11 @@
     },
     "nixpkgs_12": {
       "locked": {
-        "lastModified": 1773960152,
-        "narHash": "sha256-zNVTOx5mvDhSusqUdyDqChbE37G3CCZFzyGjCE5kE9c=",
+        "lastModified": 1774533741,
+        "narHash": "sha256-CLmBWO4WjXX0PpyRaL65m6E7Oq8dxzvQ+lG/1Lgsi2s=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c7c630cb81efd91fad0b6f4550f80302c5f3fe3f",
+        "rev": "6e5a43c95e64241e77c0481279a83016e5275c11",
         "type": "github"
       },
       "original": {
@@ -418,11 +418,11 @@
         "nixpkgs": "nixpkgs_12"
       },
       "locked": {
-        "lastModified": 1774087050,
-        "narHash": "sha256-HvPz08UXPV8A20ZcrRFoZVL6XcSPVQPMEwJ3H5BJUqg=",
+        "lastModified": 1774535306,
+        "narHash": "sha256-/T8oyQtRG2DcpNNJANjXvr+/h3MqL/lKf4gJ6Sdq1/k=",
         "owner": "shnarazk",
         "repo": "SAT-bench",
-        "rev": "171cc8b82439024d67a824d17bfd478df2486706",
+        "rev": "f37f959fa74cf1cbb5f3e8eaa7f522f694e12e8b",
         "type": "github"
       },
       "original": {

--- a/src/solver/conflict.rs
+++ b/src/solver/conflict.rs
@@ -71,11 +71,22 @@ pub fn handle_conflict(
             panic!();
         }
     }
+    // FIXME: this is for chrono_BT, right?
     asg.cancel_until(cdb, conflicting_level);
     asg.handle(SolverEvent::Conflict);
 
     let assign_level = conflict_analyze(asg, cdb, state, cc).max(asg.root_level());
     let new_learnt = &mut state.new_learnt;
+    /* {
+        let lbd_tmp = new_learnt
+            .iter()
+            .skip(1)
+            .map(|l| asg.level(l.vi()))
+            .collect::<std::collections::HashSet<_>>()
+            .len();
+        let decay: f64 = 1.0 - 0.1 / ((lbd_tmp + 1) as f64).log2();
+        asg.update_activity_decay(decay);
+    } */
     let learnt_len = new_learnt.len();
     if learnt_len == 0 {
         return Err(SolverError::EmptyClause);

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -236,6 +236,30 @@ fn search(
         asg.update_activity_tick();
         #[cfg(feature = "clause_rewarding")]
         cdb.update_activity_tick();
+        {
+            // f(1) = 1
+            // f(10) = 0.999
+            // f(20) = 0.994
+            // f(40) = 0.91
+            // f(80) = 0.80
+            fn f(x: f64) -> f64 {
+                let t = (x - 1.0).max(0.0);
+                let s = 30.0;
+                let k = 6.0;
+                let m = 0.055;
+                (1.0 + (t / s).powf(k)).powf(-m)
+            }
+            // fn f(x: f64) -> f64 {
+            //     // let t = (x - 1.0).max(0.0);
+            //     let t = x - 1.0;
+            //     (1.0 + 4.57e-6 * t * t).powf(-0.921)
+            // }
+            // let index: f64 = state.c_lvl.get();
+            let index: f64 = asg.decision_level() as f64;
+            let decay: f64 = f(index);
+            // let index = 1.0 - state.c_lvl.get().log2() / 32.0;
+            asg.update_activity_decay(decay);
+        }
         let lbd = handle_conflict(asg, cdb, state, &cc)?;
         if 1 < lbd {
             num_learnts += 1;
@@ -286,14 +310,14 @@ fn search(
                 }
             }
             if let Some(_new_envelope) = new_segment {
-                {
+                /* {
                     // Longer segments reduces learning rates to search deeper space.
                     let index_e = 20.0;
                     let index_s =
                         state.stm.current_segment() - state.stm.envelope_starting_segment();
                     let decay_index: f64 = index_e + index_s as f64;
                     asg.update_activity_decay(1.0 - 1.0 / decay_index);
-                }
+                } */
 
                 #[cfg(feature = "stochastic_local_search")]
                 {
@@ -362,13 +386,12 @@ fn search(
                     }
                     processing_pressure = 0;
                 }
-                // if new_envelope {
-                //     {
-                //         let base = state.stm.current_segment();
-                //         let decay_index: f64 = (20 + 2 * base) as f64;
-                //         asg.update_activity_decay((decay_index - 1.0) / decay_index);
-                //     }
-                // }
+                /* if new_envelope {
+                    let _l = 10.0 /* state.c_lvl.get() */
+                        / asg.derefer(assign::property::Tusize::NumUnassertedVar) as f64;
+                    asg.update_activity_decay(0.99);
+                    // asg.update_activity_decay(1.0 - 1.0 / (10 + state.stm.envelop_index()) as f64);
+                } */
             }
 
             if num_learnts > restart_interval {

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -213,14 +213,11 @@ fn search(
     let mut previous_span: Option<bool> = Some(true);
     let mut current_core: usize = 999_999;
     let mut core_was_rebuilt: Option<usize> = None;
-    let mut after_restart: usize = 0;
     let mut num_learnts: usize = 0;
     let mut restart_pressure: usize = 0;
     let restart_interval: usize = 40_000;
-    let mut lbd_threshold: u16 = 0;
     let mut processing_pressure: usize = 0;
     let processing_interval: usize = 80_000;
-    let cooling_length: usize = 12;
     let mut count: usize = 0;
 
     state.stm.reset();
@@ -233,7 +230,6 @@ fn search(
             continue;
         };
         count += 1;
-        after_restart += 1;
         if asg.decision_level() == asg.root_level() {
             return Err(SolverError::RootLevelConflict(cc));
         }
@@ -241,16 +237,25 @@ fn search(
         #[cfg(feature = "clause_rewarding")]
         cdb.update_activity_tick();
         let lbd = handle_conflict(asg, cdb, state, &cc)?;
-        if after_restart == cooling_length {
-            lbd_threshold = cdb.lbd.get_fast() as u16;
-            restart_pressure = 0;
-        }
-        if lbd == 0 {
-            // lbd_threshold = cdb.lbd.get_fast() as u16;
-        } else if 1 < lbd {
+        if 1 < lbd {
             num_learnts += 1;
-            if after_restart >= cooling_length && lbd > lbd_threshold {
-                restart_pressure += 1;
+            {
+                let conflict_activity: f64 = asg.var(cc.0.vi()).reward;
+                let mut prev_activity = f64::MAX;
+                for lv in 1..asg.decision_level() {
+                    let va = asg.var(asg.decision_vi(lv)).reward;
+                    if va < conflict_activity {
+                        asg.cancel_until(cdb, lv);
+                        restart_pressure += 1;
+                        break;
+                    }
+                    if prev_activity < va {
+                        restart_pressure += 1;
+                        break;
+                    }
+                    prev_activity = va;
+                }
+                // restart_pressure = usize::MAX;
             }
             cdb.lbd.update(lbd);
             if num_learnts >= restart_interval.max(state.stm.envelop_index() * 10_000) {
@@ -268,14 +273,11 @@ fn search(
             } else {
                 return Err(SolverError::UndescribedError);
             }
-            after_restart = 0;
             restart_pressure = 0;
-            lbd_threshold = 0;
             RESTART!(asg, cdb, state);
             asg.clear_asserted_literals(cdb)?;
-
             dump_stage(asg, cdb, state, previous_span);
-            let new_span: Option<bool> = state.stm.prepare_new_span(restart_pressure);
+            let new_segment: Option<bool> = state.stm.prepare_new_span(restart_pressure);
             let segment_length = state.stm.current_segment_length();
             #[cfg(feature = "rephase")]
             {
@@ -283,16 +285,15 @@ fn search(
                     asg.select_rephasing_target();
                 }
             }
-            if let Some(new_envelope) = new_span {
-                // a beginning of a new cycle
-                /* {
+            if let Some(_new_envelope) = new_segment {
+                {
                     // Longer segments reduces learning rates to search deeper space.
                     let index_e = 20.0;
                     let index_s =
                         state.stm.current_segment() - state.stm.envelope_starting_segment();
                     let decay_index: f64 = index_e + index_s as f64;
                     asg.update_activity_decay(1.0 - 1.0 / decay_index);
-                } */
+                }
 
                 #[cfg(feature = "stochastic_local_search")]
                 {
@@ -377,7 +378,7 @@ fn search(
 
             asg.handle(SolverEvent::Stage(segment_length));
             state.restart.set_stage_parameters(segment_length);
-            previous_span = new_span;
+            previous_span = new_segment;
         }
         if count.is_multiple_of(10_000) {
             state.progress(asg, cdb);

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -220,12 +220,10 @@ fn search(
     let mut lbd_threshold: u16 = 0;
     let mut processing_pressure: usize = 0;
     let processing_interval: usize = 80_000;
-    let cooling_length_base: usize = 2;
-    let mut cooling_length: usize = cooling_length_base;
+    let cooling_length: usize = 12;
     let mut count: usize = 0;
 
     state.stm.reset();
-    asg.update_activity_decay(0.98);
     while 0 < asg.derefer(assign::property::Tusize::NumUnassignedVar) || asg.remains() {
         if !asg.remains() {
             let lit = asg.select_decision_literal();
@@ -242,24 +240,19 @@ fn search(
         asg.update_activity_tick();
         #[cfg(feature = "clause_rewarding")]
         cdb.update_activity_tick();
-        let mut lbd = handle_conflict(asg, cdb, state, &cc)?;
+        let lbd = handle_conflict(asg, cdb, state, &cc)?;
+        if after_restart == cooling_length {
+            lbd_threshold = cdb.lbd.get_fast() as u16;
+            restart_pressure = 0;
+        }
         if lbd == 0 {
-            restart_pressure += 1;
-            cooling_length = cooling_length_base;
-            lbd_threshold = cdb.lbd.get_slow() as u16;
+            // lbd_threshold = cdb.lbd.get_fast() as u16;
         } else if 1 < lbd {
             num_learnts += 1;
-            if after_restart >= cooling_length {
-                if restart_pressure == 0 {
-                    lbd_threshold = cdb.lbd.get_slow() as u16;
-                }
-                if lbd > lbd_threshold {
-                    restart_pressure += 1;
-                    lbd = lbd_threshold;
-                }
+            if after_restart >= cooling_length && lbd > lbd_threshold {
+                restart_pressure += 1;
             }
             cdb.lbd.update(lbd);
-            // lbd_threshold = lbd_threshold.min(cdb.lbd.get() as u16);
             if num_learnts >= restart_interval.max(state.stm.envelop_index() * 10_000) {
                 cdb.reduce(asg, state.stm.envelop_index());
                 num_learnts = 0;
@@ -292,14 +285,14 @@ fn search(
             }
             if let Some(new_envelope) = new_span {
                 // a beginning of a new cycle
-                {
+                /* {
                     // Longer segments reduces learning rates to search deeper space.
                     let index_e = 20.0;
                     let index_s =
                         state.stm.current_segment() - state.stm.envelope_starting_segment();
                     let decay_index: f64 = index_e + index_s as f64;
                     asg.update_activity_decay(1.0 - 1.0 / decay_index);
-                }
+                } */
 
                 #[cfg(feature = "stochastic_local_search")]
                 {
@@ -368,13 +361,13 @@ fn search(
                     }
                     processing_pressure = 0;
                 }
-                if new_envelope {
-                    {
-                        let base = state.stm.current_segment();
-                        let decay_index: f64 = (20 + 2 * base) as f64;
-                        asg.update_activity_decay((decay_index - 1.0) / decay_index);
-                    }
-                }
+                // if new_envelope {
+                //     {
+                //         let base = state.stm.current_segment();
+                //         let decay_index: f64 = (20 + 2 * base) as f64;
+                //         asg.update_activity_decay((decay_index - 1.0) / decay_index);
+                //     }
+                // }
             }
 
             if num_learnts > restart_interval {
@@ -393,10 +386,6 @@ fn search(
             }
         }
         if let Some(na) = asg.best_assigned() {
-            if na < current_core {
-                cooling_length += 1;
-                state.stm.extend(10_000);
-            }
             if current_core < na && core_was_rebuilt.is_none() {
                 core_was_rebuilt = Some(current_core);
             }


### PR DESCRIPTION
Restart only if the order of decision var will change.

### Kissat
```
solver,       num,                       target,     time
# "kissat",       1,"0a8a4c28d27228e954354ea0a6e7f16c-sum_of_three_cubes_42_known_representation.cnf",  126.650
# "kissat",       2,"1a936d41e3439d602c3ddcf96458a38c-arles_thres10_p10_r8185.cnf",    0.007
# "kissat",       3,"2b4467a5ac4ac41b36d4c3432b07f767-oddball_69_5_tto_zp.normalised.cnf", 1065.746
# "kissat",       4,"3a1f1b4b9a521737cc760017fe9d8b43-MVRoundRobin_n16_d10_v3.cnf",  TIMEOUT
# "kissat",       5,"4ba2c1aa580b6497df6baf5e7e2c87be-at-least-two-vmpc_28.cnf", 1120.135
# "kissat",       6,"5aed29ce52192a55ffbd2a6f340017e7-oisc-subrv-and-nested-12.cnf",  TIMEOUT
# "kissat",       7,"6cb995b1c550beb579c53e27f6ca881a-RoundRobin_n16_d13.cnf", 1116.055
# "kissat",       8,"7a044c997ede14d00002f1db39d45170-sum_of_3_cubes_37_bits_87.cnf",  650.169
# "kissat",       9,"8a05f9b6bf49285e40d0a197967ea5d3-arles_thres10_p10_r7466.cnf",    0.696
# "kissat",      10,"9a839badecb20dcf505ec79eedd3753a-anbul-dated-5-15-u.cnf",   15.028
# "kissat",      11,"a0bcdaffb0ea36b678899fd86bdc7f18-arles_thres10_p10_r8186.cnf",    0.018
# "kissat",      12,"b1c8eaa002ac2fa1c8bfd1002738e78e-cliquecolouring_n15_k7_c6.sanitized.cnf",  TIMEOUT
# "kissat",      13,"c0bd86bd7ca2c65e44311de374168150-goldcrest-and-14.cnf",  528.235
# "kissat",      14,"d0298807e51730261ef65db827dcd70f-Break_triple_16_70.xml.cnf",   23.596
# "kissat",      15,"e2d2b011b0805782df6adba648db92e8-59-129706.cnf",  405.921
# "kissat",      16,"f0bafebdcce23ccfbaf6c27a7522069b-div-mitern172.cnf",   26.040
# "kissat",      17,              "sc2025(13/16)", 4378.523
# med:   126.650, max:  1120.135,total except 3 timeouts: 5078.296
```

8a2fef7
```
solver,       num,                       target,     time
"splr",         1,"0a8a4c28d27228e954354ea0a6e7f16c-sum_of_three_cubes_42_known_representation.cnf",  TIMEOUT
"splr",         2,"1a936d41e3439d602c3ddcf96458a38c-arles_thres10_p10_r8185.cnf",    0.020
"splr",         3,"2b4467a5ac4ac41b36d4c3432b07f767-oddball_69_5_tto_zp.normalised.cnf",  TIMEOUT
"splr",         4,"3a1f1b4b9a521737cc760017fe9d8b43-MVRoundRobin_n16_d10_v3.cnf",  TIMEOUT
"splr",         5,"4ba2c1aa580b6497df6baf5e7e2c87be-at-least-two-vmpc_28.cnf",  125.349
"splr",         6,"5aed29ce52192a55ffbd2a6f340017e7-oisc-subrv-and-nested-12.cnf",  TIMEOUT
"splr",         7,"6cb995b1c550beb579c53e27f6ca881a-RoundRobin_n16_d13.cnf",  TIMEOUT
"splr",         8,"7a044c997ede14d00002f1db39d45170-sum_of_3_cubes_37_bits_87.cnf",  658.462
"splr",         9,"8a05f9b6bf49285e40d0a197967ea5d3-arles_thres10_p10_r7466.cnf",    0.677
"splr",        10,"9a839badecb20dcf505ec79eedd3753a-anbul-dated-5-15-u.cnf",  106.679
"splr",        11,"a0bcdaffb0ea36b678899fd86bdc7f18-arles_thres10_p10_r8186.cnf",    0.019
"splr",        12,"b1c8eaa002ac2fa1c8bfd1002738e78e-cliquecolouring_n15_k7_c6.sanitized.cnf",  TIMEOUT
"splr",        13,"c0bd86bd7ca2c65e44311de374168150-goldcrest-and-14.cnf",  TIMEOUT
"splr",        14,"d0298807e51730261ef65db827dcd70f-Break_triple_16_70.xml.cnf",  TIMEOUT
"splr",        15,"e2d2b011b0805782df6adba648db92e8-59-129706.cnf",  TIMEOUT
"splr",        16,"f0bafebdcce23ccfbaf6c27a7522069b-div-mitern172.cnf",  299.150
"splr",        17,               "sc2025(7/16)",10000.198
med:   106.679, max:   658.462,total except 9 timeouts: 1190.356
```