### PR TITLE
Implement focused search mode like Kissat

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,7 +74,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "splr"
-version = "0.19.0-rc2"
+version = "0.19.0-rc3"
 dependencies = [
  "bitflags",
  "instant",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "splr"
-version = "0.19.0-rc2"
+version = "0.19.0-rc3"
 authors = ["Narazaki Shuji <shujinarazaki@protonmail.com>"]
 description = "A modern CDCL SAT solver in Rust"
 edition = "2024"
@@ -29,7 +29,7 @@ default = [
 
     # "clause_rewarding",
     "reason_side_rewarding",
-    # "rephase",
+    "rephase",
     # "stochastic_local_search",
 
     ### Logic formula processor

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ default = [
 
     # "clause_rewarding",
     "reason_side_rewarding",
-    "rephase",
+    # "rephase",
     # "stochastic_local_search",
 
     ### Logic formula processor

--- a/flake.lock
+++ b/flake.lock
@@ -181,11 +181,11 @@
     },
     "nixpkgs_11": {
       "locked": {
-        "lastModified": 1773961357,
-        "narHash": "sha256-1yKTuOe5v4m+NMjWtpu+8mXQQWPb1B1RYH510wee+hw=",
+        "lastModified": 1774726786,
+        "narHash": "sha256-/x9aPephAMsYDwmpxK5mN4x6W86gj6S8ZE8JgukmBWQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "27ba396fbbdd21fb39e12968c62b59df3b272f6b",
+        "rev": "1ec6ad00ff94be95ca85f6c2f01a793bf9e4652c",
         "type": "github"
       },
       "original": {
@@ -196,11 +196,11 @@
     },
     "nixpkgs_12": {
       "locked": {
-        "lastModified": 1773960152,
-        "narHash": "sha256-zNVTOx5mvDhSusqUdyDqChbE37G3CCZFzyGjCE5kE9c=",
+        "lastModified": 1774679983,
+        "narHash": "sha256-x7TZKCMEzNEsq3yqGL2HH1idlpaqiFd2yzOTw74GREA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c7c630cb81efd91fad0b6f4550f80302c5f3fe3f",
+        "rev": "9bce37898d6cd2061784e62e2a188cbb16220c4b",
         "type": "github"
       },
       "original": {
@@ -418,11 +418,11 @@
         "nixpkgs": "nixpkgs_12"
       },
       "locked": {
-        "lastModified": 1773961684,
-        "narHash": "sha256-dupR9QcZIDhvVCpatquFVtkQ6ID9jTXgXDIfbQVZ418=",
+        "lastModified": 1774682391,
+        "narHash": "sha256-OCDINowFwWu0BTk0DExvj6DXOGpBOWTItQRBK91IoK0=",
         "owner": "shnarazk",
         "repo": "SAT-bench",
-        "rev": "070ef71eb30f37a5db0b5e90dece9ffe24071421",
+        "rev": "0a9ba78613b938e47ecb723ac3372e371ec95724",
         "type": "github"
       },
       "original": {

--- a/src/assign/heap.rs
+++ b/src/assign/heap.rs
@@ -93,28 +93,56 @@ impl VarHeapIF for AssignStack {
         let mut q = start;
         let vq = self.var_order.heap[q as usize];
         debug_assert!(0 < vq, "size of heap is too small");
-        let aq = self.activity(vq as usize);
-        loop {
-            let p = q / 2;
-            if p == 0 {
-                self.var_order.heap[q as usize] = vq;
-                debug_assert!(vq != 0, "Invalid index in percolate_up");
-                self.var_order.idxs[vq as usize] = q;
-                return;
-            } else {
-                let vp = self.var_order.heap[p as usize];
-                let ap = self.activity(vp as usize);
-                if ap < aq {
-                    // move down the current parent, and make it empty
-                    self.var_order.heap[q as usize] = vp;
-                    debug_assert!(vq != 0, "Invalid index in percolate_up");
-                    self.var_order.idxs[vp as usize] = q;
-                    q = p;
-                } else {
+        if self.ordering_by_conflict {
+            let aq = self.var[vq as usize].last_conflict;
+            loop {
+                let p = q / 2;
+                if p == 0 {
                     self.var_order.heap[q as usize] = vq;
                     debug_assert!(vq != 0, "Invalid index in percolate_up");
                     self.var_order.idxs[vq as usize] = q;
                     return;
+                } else {
+                    let vp = self.var_order.heap[p as usize];
+                    let ap = self.var[vp as usize].last_conflict;
+                    if ap < aq {
+                        // move down the current parent, and make it empty
+                        self.var_order.heap[q as usize] = vp;
+                        debug_assert!(vq != 0, "Invalid index in percolate_up");
+                        self.var_order.idxs[vp as usize] = q;
+                        q = p;
+                    } else {
+                        self.var_order.heap[q as usize] = vq;
+                        debug_assert!(vq != 0, "Invalid index in percolate_up");
+                        self.var_order.idxs[vq as usize] = q;
+                        return;
+                    }
+                }
+            }
+        } else {
+            let aq = self.activity(vq as usize);
+            loop {
+                let p = q / 2;
+                if p == 0 {
+                    self.var_order.heap[q as usize] = vq;
+                    debug_assert!(vq != 0, "Invalid index in percolate_up");
+                    self.var_order.idxs[vq as usize] = q;
+                    return;
+                } else {
+                    let vp = self.var_order.heap[p as usize];
+                    let ap = self.activity(vp as usize);
+                    if ap < aq {
+                        // move down the current parent, and make it empty
+                        self.var_order.heap[q as usize] = vp;
+                        debug_assert!(vq != 0, "Invalid index in percolate_up");
+                        self.var_order.idxs[vp as usize] = q;
+                        q = p;
+                    } else {
+                        self.var_order.heap[q as usize] = vq;
+                        debug_assert!(vq != 0, "Invalid index in percolate_up");
+                        self.var_order.idxs[vq as usize] = q;
+                        return;
+                    }
                 }
             }
         }
@@ -123,36 +151,71 @@ impl VarHeapIF for AssignStack {
         let n = self.var_order.len();
         let mut i = start;
         let vi = self.var_order.heap[i as usize];
-        let ai = self.activity(vi as usize);
-        loop {
-            let l = 2 * i; // left
-            if l < n as u32 {
-                let vl = self.var_order.heap[l as usize];
-                let al = self.activity(vl as usize);
-                let r = l + 1; // right
-                let (target, vc, ac) = if r < (n as u32)
-                    && al < self.activity(self.var_order.heap[r as usize] as usize)
-                {
-                    let vr = self.var_order.heap[r as usize];
-                    (r, vr, self.activity(vr as usize))
-                } else {
-                    (l, vl, al)
-                };
-                if ai < ac {
-                    self.var_order.heap[i as usize] = vc;
-                    self.var_order.idxs[vc as usize] = i;
-                    i = target;
+        if self.ordering_by_conflict {
+            let ai = self.var[vi as usize].last_conflict;
+            loop {
+                let l = 2 * i; // left
+                if l < n as u32 {
+                    let vl = self.var_order.heap[l as usize];
+                    let al = self.var[vl as usize].last_conflict;
+                    let r = l + 1; // right
+                    let (target, vc, ac) = if r < (n as u32)
+                        && al < self.var[self.var_order.heap[r as usize] as usize].last_conflict
+                    {
+                        let vr = self.var_order.heap[r as usize];
+                        (r, vr, self.var[vr as usize].last_conflict)
+                    } else {
+                        (l, vl, al)
+                    };
+                    if ai < ac {
+                        self.var_order.heap[i as usize] = vc;
+                        self.var_order.idxs[vc as usize] = i;
+                        i = target;
+                    } else {
+                        self.var_order.heap[i as usize] = vi;
+                        debug_assert!(vi != 0, "invalid index");
+                        self.var_order.idxs[vi as usize] = i;
+                        return;
+                    }
                 } else {
                     self.var_order.heap[i as usize] = vi;
                     debug_assert!(vi != 0, "invalid index");
                     self.var_order.idxs[vi as usize] = i;
                     return;
                 }
-            } else {
-                self.var_order.heap[i as usize] = vi;
-                debug_assert!(vi != 0, "invalid index");
-                self.var_order.idxs[vi as usize] = i;
-                return;
+            }
+        } else {
+            let ai = self.activity(vi as usize);
+            loop {
+                let l = 2 * i; // left
+                if l < n as u32 {
+                    let vl = self.var_order.heap[l as usize];
+                    let al = self.activity(vl as usize);
+                    let r = l + 1; // right
+                    let (target, vc, ac) = if r < (n as u32)
+                        && al < self.activity(self.var_order.heap[r as usize] as usize)
+                    {
+                        let vr = self.var_order.heap[r as usize];
+                        (r, vr, self.activity(vr as usize))
+                    } else {
+                        (l, vl, al)
+                    };
+                    if ai < ac {
+                        self.var_order.heap[i as usize] = vc;
+                        self.var_order.idxs[vc as usize] = i;
+                        i = target;
+                    } else {
+                        self.var_order.heap[i as usize] = vi;
+                        debug_assert!(vi != 0, "invalid index");
+                        self.var_order.idxs[vi as usize] = i;
+                        return;
+                    }
+                } else {
+                    self.var_order.heap[i as usize] = vi;
+                    debug_assert!(vi != 0, "invalid index");
+                    self.var_order.idxs[vi as usize] = i;
+                    return;
+                }
             }
         }
     }

--- a/src/assign/propagate.rs
+++ b/src/assign/propagate.rs
@@ -310,6 +310,7 @@ impl PropagateIF for AssignStack {
                 self.dpc_ema.update(self.num_decision);
                 self.ppc_ema.update(self.num_propagation);
                 self.num_conflict += 1;
+                self.var[$lit.vi()].last_conflict = self.num_conflict;
                 return Err(($lit, $reason));
             };
         }

--- a/src/assign/stack.rs
+++ b/src/assign/stack.rs
@@ -91,6 +91,8 @@ pub struct AssignStack {
     pub(super) activity_decay: f64,
     /// its diff
     pub(super) activity_anti_decay: f64,
+    /// ordering_mode
+    pub(crate) ordering_by_conflict: bool,
 }
 
 impl Default for AssignStack {
@@ -140,6 +142,7 @@ impl Default for AssignStack {
             activity_decay: 0.94,
 
             activity_anti_decay: 0.06,
+            ordering_by_conflict: false,
         }
     }
 }

--- a/src/processor/simplify.rs
+++ b/src/processor/simplify.rs
@@ -264,7 +264,7 @@ impl EliminateIF for Eliminator {
             if !force_run && self.mode == EliminatorMode::Dormant {
                 self.prepare(asg, cdb, true);
             }
-            self.eliminate_grow_limit = state.derefer(state::property::Tusize::IntervalScale) / 2;
+            self.eliminate_grow_limit = state.derefer(state::property::Tusize::SegmentLength) / 2;
             self.subsume_literal_limit = state.config.elm_cls_lim
                 + cdb.derefer(cdb::property::Tf64::LiteralBlockEntanglement) as usize;
             debug_assert!(

--- a/src/solver/conflict.rs
+++ b/src/solver/conflict.rs
@@ -160,6 +160,7 @@ pub fn handle_conflict(
     {
         Some(true)
     } else if cfg!(feature = "BT_deepen")
+        && !asg.ordering_by_conflict
         && assign_level > 0
         && new_learnt.len() > 2
         && new_learnt

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -219,9 +219,8 @@ fn search(
     let restart_interval: usize = 40_000;
     let mut lbd_threshold: u16 = 0;
     let mut processing_pressure: usize = 0;
-    let processing_interval: usize = 80_000;
-    let cooling_length_base: usize = 2;
-    let mut cooling_length: usize = cooling_length_base;
+    let processing_interval: usize = 40_000;
+    let cooling_length: usize = 0;
     let mut count: usize = 0;
     let mut unreachable_ema: Ema2 = Ema2::new(80).with_slow(1000);
     let mut unreachable_threshold: usize = 0;
@@ -247,7 +246,6 @@ fn search(
         let mut lbd = handle_conflict(asg, cdb, state, &cc)?;
         if lbd == 0 {
             restart_pressure += 1;
-            cooling_length = cooling_length_base;
             lbd_threshold = cdb.lbd.get_slow() as u16;
         } else {
             if 1 < lbd {
@@ -255,25 +253,14 @@ fn search(
             }
             let num_unassigns = asg.derefer(assign::property::Tusize::NumUnassignedVar);
             unreachable_ema.update(num_unassigns as f64);
-            if !asg.ordering_by_conflict
-                && ((num_unassigns as f64).log10() * 2.0) as usize + num_unassigns
-                    < unreachable_ema.get() as usize
-            {
-                state.flush("");
-                state.flush("switch to stable search mode");
-                asg.ordering_by_conflict = true;
-                asg.rebuild_order();
-                // state.stm.extend(1000);
-                unreachable_threshold = num_unassigns;
-            }
-            if asg.ordering_by_conflict {
-                if num_unassigns > unreachable_threshold {
-                    restart_pressure += 1;
+            if after_restart >= cooling_length {
+                if asg.ordering_by_conflict {
+                    if num_unassigns > unreachable_threshold {
+                        restart_pressure += 1;
+                    } else {
+                        unreachable_threshold = num_unassigns;
+                    }
                 } else {
-                    unreachable_threshold = num_unassigns;
-                }
-            } else {
-                if after_restart >= cooling_length {
                     if restart_pressure == 0 {
                         lbd_threshold = cdb.lbd.get_slow() as u16;
                     }
@@ -304,43 +291,54 @@ fn search(
             restart_pressure = 0;
             lbd_threshold = 0;
             RESTART!(asg, cdb, state);
-            // if asg.ordering_by_conflict {
-            //     asg.ordering_by_conflict = false;
-            //     asg.rebuild_order();
-            // }
             asg.clear_asserted_literals(cdb)?;
 
             dump_stage(asg, cdb, state, previous_span);
+
+            // change search mode
+            {
+                let ei = state.stm.envelop_index();
+                let sl = state.stm.current_index_in_segment();
+                // dbg!(state.stm.envelop_index());
+                // dbg!(state.stm.current_index_in_segment());
+                if ei > 10 {
+                    if sl + 2 == ei && !asg.ordering_by_conflict {
+                        state.flush("");
+                        state.flush("switch to focused search mode");
+                        // println!("switch to focused search mode");
+                        asg.ordering_by_conflict = true;
+                        unreachable_threshold = usize::MAX;
+                        asg.update_activity_decay(1.0);
+                        asg.rebuild_order();
+                    } else if sl + 1 == ei {
+                        state.flush("");
+                        state.flush("switch to stable search mode");
+                        // println!("switch to stable search mode");
+                        asg.ordering_by_conflict = false;
+                        asg.update_activity_decay(state.config.vrw_dcy_rat);
+                        asg.rebuild_order();
+                    }
+                }
+            }
+
             let new_span: Option<bool> = state.stm.prepare_new_span(restart_pressure);
             let segment_length = state.stm.current_segment_length();
             #[cfg(feature = "rephase")]
             {
-                if state.stm.current_span() == 1 {
+                if !asg.ordering_by_conflict && state.stm.current_span() == 1 {
                     asg.select_rephasing_target();
                 }
             }
-            if let Some(new_envelope) = new_span {
+            if let Some(_new_envelope) = new_span {
                 // a beginning of a new cycle
                 {
                     // Longer segments reduces learning rates to search deeper space.
-                    let index_e = 20.0;
-                    let index_s =
-                        state.stm.current_segment() - state.stm.envelope_starting_segment();
-                    let decay_index: f64 = index_e + index_s as f64;
-                    asg.update_activity_decay(1.0 - 1.0 / decay_index);
-                    if new_envelope && asg.ordering_by_conflict {
-                        asg.ordering_by_conflict = false;
-                        asg.rebuild_order();
-                    }
-                    // if asg.ordering_by_conflict {
-                    //     asg.rebuild_order();
-                    // }
+                    // let index_e = 20.0;
+                    // let index_s =
+                    //     state.stm.current_segment() - state.stm.envelope_starting_segment();
+                    // let decay_index: f64 = index_e + index_s as f64;
+                    // asg.update_activity_decay(1.0 - 1.0 / decay_index);
                 }
-                // if new_envelope {
-                //     let base = state.stm.current_segment();
-                //     let decay_index: f64 = (20 + 2 * base) as f64;
-                //     asg.update_activity_decay((decay_index - 1.0) / decay_index);
-                // }
 
                 #[cfg(feature = "stochastic_local_search")]
                 {
@@ -410,13 +408,6 @@ fn search(
                     processing_pressure = 0;
                 }
             }
-            // if state.stm.current_span() >= 8192 {
-            //     stable_search = !stable_search;
-            //     asg.ordering_by_conflict = stable_search;
-            // } else {
-            //     asg.ordering_by_conflict = false;
-            // }
-
             if num_learnts > restart_interval {
                 cdb.reduce(asg, state.stm.envelop_index());
                 num_learnts = 0;
@@ -430,17 +421,17 @@ fn search(
             state.progress(asg, cdb);
             if state.stm.current_span() >= 8192 {
                 state.flush(if asg.ordering_by_conflict {
-                    "deep stable search..."
+                    "deep focused search..."
                 } else {
-                    "deep search..."
+                    "deep stable search..."
                 });
             } else {
                 state.flush(format!(
-                    "{}assign trend: {:.3}",
+                    "{} assign trend: {:.3}",
                     if asg.ordering_by_conflict {
-                        "stable "
+                        "focused"
                     } else {
-                        ""
+                        "stable"
                     },
                     1.0 / unreachable_ema.trend()
                 ));

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -223,6 +223,8 @@ fn search(
     let cooling_length_base: usize = 2;
     let mut cooling_length: usize = cooling_length_base;
     let mut count: usize = 0;
+    let mut unreachable_ema: Ema2 = Ema2::new(80).with_slow(1000);
+    let mut unreachable_threshold: usize = 0;
 
     state.stm.reset();
     asg.update_activity_decay(0.98);
@@ -247,15 +249,38 @@ fn search(
             restart_pressure += 1;
             cooling_length = cooling_length_base;
             lbd_threshold = cdb.lbd.get_slow() as u16;
-        } else if 1 < lbd {
-            num_learnts += 1;
-            if after_restart >= cooling_length {
-                if restart_pressure == 0 {
-                    lbd_threshold = cdb.lbd.get_slow() as u16;
-                }
-                if lbd > lbd_threshold {
+        } else {
+            if 1 < lbd {
+                num_learnts += 1;
+            }
+            let num_unassigns = asg.derefer(assign::property::Tusize::NumUnassignedVar);
+            unreachable_ema.update(num_unassigns as f64);
+            if !asg.ordering_by_conflict
+                && ((num_unassigns as f64).log10() * 2.0) as usize + num_unassigns
+                    < unreachable_ema.get() as usize
+            {
+                state.flush("");
+                state.flush("switch to stable search mode");
+                asg.ordering_by_conflict = true;
+                asg.rebuild_order();
+                // state.stm.extend(1000);
+                unreachable_threshold = num_unassigns;
+            }
+            if asg.ordering_by_conflict {
+                if num_unassigns > unreachable_threshold {
                     restart_pressure += 1;
-                    lbd = lbd_threshold;
+                } else {
+                    unreachable_threshold = num_unassigns;
+                }
+            } else {
+                if after_restart >= cooling_length {
+                    if restart_pressure == 0 {
+                        lbd_threshold = cdb.lbd.get_slow() as u16;
+                    }
+                    if lbd > lbd_threshold {
+                        restart_pressure += 1;
+                        lbd = lbd_threshold;
+                    }
                 }
             }
             cdb.lbd.update(lbd);
@@ -279,6 +304,10 @@ fn search(
             restart_pressure = 0;
             lbd_threshold = 0;
             RESTART!(asg, cdb, state);
+            // if asg.ordering_by_conflict {
+            //     asg.ordering_by_conflict = false;
+            //     asg.rebuild_order();
+            // }
             asg.clear_asserted_literals(cdb)?;
 
             dump_stage(asg, cdb, state, previous_span);
@@ -299,7 +328,19 @@ fn search(
                         state.stm.current_segment() - state.stm.envelope_starting_segment();
                     let decay_index: f64 = index_e + index_s as f64;
                     asg.update_activity_decay(1.0 - 1.0 / decay_index);
+                    if new_envelope && asg.ordering_by_conflict {
+                        asg.ordering_by_conflict = false;
+                        asg.rebuild_order();
+                    }
+                    // if asg.ordering_by_conflict {
+                    //     asg.rebuild_order();
+                    // }
                 }
+                // if new_envelope {
+                //     let base = state.stm.current_segment();
+                //     let decay_index: f64 = (20 + 2 * base) as f64;
+                //     asg.update_activity_decay((decay_index - 1.0) / decay_index);
+                // }
 
                 #[cfg(feature = "stochastic_local_search")]
                 {
@@ -368,14 +409,13 @@ fn search(
                     }
                     processing_pressure = 0;
                 }
-                if new_envelope {
-                    {
-                        let base = state.stm.current_segment();
-                        let decay_index: f64 = (20 + 2 * base) as f64;
-                        asg.update_activity_decay((decay_index - 1.0) / decay_index);
-                    }
-                }
             }
+            // if state.stm.current_span() >= 8192 {
+            //     stable_search = !stable_search;
+            //     asg.ordering_by_conflict = stable_search;
+            // } else {
+            //     asg.ordering_by_conflict = false;
+            // }
 
             if num_learnts > restart_interval {
                 cdb.reduce(asg, state.stm.envelop_index());
@@ -389,14 +429,24 @@ fn search(
         if count.is_multiple_of(10_000) {
             state.progress(asg, cdb);
             if state.stm.current_span() >= 8192 {
-                state.flush("deep search...");
+                state.flush(if asg.ordering_by_conflict {
+                    "deep stable search..."
+                } else {
+                    "deep search..."
+                });
+            } else {
+                state.flush(format!(
+                    "{}assign trend: {:.3}",
+                    if asg.ordering_by_conflict {
+                        "stable "
+                    } else {
+                        ""
+                    },
+                    1.0 / unreachable_ema.trend()
+                ));
             }
         }
         if let Some(na) = asg.best_assigned() {
-            if na < current_core {
-                cooling_length += 1;
-                state.stm.extend(10_000);
-            }
             if current_core < na && core_was_rebuilt.is_none() {
                 core_was_rebuilt = Some(current_core);
             }

--- a/src/solver/stage.rs
+++ b/src/solver/stage.rs
@@ -81,6 +81,10 @@ impl StageManager {
     pub fn current_segment_length(&self) -> usize {
         self.luby_iter.segment_len() as usize
     }
+    /// returns the zero-based index in the current segment
+    pub fn current_index_in_segment(&self) -> usize {
+        self.luby_iter.ix_in_seg as usize
+    }
     /// returns a recommending number of redicible learnt clauses, based on
     /// the length of span.
     pub fn num_reducible(&self, reducing_factor: f64) -> usize {
@@ -94,9 +98,6 @@ impl StageManager {
     /// None: `luby_iter.max_value` holds the maximum value so far.
     /// This means it is the value found at the last segment.
     /// So the current value should be the next value, which is the double.
-    pub fn max_scale(&self) -> usize {
-        self.envelope_hight
-    }
     pub fn envelope_starting_segment(&self) -> usize {
         self.envelope_starting_segment
     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -539,7 +539,7 @@ impl StateIF for State {
                 cdb_num_clause - cdb_num_learnt
             ),
         );
-        self[LogUsizeId::StageSegment] = stg_segment;
+        self[LogUsizeId::LubyEnvelope] = stg_segment;
         self[LogF64Id::RestartEnergy] = rst_eng;
         println!(
             "\x1B[2K    Conflict|entg:{}, cLvl:{}, bLvl:{}, /cpr:{}",
@@ -607,8 +607,7 @@ impl StateIF for State {
                 0.01
             ),
         );
-        self[LogUsizeId::Stage] = self.stm.current_segment();
-        self[LogUsizeId::StageCycle] = self.stm.envelop_index();
+        self[LogUsizeId::LubySegment] = self.stm.current_segment();
         self[LogUsizeId::Vivify] = self[Stat::Vivification];
         if self.config.show_cdb_heatmap {
             let big_change = 0.002;
@@ -750,9 +749,8 @@ impl State {
         self[LogUsizeId::PermanentClause] =
             cdb.derefer(cdb::property::Tusize::NumClause) - self[LogUsizeId::RemovableClause];
         self[LogUsizeId::Restart] = self[Stat::Restart];
-        self[LogUsizeId::Stage] = self.stm.current_segment();
-        self[LogUsizeId::StageCycle] = self.stm.envelop_index();
-        self[LogUsizeId::StageSegment] = self.stm.max_scale();
+        self[LogUsizeId::LubySegment] = self.stm.current_segment();
+        self[LogUsizeId::LubyEnvelope] = self.stm.envelop_index();
         self[LogUsizeId::Simplify] = self[Stat::Simplify];
         self[LogUsizeId::SubsumedClause] = self[Stat::SubsumedClause];
         self[LogUsizeId::VivifiedClause] = self[Stat::VivifiedClause];
@@ -891,11 +889,10 @@ pub enum LogUsizeId {
     Restart,
 
     //
-    //## stage
+    //## Luby Segment
     //
-    Stage,
-    StageCycle,
-    StageSegment,
+    LubySegment,
+    LubyEnvelope,
 
     //
     //## pre(in)-processor
@@ -1082,8 +1079,8 @@ pub mod property {
         //
         NumCycle,
         NumStage,
-        IntervalScale,
-        IntervalScaleMax,
+        SegmentLength,
+        SegmentLengthMax,
     }
 
     pub const USIZES: [Tusize; 7] = [
@@ -1092,8 +1089,8 @@ pub mod property {
         Tusize::VivifiedVar,
         Tusize::NumCycle,
         Tusize::NumStage,
-        Tusize::IntervalScale,
-        Tusize::IntervalScaleMax,
+        Tusize::SegmentLength,
+        Tusize::SegmentLengthMax,
     ];
 
     impl PropertyDereference<Tusize, usize> for State {
@@ -1105,8 +1102,8 @@ pub mod property {
                 Tusize::VivifiedVar => self[Stat::VivifiedVar],
                 Tusize::NumCycle => self.stm.envelop_index(),
                 Tusize::NumStage => self.stm.current_segment(),
-                Tusize::IntervalScale => self.stm.current_segment_length(),
-                Tusize::IntervalScaleMax => self.stm.max_scale(),
+                Tusize::SegmentLength => self.stm.current_segment_length(),
+                Tusize::SegmentLengthMax => self.stm.envelop_index(),
             }
         }
     }

--- a/src/types/luby.rs
+++ b/src/types/luby.rs
@@ -3,8 +3,11 @@ use std::fmt;
 
 #[derive(Clone, Debug)]
 pub struct LubySegment {
+    /// the corresponding `N`
     pub as_n: usize,
+    /// one-based segment index
     pub seg_index: u32,
+    /// zero-based index in the current segment
     pub ix_in_seg: u32,
 }
 

--- a/src/types/var.rs
+++ b/src/types/var.rs
@@ -21,7 +21,8 @@ pub struct Var {
     pub(crate) flags: FlagVar,
     /// a dynamic evaluation criterion.
     pub(crate) reward: f64,
-    // reward_ema: Ema2,
+    /// the last conflict by this
+    pub(crate) last_conflict: usize,
 }
 
 impl Default for Var {
@@ -34,7 +35,7 @@ impl Default for Var {
             reason_saved: AssignReason::None,
             flags: FlagVar::empty(),
             reward: 0.0,
-            // reward_ema: Ema2::new(200).with_slow(4_000),
+            last_conflict: 0,
         }
     }
 }


### PR DESCRIPTION
# Kissat Search Modes Summary

Kissat alternates between two search modes — **focused** and **stable** — each
using a different variable-ordering heuristic.  The `stable` option controls
which modes are enabled.

## Focused Mode (VMTF)

* **Heuristic:** Variable Move To Front (VMTF).
* **Data structure:** A doubly-linked list (queue) where every variable carries
  a monotonically increasing *stamp*.
* **Decision rule:** Walk backward from the tail of the queue and pick the first
  unassigned variable (the one with the highest stamp).
* **Bumping:** After a conflict, every variable involved in the conflict analysis
  is moved to the end of the queue, receiving a fresh (highest) stamp.  This
  makes recently conflicting variables the most preferred for future decisions.
* **Restart strategy:** Glucose-style EMA (exponential moving average) restarts.
  A restart triggers when the *fast* glue average exceeds the *slow* glue
  average (scaled by `restartmargin`).  This is aggressive and adaptive —
  the solver restarts frequently whenever recent clause quality degrades.

## Stable Mode (EVSIDS)

* **Heuristic:** Exponential Variable State Independent Decaying Sum (EVSIDS),
  the modern variant of VSIDS.
* **Data structure:** A max-heap of variables keyed by floating-point *scores*.
* **Decision rule:** Pop the root of the heap — the unassigned variable with the
  highest score.
* **Bumping:** After a conflict, each analyzed variable's score is incremented by
  `scinc` (the current score increment).  The heap is then re-heapified.
* **Decay:** Instead of decaying all scores, `scinc` is multiplied by
  `1 / (1 − decay/1000)` after every conflict (the `decay` option defaults to
  50, i.e. 5%).  This achieves exponential decay of older bumps relative to
  newer ones.  When scores exceed 10^150 (`MAX_SCORE`), all scores and `scinc`
  are rescaled down.
* **Restart strategy:** Stable mode uses a *reluctant doubling* restart schedule.

## Mode Switching

### The `stable` option

| Value | Behaviour                                          |
|------:|----------------------------------------------------|
|   0   | Only focused mode; never switches.                 |
|   1   | **(default)** Alternates between focused and stable. |
|   2   | Only stable mode; never switches.                  |

### When does a switch happen?

The solver always starts in **focused** mode.  Mode switching is checked on
every iteration of the main search loop in `search.c`:

```
if (kissat_switching_search_mode (solver))
    kissat_switch_search_mode (solver);
```

The trigger condition depends on the current mode:

* **Focused → Stable:** switches when the number of *conflicts* exceeds a limit.
  The initial limit is `modeinit` (default 1000) conflicts.  Subsequent focused
  limits use `modeint × n·log⁴(n)` additional conflicts, where *n* is the
  number of completed mode cycles — so focused phases grow progressively longer.
* **Stable → Focused:** switches when the number of *search ticks* exceeds a
  limit.  The tick budget for a stable phase equals the number of ticks consumed
  by the preceding focused phase, effectively mirroring its duration.

### What happens at a switch?

| Transition        | Key actions                                                 |
|-------------------|-------------------------------------------------------------|
| Focused → Stable  | Set `solver->stable = true`, initialise reluctant-doubling restarts, synchronise the EVSIDS score heap (`kissat_update_scores`). |
| Stable → Focused  | Set `solver->stable = false`, reset the VMTF queue search pointer (`kissat_reset_search_of_queue`), reset the focused restart limit. |

In both directions the solver also reinitialises its running averages and
computes the next mode-switching limit.

### Relevant options

| Option      | Default | Description                                      |
|-------------|--------:|--------------------------------------------------|
| `stable`    |       1 | Enable mode switching (0 = focused only, 2 = stable only). |
| `modeinit`  |    1000 | Conflicts before the first switch to stable mode. |
| `modeint`   |    1000 | Base conflict interval for focused-mode limits.   |
| `decay`     |      50 | Score decay in per mille (EVSIDS, stable mode).   |