### PR TITLE
Revise memory layout 20260410

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ instant = { version = "0.1", features = ["wasm-bindgen"], optional = true }
 [features]
 default = [
     ### Essential
-    "unsafe_access",
     # "chrono_BT",
     "trail_saving",
     "BT_deepen",
@@ -65,7 +64,6 @@ trace_analysis = []             # for debug
 trace_elimination = []          # for debug
 trace_propagation = []          # for debug
 trail_saving = []               # reduce propagation cost by reusing propagation chain
-unsafe_access = []              # access elements of vectors without boundary checking
 
 [profile.release]
 lto = "fat"

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,6 +17,7 @@
 - remove feature 'suppress_reason_chain'
 - remove feature 'trace_equivalency'
 - remove feature 'two_mode_reduction'
+- remove feature 'unsafe_access'
 - rename feature 'debug_propagation' to 'trace_propagation'
 - remove src/solver/restart.rs
 

--- a/src/assign/propagate.rs
+++ b/src/assign/propagate.rs
@@ -1,7 +1,6 @@
 // implement boolean constraint propagation, backjump
 // This version can handle Chronological and Non Chronological Backtrack.
 use {
-    super::stack::{BOTTOM, FALSE, TRUE, lit_val_to_option},
     super::{AssignIF, AssignStack, VarManipulateIF, heap::VarHeapIF},
     crate::{cdb::ClauseDBIF, types::*},
 };
@@ -44,13 +43,13 @@ pub trait PropagateIF {
 #[cfg(feature = "unsafe_access")]
 macro_rules! var_assign {
     ($asg: expr, $var: expr) => {
-        unsafe { lit_val_to_option(*$asg.lit_val.get_unchecked(2 * $var + 1)) }
+        unsafe { *$asg.lit_val.get_unchecked(2 * $var + 1) }
     };
 }
 #[cfg(not(feature = "unsafe_access"))]
 macro_rules! var_assign {
     ($asg: expr, $var: expr) => {
-        lit_val_to_option($asg.lit_val[2 * $var + 1])
+        $asg.lit_val[2 * $var + 1]
     };
 }
 
@@ -58,7 +57,7 @@ macro_rules! var_assign {
 macro_rules! lit_assign {
     ($asg: expr, $lit: expr) => {
         match $lit {
-            l => unsafe { lit_val_to_option(*$asg.lit_val.get_unchecked(usize::from(l))) },
+            l => unsafe { *$asg.lit_val.get_unchecked(usize::from(l)) },
         }
     };
 }
@@ -66,7 +65,7 @@ macro_rules! lit_assign {
 macro_rules! lit_assign {
     ($asg: expr, $lit: expr) => {
         match $lit {
-            l => lit_val_to_option($asg.lit_val[usize::from(l)]),
+            l => $asg.lit_val[usize::from(l)],
         }
     };
 }
@@ -77,8 +76,8 @@ macro_rules! set_assign {
         match $lit {
             l => unsafe {
                 let ord = usize::from(l);
-                *$asg.lit_val.get_unchecked_mut(ord) = TRUE;
-                *$asg.lit_val.get_unchecked_mut(ord ^ 1) = FALSE;
+                *$asg.lit_val.get_unchecked_mut(ord) = Some(true);
+                *$asg.lit_val.get_unchecked_mut(ord ^ 1) = Some(false);
             },
         }
     };
@@ -89,18 +88,19 @@ macro_rules! set_assign {
         match $lit {
             l => {
                 let ord = usize::from(l);
-                $asg.lit_val[ord] = TRUE;
-                $asg.lit_val[ord ^ 1] = FALSE;
+                $asg.lit_val[ord] = Some(true);
+                $asg.lit_val[ord ^ 1] = Some(false);
             }
         }
     };
 }
 
 macro_rules! unset_assign {
-    ($asg: expr, $var: expr) => {
-        $asg.lit_val[2 * $var] = BOTTOM;
-        $asg.lit_val[2 * $var + 1] = BOTTOM;
-    };
+    ($asg: expr, $lit: expr) => {{
+        let ord = usize::from($lit);
+        $asg.lit_val[ord] = None;
+        $asg.lit_val[ord ^ 1] = None;
+    }};
 }
 
 impl PropagateIF for AssignStack {
@@ -205,7 +205,7 @@ impl PropagateIF for AssignStack {
         for i in lim..self.trail.len() {
             let l = self.trail[i];
             debug_assert!(
-                self.lit_val[2 * l.vi()] != BOTTOM || self.lit_val[2 * l.vi() + 1] != BOTTOM,
+                self.lit_val[usize::from(l)].is_some(),
                 "cancel_until found unassigned var in trail {}{:?}",
                 l.vi(),
                 &self.var[l.vi()],
@@ -232,13 +232,13 @@ impl PropagateIF for AssignStack {
                 continue;
             }
 
-            let phase = self.lit_val[2 * vi + 1] == TRUE;
+            let phase = bool::from(l);
             let v = &mut self.var[vi];
             #[cfg(feature = "trace_propagation")]
             v.turn_off(FlagVar::PROPAGATED);
             v.set(FlagVar::PHASE, phase);
 
-            unset_assign!(self, vi);
+            unset_assign!(self, l);
             if let AssignReason::Implication(cid) = self.var[vi].reason {
                 cdb[cid].turn_off(FlagClause::ASSIGN_REASON);
             }
@@ -286,7 +286,7 @@ impl PropagateIF for AssignStack {
             let l = self.trail[i];
             let vi = l.vi();
             debug_assert!(self.root_level < self.var[vi].level);
-            unset_assign!(self, vi);
+            unset_assign!(self, l);
             self.var[vi].reason = AssignReason::None;
             self.insert_heap(vi);
         }
@@ -732,11 +732,8 @@ impl AssignStack {
             self.best_phases.clear();
             for l in self.trail.iter().skip(self.len_upto(self.root_level)) {
                 let vi = l.vi();
-                let val = self.lit_val[2 * vi + 1];
-                if val != BOTTOM {
-                    let b = val == TRUE;
-                    self.best_phases.insert(vi, (b, self.var[vi].reason));
-                }
+                self.best_phases
+                    .insert(vi, (bool::from(*l), self.var[vi].reason));
             }
         }
         self.build_best_at = self.num_propagation;

--- a/src/assign/propagate.rs
+++ b/src/assign/propagate.rs
@@ -69,8 +69,10 @@ macro_rules! set_assign {
 macro_rules! unset_assign {
     ($asg: expr, $lit: expr) => {{
         let ord = usize::from($lit);
-        $asg.lit_val[ord] = None;
-        $asg.lit_val[ord ^ 1] = None;
+        unsafe {
+            *$asg.lit_val.get_unchecked_mut(ord) = None;
+            *$asg.lit_val.get_unchecked_mut(ord ^ 1) = None;
+        }
     }};
 }
 
@@ -120,8 +122,10 @@ impl PropagateIF for AssignStack {
         debug_assert!(self.trail.iter().all(|rl| *rl != l));
         set_assign!(self, l);
 
-        self.var[vi].level = lv;
-        self.var[vi].reason = reason;
+        // SAFETY: vi = l.vi(), already debug_assert!(l.vi() < self.var.len()) at top
+        let v = unsafe { self.var.get_unchecked_mut(vi) };
+        v.level = lv;
+        v.reason = reason;
         self.reward_at_assign(vi);
         debug_assert!(!self.trail.contains(&l));
         debug_assert!(!self.trail.contains(&!l));
@@ -168,7 +172,8 @@ impl PropagateIF for AssignStack {
         let mut unpropagated: Vec<Lit> = Vec::new();
 
         // We assume that backtrack is never happened in level zero.
-        let lim = self.trail_lim[lv as usize];
+        // SAFETY: lv < trail_lim.len() is guaranteed by the early-return check above
+        let lim = unsafe { *self.trail_lim.get_unchecked(lv as usize) };
 
         #[cfg(feature = "trail_saving")]
         self.save_trail(lv);
@@ -182,6 +187,7 @@ impl PropagateIF for AssignStack {
                 &self.var[l.vi()],
             );
             let vi = l.vi();
+            debug_assert!(vi < self.var.len());
             #[cfg(feature = "trace_propagation")]
             debug_assert!(
                 self.q_head <= i || self.var[vi].is(Flag::PROPAGATED),
@@ -198,22 +204,23 @@ impl PropagateIF for AssignStack {
             );
 
             #[cfg(feature = "chrono_BT")]
-            if self.var[vi].level <= lv {
+            if unsafe { self.var.get_unchecked(vi) }.level <= lv {
                 unpropagated.push(l);
                 continue;
             }
 
             let phase = bool::from(l);
-            let v = &mut self.var[vi];
+            // SAFETY: vi < self.var.len() per debug_assert! above
+            let v = unsafe { self.var.get_unchecked_mut(vi) };
             #[cfg(feature = "trace_propagation")]
             v.turn_off(FlagVar::PROPAGATED);
             v.set(FlagVar::PHASE, phase);
 
             unset_assign!(self, l);
-            if let AssignReason::Implication(cid) = self.var[vi].reason {
+            if let AssignReason::Implication(cid) = unsafe { self.var.get_unchecked(vi) }.reason {
                 cdb[cid].turn_off(FlagClause::ASSIGN_REASON);
             }
-            self.var[vi].reason = AssignReason::None;
+            unsafe { self.var.get_unchecked_mut(vi) }.reason = AssignReason::None;
 
             #[cfg(not(feature = "trail_saving"))]
             {

--- a/src/assign/propagate.rs
+++ b/src/assign/propagate.rs
@@ -40,20 +40,12 @@ pub trait PropagateIF {
     fn clear_asserted_literals(&mut self, cdb: &mut impl ClauseDBIF) -> MaybeInconsistent;
 }
 
-#[cfg(feature = "unsafe_access")]
 macro_rules! var_assign {
     ($asg: expr, $var: expr) => {
         unsafe { *$asg.lit_val.get_unchecked(2 * $var + 1) }
     };
 }
-#[cfg(not(feature = "unsafe_access"))]
-macro_rules! var_assign {
-    ($asg: expr, $var: expr) => {
-        $asg.lit_val[2 * $var + 1]
-    };
-}
 
-#[cfg(feature = "unsafe_access")]
 macro_rules! lit_assign {
     ($asg: expr, $lit: expr) => {
         match $lit {
@@ -61,16 +53,7 @@ macro_rules! lit_assign {
         }
     };
 }
-#[cfg(not(feature = "unsafe_access"))]
-macro_rules! lit_assign {
-    ($asg: expr, $lit: expr) => {
-        match $lit {
-            l => $asg.lit_val[usize::from(l)],
-        }
-    };
-}
 
-#[cfg(feature = "unsafe_access")]
 macro_rules! set_assign {
     ($asg: expr, $lit: expr) => {
         match $lit {
@@ -79,18 +62,6 @@ macro_rules! set_assign {
                 *$asg.lit_val.get_unchecked_mut(ord) = Some(true);
                 *$asg.lit_val.get_unchecked_mut(ord ^ 1) = Some(false);
             },
-        }
-    };
-}
-#[cfg(not(feature = "unsafe_access"))]
-macro_rules! set_assign {
-    ($asg: expr, $lit: expr) => {
-        match $lit {
-            l => {
-                let ord = usize::from(l);
-                $asg.lit_val[ord] = Some(true);
-                $asg.lit_val[ord ^ 1] = Some(false);
-            }
         }
     };
 }
@@ -374,12 +345,7 @@ impl PropagateIF for AssignStack {
                             blocker,
                             AssignReason::BinaryLink(propagating),
                             if cfg!(feature = "chrono_BT") {
-                                #[cfg(feature = "unsafe_access")]
-                                unsafe {
-                                    self.var.get_unchecked(propagating.vi()).level
-                                }
-                                #[cfg(not(feature = "unsafe_access"))]
-                                self.var[propagating.vi()].level
+                                unsafe { self.var.get_unchecked(propagating.vi()).level }
                             } else {
                                 dl
                             },
@@ -474,14 +440,7 @@ impl PropagateIF for AssignStack {
                         cdb[cid]
                             .iter()
                             .skip(1)
-                            .map(|l| {
-                                #[cfg(feature = "unsafe_access")]
-                                unsafe {
-                                    self.var.get_unchecked(l.vi()).level
-                                }
-                                #[cfg(not(feature = "unsafe_access"))]
-                                self.var[l.vi()].level
-                            })
+                            .map(|l| unsafe { self.var.get_unchecked(l.vi()).level })
                             .max()
                             .unwrap_or(self.root_level)
                     } else {

--- a/src/assign/propagate.rs
+++ b/src/assign/propagate.rs
@@ -308,23 +308,11 @@ impl PropagateIF for AssignStack {
                 self.ppc_ema.update(self.num_propagation);
                 self.num_conflict += 1;
                 {
-                    // let d = self.num_conflict - self.var[$lit.vi()].last_conflict;
-                    // let f: f64 = 1.0 / (d as f64 + 1.0).log2();
-                    // let f: f64 = 1.0 / d as f64;
                     let vi = $lit.vi();
-                    #[cfg(feature = "unsafe_access")]
-                    let f = unsafe { self.var.get_unchecked(vi).reward };
-                    #[cfg(not(feature = "unsafe_access"))]
-                    let f = self.var[vi].reward;
+                    let d = self.num_conflict - unsafe { self.var.get_unchecked(vi).last_conflict };
+                    let f: f64 = 1.0 / (d as f64 + 1.0).log2();
                     self.conflict_interval_index.update(f);
-                    #[cfg(feature = "unsafe_access")]
-                    unsafe {
-                        self.var.get_unchecked_mut(vi).last_conflict = self.num_conflict
-                    };
-                    #[cfg(not(feature = "unsafe_access"))]
-                    {
-                        self.var[vi].last_conflict = self.num_conflict;
-                    }
+                    unsafe { self.var.get_unchecked_mut(vi).last_conflict = self.num_conflict };
                 }
                 return Err(($lit, $reason));
             };

--- a/src/assign/propagate.rs
+++ b/src/assign/propagate.rs
@@ -311,10 +311,21 @@ impl PropagateIF for AssignStack {
                     // let d = self.num_conflict - self.var[$lit.vi()].last_conflict;
                     // let f: f64 = 1.0 / (d as f64 + 1.0).log2();
                     // let f: f64 = 1.0 / d as f64;
-                    let f = self.var[$lit.vi()].reward;
+                    let vi = $lit.vi();
+                    #[cfg(feature = "unsafe_access")]
+                    let f = unsafe { self.var.get_unchecked(vi).reward };
+                    #[cfg(not(feature = "unsafe_access"))]
+                    let f = self.var[vi].reward;
                     self.conflict_interval_index.update(f);
+                    #[cfg(feature = "unsafe_access")]
+                    unsafe {
+                        self.var.get_unchecked_mut(vi).last_conflict = self.num_conflict
+                    };
+                    #[cfg(not(feature = "unsafe_access"))]
+                    {
+                        self.var[vi].last_conflict = self.num_conflict;
+                    }
                 }
-                self.var[$lit.vi()].last_conflict = self.num_conflict;
                 return Err(($lit, $reason));
             };
         }
@@ -375,6 +386,11 @@ impl PropagateIF for AssignStack {
                             blocker,
                             AssignReason::BinaryLink(propagating),
                             if cfg!(feature = "chrono_BT") {
+                                #[cfg(feature = "unsafe_access")]
+                                unsafe {
+                                    self.var.get_unchecked(propagating.vi()).level
+                                }
+                                #[cfg(not(feature = "unsafe_access"))]
                                 self.var[propagating.vi()].level
                             } else {
                                 dl
@@ -470,7 +486,14 @@ impl PropagateIF for AssignStack {
                         cdb[cid]
                             .iter()
                             .skip(1)
-                            .map(|l| self.var[l.vi()].level)
+                            .map(|l| {
+                                #[cfg(feature = "unsafe_access")]
+                                unsafe {
+                                    self.var.get_unchecked(l.vi()).level
+                                }
+                                #[cfg(not(feature = "unsafe_access"))]
+                                self.var[l.vi()].level
+                            })
                             .max()
                             .unwrap_or(self.root_level)
                     } else {

--- a/src/assign/propagate.rs
+++ b/src/assign/propagate.rs
@@ -1,6 +1,7 @@
 // implement boolean constraint propagation, backjump
 // This version can handle Chronological and Non Chronological Backtrack.
 use {
+    super::stack::{BOTTOM, FALSE, TRUE, lit_val_to_option},
     super::{AssignIF, AssignStack, VarManipulateIF, heap::VarHeapIF},
     crate::{cdb::ClauseDBIF, types::*},
 };
@@ -43,13 +44,13 @@ pub trait PropagateIF {
 #[cfg(feature = "unsafe_access")]
 macro_rules! var_assign {
     ($asg: expr, $var: expr) => {
-        unsafe { $asg.var.get_unchecked($var).assign }
+        unsafe { lit_val_to_option(*$asg.lit_val.get_unchecked(2 * $var + 1)) }
     };
 }
 #[cfg(not(feature = "unsafe_access"))]
 macro_rules! var_assign {
     ($asg: expr, $var: expr) => {
-        $asg.assign[$var]
+        lit_val_to_option($asg.lit_val[2 * $var + 1])
     };
 }
 
@@ -57,10 +58,7 @@ macro_rules! var_assign {
 macro_rules! lit_assign {
     ($asg: expr, $lit: expr) => {
         match $lit {
-            l => match unsafe { $asg.var.get_unchecked(l.vi()).assign } {
-                Some(x) if !bool::from(l) => Some(!x),
-                x => x,
-            },
+            l => unsafe { lit_val_to_option(*$asg.lit_val.get_unchecked(usize::from(l))) },
         }
     };
 }
@@ -68,10 +66,7 @@ macro_rules! lit_assign {
 macro_rules! lit_assign {
     ($asg: expr, $lit: expr) => {
         match $lit {
-            l => match $asg.assign[l.vi()] {
-                Some(x) if !bool::from(l) => Some(!x),
-                x => x,
-            },
+            l => lit_val_to_option($asg.lit_val[usize::from(l)]),
         }
     };
 }
@@ -81,8 +76,9 @@ macro_rules! set_assign {
     ($asg: expr, $lit: expr) => {
         match $lit {
             l => unsafe {
-                let vi = l.vi();
-                $asg.var.get_unchecked_mut(vi).assign = Some(bool::from(l));
+                let ord = usize::from(l);
+                *$asg.lit_val.get_unchecked_mut(ord) = TRUE;
+                *$asg.lit_val.get_unchecked_mut(ord ^ 1) = FALSE;
             },
         }
     };
@@ -92,8 +88,9 @@ macro_rules! set_assign {
     ($asg: expr, $lit: expr) => {
         match $lit {
             l => {
-                let vi = l.vi();
-                $asg.assign[vi] = Some(bool::from(l));
+                let ord = usize::from(l);
+                $asg.lit_val[ord] = TRUE;
+                $asg.lit_val[ord ^ 1] = FALSE;
             }
         }
     };
@@ -101,7 +98,8 @@ macro_rules! set_assign {
 
 macro_rules! unset_assign {
     ($asg: expr, $var: expr) => {
-        $asg.var[$var].assign = None;
+        $asg.lit_val[2 * $var] = BOTTOM;
+        $asg.lit_val[2 * $var + 1] = BOTTOM;
     };
 }
 
@@ -142,10 +140,10 @@ impl PropagateIF for AssignStack {
             var_assign!(self, vi) == Some(bool::from(l)) || var_assign!(self, vi).is_none(),
             "wrong assignmentto {:?}: {:?} by {:?} ",
             l,
-            self.var[vi].assign,
+            var_assign!(self, vi),
             reason
         );
-        debug_assert_eq!(self.var[vi].assign, None);
+        debug_assert_eq!(var_assign!(self, vi), None);
         debug_assert_eq!(self.var[vi].reason, AssignReason::None);
         debug_assert_ne!(self.var[vi].reason, reason);
         debug_assert!(self.trail.iter().all(|rl| *rl != l));
@@ -177,7 +175,7 @@ impl PropagateIF for AssignStack {
         let v = &mut self.var[vi];
         v.level = dl;
         debug_assert!(!v.is(FlagVar::ELIMINATED));
-        debug_assert_eq!(self.var[vi].assign, None);
+        debug_assert_eq!(var_assign!(self, vi), None);
         debug_assert_eq!(self.var[vi].reason, AssignReason::None);
         set_assign!(self, l);
         self.var[vi].reason = AssignReason::Decision(self.decision_level());
@@ -207,7 +205,7 @@ impl PropagateIF for AssignStack {
         for i in lim..self.trail.len() {
             let l = self.trail[i];
             debug_assert!(
-                self.var[l.vi()].assign.is_some(),
+                self.lit_val[2 * l.vi()] != BOTTOM || self.lit_val[2 * l.vi() + 1] != BOTTOM,
                 "cancel_until found unassigned var in trail {}{:?}",
                 l.vi(),
                 &self.var[l.vi()],
@@ -234,10 +232,11 @@ impl PropagateIF for AssignStack {
                 continue;
             }
 
+            let phase = self.lit_val[2 * vi + 1] == TRUE;
             let v = &mut self.var[vi];
             #[cfg(feature = "trace_propagation")]
             v.turn_off(FlagVar::PROPAGATED);
-            v.set(FlagVar::PHASE, v.assign.unwrap());
+            v.set(FlagVar::PHASE, phase);
 
             unset_assign!(self, vi);
             if let AssignReason::Implication(cid) = self.var[vi].reason {
@@ -272,9 +271,7 @@ impl PropagateIF for AssignStack {
             self.cpr_ema.update(self.num_conflict);
         }
 
-        debug_assert!(
-            self.q_head == 0 || self.var[self.trail[self.q_head - 1].vi()].assign.is_some()
-        );
+        debug_assert!(self.q_head == 0 || self.assign(self.trail[self.q_head - 1].vi()).is_some());
         #[cfg(feature = "trace_propagation")]
         debug_assert!(
             self.q_head == 0 || self.var[self.trail[self.q_head - 1].vi()].is(FlagVar::PROPAGATED)
@@ -469,7 +466,7 @@ impl PropagateIF for AssignStack {
                     cached,
                     AssignReason::Implication(cid),
                     if cfg!(feature = "chrono_BT") {
-                        debug_assert!(self.var[cdb[cid].lit0().vi()].assign.is_none());
+                        debug_assert!(self.assign(cdb[cid].lit0().vi()).is_none());
                         cdb[cid]
                             .iter()
                             .skip(1)
@@ -712,7 +709,9 @@ impl AssignStack {
             self.best_phases.clear();
             for l in self.trail.iter().skip(self.len_upto(self.root_level)) {
                 let vi = l.vi();
-                if let Some(b) = self.var[vi].assign {
+                let val = self.lit_val[2 * vi + 1];
+                if val != BOTTOM {
+                    let b = val == TRUE;
                     self.best_phases.insert(vi, (b, self.var[vi].reason));
                 }
             }

--- a/src/assign/select.rs
+++ b/src/assign/select.rs
@@ -4,7 +4,6 @@
 use super::property;
 
 use {
-    super::stack::lit_val_to_option,
     super::{heap::VarHeapIF, stack::AssignStack},
     crate::types::*,
     std::collections::HashMap,
@@ -16,13 +15,13 @@ use {
 #[cfg(feature = "unsafe_access")]
 macro_rules! var_assign {
     ($asg: expr, $var: expr) => {
-        unsafe { lit_val_to_option(*$asg.lit_val.get_unchecked(2 * $var + 1)) }
+        unsafe { *$asg.lit_val.get_unchecked(2 * $var + 1) }
     };
 }
 #[cfg(not(feature = "unsafe_access"))]
 macro_rules! var_assign {
     ($asg: expr, $var: expr) => {
-        lit_val_to_option($asg.lit_val[2 * $var + 1])
+        $asg.lit_val[2 * $var + 1]
     };
 }
 
@@ -65,8 +64,7 @@ impl VarSelectIF for AssignStack {
                     Some((
                         vi,
                         self.best_phases.get(&vi).map_or(
-                            lit_val_to_option(self.lit_val[2 * vi + 1])
-                                .unwrap_or_else(|| v.is(FlagVar::PHASE)),
+                            self.lit_val[2 * vi + 1].unwrap_or_else(|| v.is(FlagVar::PHASE)),
                             |(b, _)| *b,
                         ),
                     ))
@@ -112,7 +110,7 @@ impl VarSelectIF for AssignStack {
         debug_assert!(
             self.best_phases
                 .iter()
-                .all(|(vi, b)| lit_val_to_option(self.lit_val[2 * *vi + 1]) != Some(!b.0))
+                .all(|(vi, b)| self.lit_val[2 * *vi + 1] != Some(!b.0))
         );
         self.num_rephase += 1;
         for (vi, (b, _)) in self.best_phases.iter() {
@@ -125,7 +123,7 @@ impl VarSelectIF for AssignStack {
         if self
             .best_phases
             .iter()
-            .any(|(vi, b)| lit_val_to_option(self.lit_val[2 * *vi + 1]) == Some(!b.0))
+            .any(|(vi, b)| self.lit_val[2 * *vi + 1] == Some(!b.0))
         {
             self.best_phases.clear();
             self.num_best_assign = self.num_asserted_vars + self.num_eliminated_vars;

--- a/src/assign/select.rs
+++ b/src/assign/select.rs
@@ -12,16 +12,9 @@ use {
 /// ```ignore
 /// let x: Option<bool> = var_assign!(self, lit.vi());
 /// ```
-#[cfg(feature = "unsafe_access")]
 macro_rules! var_assign {
     ($asg: expr, $var: expr) => {
         unsafe { *$asg.lit_val.get_unchecked(2 * $var + 1) }
-    };
-}
-#[cfg(not(feature = "unsafe_access"))]
-macro_rules! var_assign {
-    ($asg: expr, $var: expr) => {
-        $asg.lit_val[2 * $var + 1]
     };
 }
 

--- a/src/assign/select.rs
+++ b/src/assign/select.rs
@@ -4,6 +4,7 @@
 use super::property;
 
 use {
+    super::stack::lit_val_to_option,
     super::{heap::VarHeapIF, stack::AssignStack},
     crate::types::*,
     std::collections::HashMap,
@@ -15,13 +16,13 @@ use {
 #[cfg(feature = "unsafe_access")]
 macro_rules! var_assign {
     ($asg: expr, $var: expr) => {
-        unsafe { $asg.var.get_unchecked($var).assign }
+        unsafe { lit_val_to_option(*$asg.lit_val.get_unchecked(2 * $var + 1)) }
     };
 }
 #[cfg(not(feature = "unsafe_access"))]
 macro_rules! var_assign {
     ($asg: expr, $var: expr) => {
-        $asg.assign[$var]
+        lit_val_to_option($asg.lit_val[2 * $var + 1])
     };
 }
 
@@ -64,7 +65,8 @@ impl VarSelectIF for AssignStack {
                     Some((
                         vi,
                         self.best_phases.get(&vi).map_or(
-                            self.var[vi].assign.unwrap_or_else(|| v.is(FlagVar::PHASE)),
+                            lit_val_to_option(self.lit_val[2 * vi + 1])
+                                .unwrap_or_else(|| v.is(FlagVar::PHASE)),
                             |(b, _)| *b,
                         ),
                     ))
@@ -110,7 +112,7 @@ impl VarSelectIF for AssignStack {
         debug_assert!(
             self.best_phases
                 .iter()
-                .all(|(vi, b)| self.var[*vi].assign != Some(!b.0))
+                .all(|(vi, b)| lit_val_to_option(self.lit_val[2 * *vi + 1]) != Some(!b.0))
         );
         self.num_rephase += 1;
         for (vi, (b, _)) in self.best_phases.iter() {
@@ -123,7 +125,7 @@ impl VarSelectIF for AssignStack {
         if self
             .best_phases
             .iter()
-            .any(|(vi, b)| self.var[*vi].assign == Some(!b.0))
+            .any(|(vi, b)| lit_val_to_option(self.lit_val[2 * *vi + 1]) == Some(!b.0))
         {
             self.best_phases.clear();
             self.num_best_assign = self.num_asserted_vars + self.num_eliminated_vars;

--- a/src/assign/stack.rs
+++ b/src/assign/stack.rs
@@ -12,6 +12,23 @@ use {
 #[cfg(any(feature = "best_phases_tracking", feature = "rephase"))]
 use std::collections::HashMap;
 
+/// Literal value: unassigned
+pub(super) const BOTTOM: u8 = 0;
+/// Literal value: satisfied (literal evaluates to true)
+pub(super) const TRUE: u8 = 1;
+/// Literal value: falsified (literal evaluates to false)
+pub(super) const FALSE: u8 = 2;
+
+/// Convert a `lit_val` byte to `Option<bool>`.
+#[inline(always)]
+pub(super) fn lit_val_to_option(v: u8) -> Option<bool> {
+    match v {
+        TRUE => Some(true),
+        FALSE => Some(false),
+        _ => None,
+    }
+}
+
 /// A record of assignment. It's called 'trail' in Glucose.
 #[derive(Clone, Debug)]
 pub struct AssignStack {
@@ -81,6 +98,10 @@ pub struct AssignStack {
     pub(super) tick: usize,
     /// vars
     pub(super) var: Vec<Var>,
+    /// Literal-indexed assignment cache (SoA).
+    /// Indexed by `Lit` ordinal: `lit_val[usize::from(lit)]`.
+    /// Values: BOTTOM (unassigned), TRUE (satisfied), FALSE (falsified).
+    pub(super) lit_val: Vec<u8>,
 
     //
     //## Var Rewarding
@@ -135,6 +156,7 @@ impl Default for AssignStack {
 
             tick: 0,
             var: Vec::new(),
+            lit_val: Vec::new(),
 
             activity_decay: 0.94,
 
@@ -171,6 +193,7 @@ impl Instantiate for AssignStack {
             num_vars: cnf.num_of_variables,
 
             var: Var::new_vars(nv),
+            lit_val: vec![BOTTOM; 2 * (nv + 1)],
 
             activity_decay: 1.0 - config.vrw_learning_rate,
 
@@ -192,6 +215,8 @@ impl Instantiate for AssignStack {
                 self.expand_heap();
                 self.num_vars += 1;
                 self.var.push(Var::default());
+                self.lit_val.push(BOTTOM); // negative literal slot
+                self.lit_val.push(BOTTOM); // positive literal slot
             }
             e => panic!("don't call asg with {e:?}"),
         }
@@ -231,7 +256,9 @@ impl AssignIF for AssignStack {
         self.q_head < self.trail.len()
     }
     fn assign_ref(&self) -> Vec<Option<bool>> {
-        self.var.iter().map(|v| v.assign).collect::<Vec<_>>()
+        (0..self.var.len())
+            .map(|vi| lit_val_to_option(self.lit_val[2 * vi + 1]))
+            .collect()
     }
     fn best_assigned(&mut self) -> Option<usize> {
         (self.build_best_at == self.num_propagation).then_some(self.num_vars - self.num_best_assign)
@@ -371,19 +398,16 @@ pub trait VarManipulateIF {
 
 impl VarManipulateIF for AssignStack {
     fn assigned(&self, l: Lit) -> Option<bool> {
-        match self.var[l.vi()].assign {
-            Some(x) if !bool::from(l) => Some(!x),
-            x => x,
-        }
+        lit_val_to_option(self.lit_val[usize::from(l)])
     }
     #[inline]
     fn assign(&self, vi: VarId) -> Option<bool> {
         #[cfg(feature = "unsafe_access")]
         unsafe {
-            self.var.get_unchecked(vi).assign
+            lit_val_to_option(*self.lit_val.get_unchecked(2 * vi + 1))
         }
         #[cfg(not(feature = "unsafe_access"))]
-        self.var[vi].assign
+        lit_val_to_option(self.lit_val[2 * vi + 1])
     }
     #[inline]
     fn level(&self, vi: VarId) -> DecisionLevel {
@@ -447,22 +471,20 @@ impl VarManipulateIF for AssignStack {
             #[cfg(feature = "trace_elimination")]
             {
                 let lv = self.var[vi].level;
-                if self.root_level == self.var[vi].level && self.var[vi].assign.is_some() {
+                if self.root_level == self.var[vi].level && self.assign(vi).is_some() {
                     panic!("v:{}, dl:{}", self.var[vi], self.decision_level());
                 }
-                if !(self.root_level < self.var[vi].level || self.var[vi].assign.is_none()) {
+                if !(self.root_level < self.var[vi].level || self.assign(vi).is_none()) {
                     panic!(
                         "v:{}, lvl:{} => {}, dl:{}, assign:{:?} ",
                         self.var[vi],
                         lv,
                         self.var[vi].level,
                         self.decision_level(),
-                        self.var[vi].assign,
+                        self.assign(vi),
                     );
                 }
-                debug_assert!(
-                    self.root_level < self.var[vi].level || self.var[vi].assign.is_none()
-                );
+                debug_assert!(self.root_level < self.var[vi].level || self.assign(vi).is_none());
             }
         }
     }
@@ -474,8 +496,8 @@ impl AssignStack {
     /// return `true` if the current best phase got invalid.
     fn check_best_phase(&mut self, vi: VarId) -> bool {
         if let Some((b, _)) = self.best_phases.get(&vi) {
-            debug_assert!(self.var[vi].assign.is_some());
-            if self.var[vi].assign != Some(*b) {
+            debug_assert!(self.assign(vi).is_some());
+            if self.assign(vi) != Some(*b) {
                 if self.root_level == self.var[vi].level {
                     self.best_phases.clear();
                     self.num_best_assign = self.num_asserted_vars + self.num_eliminated_vars;

--- a/src/assign/stack.rs
+++ b/src/assign/stack.rs
@@ -382,48 +382,23 @@ impl VarManipulateIF for AssignStack {
     }
     #[inline]
     fn assign(&self, vi: VarId) -> Option<bool> {
-        #[cfg(feature = "unsafe_access")]
-        unsafe {
-            *self.lit_val.get_unchecked(2 * vi + 1)
-        }
-        #[cfg(not(feature = "unsafe_access"))]
-        self.lit_val[2 * vi + 1]
+        unsafe { *self.lit_val.get_unchecked(2 * vi + 1) }
     }
     #[inline]
     fn level(&self, vi: VarId) -> DecisionLevel {
-        #[cfg(feature = "unsafe_access")]
-        unsafe {
-            self.var.get_unchecked(vi).level
-        }
-        #[cfg(not(feature = "unsafe_access"))]
-        self.var[vi].level
+        unsafe { self.var.get_unchecked(vi).level }
     }
     #[inline]
     fn reason(&self, vi: VarId) -> AssignReason {
-        #[cfg(feature = "unsafe_access")]
-        unsafe {
-            self.var.get_unchecked(vi).reason
-        }
-        #[cfg(not(feature = "unsafe_access"))]
-        self.var[vi].reason
+        unsafe { self.var.get_unchecked(vi).reason }
     }
     #[inline]
     fn var(&self, vi: VarId) -> &Var {
-        #[cfg(feature = "unsafe_access")]
-        unsafe {
-            self.var.get_unchecked(vi)
-        }
-        #[cfg(not(feature = "unsafe_access"))]
-        &self.var[vi]
+        unsafe { self.var.get_unchecked(vi) }
     }
     #[inline]
     fn var_mut(&mut self, vi: VarId) -> &mut Var {
-        #[cfg(feature = "unsafe_access")]
-        unsafe {
-            self.var.get_unchecked_mut(vi)
-        }
-        #[cfg(not(feature = "unsafe_access"))]
-        &mut self.var[vi]
+        unsafe { self.var.get_unchecked_mut(vi) }
     }
     fn var_iter(&self) -> Iter<'_, Var> {
         self.var.iter()

--- a/src/assign/stack.rs
+++ b/src/assign/stack.rs
@@ -12,23 +12,6 @@ use {
 #[cfg(any(feature = "best_phases_tracking", feature = "rephase"))]
 use std::collections::HashMap;
 
-/// Literal value: unassigned
-pub(super) const BOTTOM: u8 = 0;
-/// Literal value: satisfied (literal evaluates to true)
-pub(super) const TRUE: u8 = 1;
-/// Literal value: falsified (literal evaluates to false)
-pub(super) const FALSE: u8 = 2;
-
-/// Convert a `lit_val` byte to `Option<bool>`.
-#[inline(always)]
-pub(super) fn lit_val_to_option(v: u8) -> Option<bool> {
-    match v {
-        TRUE => Some(true),
-        FALSE => Some(false),
-        _ => None,
-    }
-}
-
 /// A record of assignment. It's called 'trail' in Glucose.
 #[derive(Clone, Debug)]
 pub struct AssignStack {
@@ -100,8 +83,7 @@ pub struct AssignStack {
     pub(super) var: Vec<Var>,
     /// Literal-indexed assignment cache (SoA).
     /// Indexed by `Lit` ordinal: `lit_val[usize::from(lit)]`.
-    /// Values: BOTTOM (unassigned), TRUE (satisfied), FALSE (falsified).
-    pub(super) lit_val: Vec<u8>,
+    pub(super) lit_val: Vec<Option<bool>>,
 
     //
     //## Var Rewarding
@@ -193,7 +175,7 @@ impl Instantiate for AssignStack {
             num_vars: cnf.num_of_variables,
 
             var: Var::new_vars(nv),
-            lit_val: vec![BOTTOM; 2 * (nv + 1)],
+            lit_val: vec![None; 2 * (nv + 1)],
 
             activity_decay: 1.0 - config.vrw_learning_rate,
 
@@ -215,8 +197,8 @@ impl Instantiate for AssignStack {
                 self.expand_heap();
                 self.num_vars += 1;
                 self.var.push(Var::default());
-                self.lit_val.push(BOTTOM); // negative literal slot
-                self.lit_val.push(BOTTOM); // positive literal slot
+                self.lit_val.push(None); // negative literal slot
+                self.lit_val.push(None); // positive literal slot
             }
             e => panic!("don't call asg with {e:?}"),
         }
@@ -256,9 +238,7 @@ impl AssignIF for AssignStack {
         self.q_head < self.trail.len()
     }
     fn assign_ref(&self) -> Vec<Option<bool>> {
-        (0..self.var.len())
-            .map(|vi| lit_val_to_option(self.lit_val[2 * vi + 1]))
-            .collect()
+        self.lit_val.iter().skip(1).step_by(2).copied().collect()
     }
     fn best_assigned(&mut self) -> Option<usize> {
         (self.build_best_at == self.num_propagation).then_some(self.num_vars - self.num_best_assign)
@@ -398,16 +378,16 @@ pub trait VarManipulateIF {
 
 impl VarManipulateIF for AssignStack {
     fn assigned(&self, l: Lit) -> Option<bool> {
-        lit_val_to_option(self.lit_val[usize::from(l)])
+        self.lit_val[usize::from(l)]
     }
     #[inline]
     fn assign(&self, vi: VarId) -> Option<bool> {
         #[cfg(feature = "unsafe_access")]
         unsafe {
-            lit_val_to_option(*self.lit_val.get_unchecked(2 * vi + 1))
+            *self.lit_val.get_unchecked(2 * vi + 1)
         }
         #[cfg(not(feature = "unsafe_access"))]
-        lit_val_to_option(self.lit_val[2 * vi + 1])
+        self.lit_val[2 * vi + 1]
     }
     #[inline]
     fn level(&self, vi: VarId) -> DecisionLevel {

--- a/src/cdb/binary.rs
+++ b/src/cdb/binary.rs
@@ -14,24 +14,14 @@ impl Index<Lit> for Vec<BinaryLinkList> {
     type Output = BinaryLinkList;
     #[inline]
     fn index(&self, l: Lit) -> &Self::Output {
-        #[cfg(feature = "unsafe_access")]
-        unsafe {
-            self.get_unchecked(usize::from(l))
-        }
-        #[cfg(not(feature = "unsafe_access"))]
-        &self[usize::from(l)]
+        unsafe { self.get_unchecked(usize::from(l)) }
     }
 }
 
 impl IndexMut<Lit> for Vec<BinaryLinkList> {
     #[inline]
     fn index_mut(&mut self, l: Lit) -> &mut Self::Output {
-        #[cfg(feature = "unsafe_access")]
-        unsafe {
-            self.get_unchecked_mut(usize::from(l))
-        }
-        #[cfg(not(feature = "unsafe_access"))]
-        &mut self[usize::from(l)]
+        unsafe { self.get_unchecked_mut(usize::from(l)) }
     }
 }
 

--- a/src/cdb/db.rs
+++ b/src/cdb/db.rs
@@ -129,12 +129,7 @@ impl Index<ClauseId> for ClauseDB {
     #[inline]
     fn index(&self, cid: ClauseId) -> &Clause {
         let i = NonZeroU32::get(cid.ordinal) as usize;
-        #[cfg(feature = "unsafe_access")]
-        unsafe {
-            self.clause.get_unchecked(i)
-        }
-        #[cfg(not(feature = "unsafe_access"))]
-        &self.clause[i]
+        unsafe { self.clause.get_unchecked(i) }
     }
 }
 
@@ -142,12 +137,7 @@ impl IndexMut<ClauseId> for ClauseDB {
     #[inline]
     fn index_mut(&mut self, cid: ClauseId) -> &mut Clause {
         let i = NonZeroU32::get(cid.ordinal) as usize;
-        #[cfg(feature = "unsafe_access")]
-        unsafe {
-            self.clause.get_unchecked_mut(i)
-        }
-        #[cfg(not(feature = "unsafe_access"))]
-        &mut self.clause[i]
+        unsafe { self.clause.get_unchecked_mut(i) }
     }
 }
 
@@ -156,12 +146,7 @@ impl Index<&ClauseId> for ClauseDB {
     #[inline]
     fn index(&self, cid: &ClauseId) -> &Clause {
         let i = NonZeroU32::get(cid.ordinal) as usize;
-        #[cfg(feature = "unsafe_access")]
-        unsafe {
-            self.clause.get_unchecked(i)
-        }
-        #[cfg(not(feature = "unsafe_access"))]
-        &self.clause[i]
+        unsafe { self.clause.get_unchecked(i) }
     }
 }
 
@@ -169,12 +154,7 @@ impl IndexMut<&ClauseId> for ClauseDB {
     #[inline]
     fn index_mut(&mut self, cid: &ClauseId) -> &mut Clause {
         let i = NonZeroU32::get(cid.ordinal) as usize;
-        #[cfg(feature = "unsafe_access")]
-        unsafe {
-            self.clause.get_unchecked_mut(i)
-        }
-        #[cfg(not(feature = "unsafe_access"))]
-        &mut self.clause[i]
+        unsafe { self.clause.get_unchecked_mut(i) }
     }
 }
 
@@ -182,12 +162,7 @@ impl Index<Range<usize>> for ClauseDB {
     type Output = [Clause];
     #[inline]
     fn index(&self, r: Range<usize>) -> &[Clause] {
-        #[cfg(feature = "unsafe_access")]
-        unsafe {
-            self.clause.get_unchecked(r)
-        }
-        #[cfg(not(feature = "unsafe_access"))]
-        &self.clause[r]
+        unsafe { self.clause.get_unchecked(r) }
     }
 }
 
@@ -195,36 +170,21 @@ impl Index<RangeFrom<usize>> for ClauseDB {
     type Output = [Clause];
     #[inline]
     fn index(&self, r: RangeFrom<usize>) -> &[Clause] {
-        #[cfg(feature = "unsafe_access")]
-        unsafe {
-            self.clause.get_unchecked(r)
-        }
-        #[cfg(not(feature = "unsafe_access"))]
-        &self.clause[r]
+        unsafe { self.clause.get_unchecked(r) }
     }
 }
 
 impl IndexMut<Range<usize>> for ClauseDB {
     #[inline]
     fn index_mut(&mut self, r: Range<usize>) -> &mut [Clause] {
-        #[cfg(feature = "unsafe_access")]
-        unsafe {
-            self.clause.get_unchecked_mut(r)
-        }
-        #[cfg(not(feature = "unsafe_access"))]
-        &mut self.clause[r]
+        unsafe { self.clause.get_unchecked_mut(r) }
     }
 }
 
 impl IndexMut<RangeFrom<usize>> for ClauseDB {
     #[inline]
     fn index_mut(&mut self, r: RangeFrom<usize>) -> &mut [Clause] {
-        #[cfg(feature = "unsafe_access")]
-        unsafe {
-            self.clause.get_unchecked_mut(r)
-        }
-        #[cfg(not(feature = "unsafe_access"))]
-        &mut self.clause[r]
+        unsafe { self.clause.get_unchecked_mut(r) }
     }
 }
 

--- a/src/cdb/watch_cache.rs
+++ b/src/cdb/watch_cache.rs
@@ -48,24 +48,14 @@ impl Index<Lit> for Vec<HashMap<Lit, ClauseId>> {
     type Output = HashMap<Lit, ClauseId>;
     #[inline]
     fn index(&self, l: Lit) -> &Self::Output {
-        #[cfg(feature = "unsafe_access")]
-        unsafe {
-            self.get_unchecked(usize::from(l))
-        }
-        #[cfg(not(feature = "unsafe_access"))]
-        &self[usize::from(l)]
+        unsafe { self.get_unchecked(usize::from(l)) }
     }
 }
 
 impl IndexMut<Lit> for Vec<HashMap<Lit, ClauseId>> {
     #[inline]
     fn index_mut(&mut self, l: Lit) -> &mut Self::Output {
-        #[cfg(feature = "unsafe_access")]
-        unsafe {
-            self.get_unchecked_mut(usize::from(l))
-        }
-        #[cfg(not(feature = "unsafe_access"))]
-        &mut self[usize::from(l)]
+        unsafe { self.get_unchecked_mut(usize::from(l)) }
     }
 }
 
@@ -73,24 +63,14 @@ impl Index<Lit> for Vec<WatchCache> {
     type Output = WatchCache;
     #[inline]
     fn index(&self, l: Lit) -> &Self::Output {
-        #[cfg(feature = "unsafe_access")]
-        unsafe {
-            self.get_unchecked(usize::from(l))
-        }
-        #[cfg(not(feature = "unsafe_access"))]
-        &self[usize::from(l)]
+        unsafe { self.get_unchecked(usize::from(l)) }
     }
 }
 
 impl IndexMut<Lit> for Vec<WatchCache> {
     #[inline]
     fn index_mut(&mut self, l: Lit) -> &mut Self::Output {
-        #[cfg(feature = "unsafe_access")]
-        unsafe {
-            self.get_unchecked_mut(usize::from(l))
-        }
-        #[cfg(not(feature = "unsafe_access"))]
-        &mut self[usize::from(l)]
+        unsafe { self.get_unchecked_mut(usize::from(l)) }
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -264,8 +264,6 @@ impl Config {
                 "trail saving",
                 #[cfg(feature = "BT_deepen")]
                 "backtrack-to-deeper-level",
-                #[cfg(feature = "unsafe_access")]
-                "unsafe access",
             ];
             println!(
                 "{}\nActivated features: {}\n{}",

--- a/src/processor/simplify.rs
+++ b/src/processor/simplify.rs
@@ -39,24 +39,14 @@ impl Index<VarId> for Eliminator {
     type Output = LitOccurs;
     #[inline]
     fn index(&self, i: VarId) -> &Self::Output {
-        #[cfg(feature = "unsafe_access")]
-        unsafe {
-            self.var.get_unchecked(i)
-        }
-        #[cfg(not(feature = "unsafe_access"))]
-        &self.var[i]
+        unsafe { self.var.get_unchecked(i) }
     }
 }
 
 impl IndexMut<VarId> for Eliminator {
     #[inline]
     fn index_mut(&mut self, i: VarId) -> &mut Self::Output {
-        #[cfg(feature = "unsafe_access")]
-        unsafe {
-            self.var.get_unchecked_mut(i)
-        }
-        #[cfg(not(feature = "unsafe_access"))]
-        &mut self.var[i]
+        unsafe { self.var.get_unchecked_mut(i) }
     }
 }
 
@@ -64,24 +54,14 @@ impl Index<&VarId> for Eliminator {
     type Output = LitOccurs;
     #[inline]
     fn index(&self, i: &VarId) -> &Self::Output {
-        #[cfg(feature = "unsafe_access")]
-        unsafe {
-            self.var.get_unchecked(*i)
-        }
-        #[cfg(not(feature = "unsafe_access"))]
-        &self.var[*i]
+        unsafe { self.var.get_unchecked(*i) }
     }
 }
 
 impl IndexMut<&VarId> for Eliminator {
     #[inline]
     fn index_mut(&mut self, i: &VarId) -> &mut Self::Output {
-        #[cfg(feature = "unsafe_access")]
-        unsafe {
-            self.var.get_unchecked_mut(*i)
-        }
-        #[cfg(not(feature = "unsafe_access"))]
-        &mut self.var[*i]
+        unsafe { self.var.get_unchecked_mut(*i) }
     }
 }
 
@@ -89,24 +69,14 @@ impl Index<Lit> for Eliminator {
     type Output = LitOccurs;
     #[inline]
     fn index(&self, l: Lit) -> &Self::Output {
-        #[cfg(feature = "unsafe_access")]
-        unsafe {
-            self.var.get_unchecked(l.vi())
-        }
-        #[cfg(not(feature = "unsafe_access"))]
-        &self.var[l.vi()]
+        unsafe { self.var.get_unchecked(l.vi()) }
     }
 }
 
 impl IndexMut<Lit> for Eliminator {
     #[inline]
     fn index_mut(&mut self, l: Lit) -> &mut Self::Output {
-        #[cfg(feature = "unsafe_access")]
-        unsafe {
-            self.var.get_unchecked_mut(l.vi())
-        }
-        #[cfg(not(feature = "unsafe_access"))]
-        &mut self.var[l.vi()]
+        unsafe { self.var.get_unchecked_mut(l.vi()) }
     }
 }
 
@@ -114,24 +84,14 @@ impl Index<&Lit> for Eliminator {
     type Output = LitOccurs;
     #[inline]
     fn index(&self, l: &Lit) -> &Self::Output {
-        #[cfg(feature = "unsafe_access")]
-        unsafe {
-            self.var.get_unchecked(l.vi())
-        }
-        #[cfg(not(feature = "unsafe_access"))]
-        &self.var[l.vi()]
+        unsafe { self.var.get_unchecked(l.vi()) }
     }
 }
 
 impl IndexMut<&Lit> for Eliminator {
     #[inline]
     fn index_mut(&mut self, l: &Lit) -> &mut Self::Output {
-        #[cfg(feature = "unsafe_access")]
-        unsafe {
-            self.var.get_unchecked_mut(l.vi())
-        }
-        #[cfg(not(feature = "unsafe_access"))]
-        &mut self.var[l.vi()]
+        unsafe { self.var.get_unchecked_mut(l.vi()) }
     }
 }
 
@@ -139,12 +99,7 @@ impl Index<Range<usize>> for Eliminator {
     type Output = [LitOccurs];
     #[inline]
     fn index(&self, r: Range<usize>) -> &Self::Output {
-        #[cfg(feature = "unsafe_access")]
-        unsafe {
-            self.var.get_unchecked(r)
-        }
-        #[cfg(not(feature = "unsafe_access"))]
-        &self.var[r]
+        unsafe { self.var.get_unchecked(r) }
     }
 }
 
@@ -152,36 +107,21 @@ impl Index<RangeFrom<usize>> for Eliminator {
     type Output = [LitOccurs];
     #[inline]
     fn index(&self, r: RangeFrom<usize>) -> &Self::Output {
-        #[cfg(feature = "unsafe_access")]
-        unsafe {
-            self.var.get_unchecked(r)
-        }
-        #[cfg(not(feature = "unsafe_access"))]
-        &self.var[r]
+        unsafe { self.var.get_unchecked(r) }
     }
 }
 
 impl IndexMut<Range<usize>> for Eliminator {
     #[inline]
     fn index_mut(&mut self, r: Range<usize>) -> &mut Self::Output {
-        #[cfg(feature = "unsafe_access")]
-        unsafe {
-            self.var.get_unchecked_mut(r)
-        }
-        #[cfg(not(feature = "unsafe_access"))]
-        &mut self.var[r]
+        unsafe { self.var.get_unchecked_mut(r) }
     }
 }
 
 impl IndexMut<RangeFrom<usize>> for Eliminator {
     #[inline]
     fn index_mut(&mut self, r: RangeFrom<usize>) -> &mut Self::Output {
-        #[cfg(feature = "unsafe_access")]
-        unsafe {
-            self.var.get_unchecked_mut(r)
-        }
-        #[cfg(not(feature = "unsafe_access"))]
-        &mut self.var[r]
+        unsafe { self.var.get_unchecked_mut(r) }
     }
 }
 

--- a/src/solver/conflict.rs
+++ b/src/solver/conflict.rs
@@ -384,8 +384,8 @@ fn conflict_analyze(
                 }
                 for q in cdb[cid].iter().skip(1) {
                     let vi = q.vi();
-                    debug_assert!(asg.var(vi).assign.is_some());
-                    // if asg.var(vi).assign.is_none() {
+                    debug_assert!(asg.assign(vi).is_some());
+                    // if asg.assign(vi).is_none() {
                     //     println!(
                     //         "Implication clause contains non-assinged lit (cc: {:?}, at level: {:?})",
                     //         cc,
@@ -398,7 +398,7 @@ fn conflict_analyze(
                     //         cid,
                     //         cdb[cid]
                     //             .iter()
-                    //             // .filter(|l| asg.var(l.vi()).assign.is_none())
+                    //             // .filter(|l| asg.assign(l.vi()).is_none())
                     //             .map(|l| (l, asg.var(l.vi()).level))
                     //             .collect::<Vec<_>>()
                     //     );

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -229,7 +229,7 @@ fn search(
     let mut cii_hist: Histogram = Histogram::default();
     let mut core_ema: Ema = Ema::new(20);
     let mut core_hist: Histogram = Histogram::default();
-    let mut lbd_hist: Histogram = Histogram::default();
+    // let mut lbd_hist: Histogram = Histogram::default();
 
     state.span_manager.reset();
     while 0 < asg.derefer(assign::property::Tusize::NumUnassignedVar) || asg.remains() {
@@ -263,6 +263,9 @@ fn search(
                 ruduction_pressure += 1;
                 processing_pressure += 1;
                 cdb.lbd.update(lbd);
+                // if focusing.is_none() {
+                //     cdb.lbd.update(lbd);
+                // }
             }
         }
         if ruduction_pressure >= reduction_interval {
@@ -270,7 +273,7 @@ fn search(
             ruduction_pressure = 0;
             cii_hist.rescale(0.95);
             core_hist.rescale(0.95);
-            lbd_hist.rescale(0.95);
+            // lbd_hist.rescale(0.95);
         }
 
         if state
@@ -278,9 +281,9 @@ fn search(
             .span_ended(span_len.saturating_sub(cooling_len))
         {
             let r = cii_hist.add(asg.conflict_interval_index.get());
-            // let s = core_hist.add(core_ema.get());
-            let t = lbd_hist.add(1.0 / cdb.lbd.get());
-            if (focusing.is_none() && 1.0 - r > 0.9) || (focusing == Some(false) && 1.0 - r > 0.5) {
+            let s = core_hist.add(core_ema.get());
+            // let t = lbd_hist.add(1.0 / cdb.lbd.get());
+            if (focusing.is_none() && r < 0.1) || (focusing == Some(false) && r < 0.2) {
                 if focusing != Some(false) {
                     focusing = Some(false);
                     asg.set_learning_rate(0.0);
@@ -289,7 +292,7 @@ fn search(
                 state.search_mode_ratio.0.update(1.0);
                 state.search_mode_ratio.1.update(0.0);
                 state.search_mode_ratio.2.update(0.0);
-            } else if (focusing.is_none() && r > 0.9) || (focusing == Some(true) && r > 0.5) {
+            } else if (focusing.is_none() && r > 0.9) || (focusing == Some(true) && r > 0.8) {
                 if focusing != Some(true) {
                     focusing = Some(true);
                     asg.set_learning_rate(0.0);
@@ -298,9 +301,7 @@ fn search(
                 state.search_mode_ratio.0.update(1.0);
                 state.search_mode_ratio.1.update(0.0);
                 state.search_mode_ratio.2.update(0.0);
-            } else if
-            /* r + s + */
-            t > 0.8 {
+            } else if !(0.25..0.75).contains(&s) {
                 if focusing.is_some() {
                     focusing = None;
                     asg.set_learning_rate(state.config.vrw_learning_rate);

--- a/src/state.rs
+++ b/src/state.rs
@@ -75,24 +75,14 @@ impl Index<Stat> for [usize] {
     type Output = usize;
     #[inline]
     fn index(&self, i: Stat) -> &usize {
-        #[cfg(feature = "unsafe_access")]
-        unsafe {
-            self.get_unchecked(i as usize)
-        }
-        #[cfg(not(feature = "unsafe_access"))]
-        &self[i as usize]
+        unsafe { self.get_unchecked(i as usize) }
     }
 }
 
 impl IndexMut<Stat> for [usize] {
     #[inline]
     fn index_mut(&mut self, i: Stat) -> &mut usize {
-        #[cfg(feature = "unsafe_access")]
-        unsafe {
-            self.get_unchecked_mut(i as usize)
-        }
-        #[cfg(not(feature = "unsafe_access"))]
-        &mut self[i as usize]
+        unsafe { self.get_unchecked_mut(i as usize) }
     }
 }
 
@@ -188,24 +178,14 @@ impl Index<Stat> for State {
     type Output = usize;
     #[inline]
     fn index(&self, i: Stat) -> &usize {
-        #[cfg(feature = "unsafe_access")]
-        unsafe {
-            self.stats.get_unchecked(i as usize)
-        }
-        #[cfg(not(feature = "unsafe_access"))]
-        &self.stats[i as usize]
+        unsafe { self.stats.get_unchecked(i as usize) }
     }
 }
 
 impl IndexMut<Stat> for State {
     #[inline]
     fn index_mut(&mut self, i: Stat) -> &mut usize {
-        #[cfg(feature = "unsafe_access")]
-        unsafe {
-            self.stats.get_unchecked_mut(i as usize)
-        }
-        #[cfg(not(feature = "unsafe_access"))]
-        &mut self.stats[i as usize]
+        unsafe { self.stats.get_unchecked_mut(i as usize) }
     }
 }
 
@@ -852,24 +832,14 @@ impl Index<LogUsizeId> for State {
     type Output = usize;
     #[inline]
     fn index(&self, i: LogUsizeId) -> &Self::Output {
-        #[cfg(feature = "unsafe_access")]
-        unsafe {
-            self.record.vali.get_unchecked(i as usize)
-        }
-        #[cfg(not(feature = "unsafe_access"))]
-        &self.record.vali[i as usize]
+        unsafe { self.record.vali.get_unchecked(i as usize) }
     }
 }
 
 impl IndexMut<LogUsizeId> for State {
     #[inline]
     fn index_mut(&mut self, i: LogUsizeId) -> &mut Self::Output {
-        #[cfg(feature = "unsafe_access")]
-        unsafe {
-            self.record.vali.get_unchecked_mut(i as usize)
-        }
-        #[cfg(not(feature = "unsafe_access"))]
-        &mut self.record.vali[i as usize]
+        unsafe { self.record.vali.get_unchecked_mut(i as usize) }
     }
 }
 
@@ -877,24 +847,14 @@ impl Index<LogF64Id> for State {
     type Output = f64;
     #[inline]
     fn index(&self, i: LogF64Id) -> &Self::Output {
-        #[cfg(feature = "unsafe_access")]
-        unsafe {
-            self.record.valf.get_unchecked(i as usize)
-        }
-        #[cfg(not(feature = "unsafe_access"))]
-        &self.record.valf[i as usize]
+        unsafe { self.record.valf.get_unchecked(i as usize) }
     }
 }
 
 impl IndexMut<LogF64Id> for State {
     #[inline]
     fn index_mut(&mut self, i: LogF64Id) -> &mut Self::Output {
-        #[cfg(feature = "unsafe_access")]
-        unsafe {
-            self.record.valf.get_unchecked_mut(i as usize)
-        }
-        #[cfg(not(feature = "unsafe_access"))]
-        &mut self.record.valf[i as usize]
+        unsafe { self.record.valf.get_unchecked_mut(i as usize) }
     }
 }
 
@@ -1061,24 +1021,14 @@ impl Index<LogUsizeId> for ProgressRecord {
     type Output = usize;
     #[inline]
     fn index(&self, i: LogUsizeId) -> &usize {
-        #[cfg(feature = "unsafe_access")]
-        unsafe {
-            self.vali.get_unchecked(i as usize)
-        }
-        #[cfg(not(feature = "unsafe_access"))]
-        &self.vali[i as usize]
+        unsafe { self.vali.get_unchecked(i as usize) }
     }
 }
 
 impl IndexMut<LogUsizeId> for ProgressRecord {
     #[inline]
     fn index_mut(&mut self, i: LogUsizeId) -> &mut usize {
-        #[cfg(feature = "unsafe_access")]
-        unsafe {
-            self.vali.get_unchecked_mut(i as usize)
-        }
-        #[cfg(not(feature = "unsafe_access"))]
-        &mut self.vali[i as usize]
+        unsafe { self.vali.get_unchecked_mut(i as usize) }
     }
 }
 
@@ -1086,24 +1036,14 @@ impl Index<LogF64Id> for ProgressRecord {
     type Output = f64;
     #[inline]
     fn index(&self, i: LogF64Id) -> &f64 {
-        #[cfg(feature = "unsafe_access")]
-        unsafe {
-            self.valf.get_unchecked(i as usize)
-        }
-        #[cfg(not(feature = "unsafe_access"))]
-        &self.valf[i as usize]
+        unsafe { self.valf.get_unchecked(i as usize) }
     }
 }
 
 impl IndexMut<LogF64Id> for ProgressRecord {
     #[inline]
     fn index_mut(&mut self, i: LogF64Id) -> &mut f64 {
-        #[cfg(feature = "unsafe_access")]
-        unsafe {
-            self.valf.get_unchecked_mut(i as usize)
-        }
-        #[cfg(not(feature = "unsafe_access"))]
-        &mut self.valf[i as usize]
+        unsafe { self.valf.get_unchecked_mut(i as usize) }
     }
 }
 

--- a/src/types/clause.rs
+++ b/src/types/clause.rs
@@ -75,24 +75,14 @@ impl Index<usize> for Clause {
     type Output = Lit;
     #[inline]
     fn index(&self, i: usize) -> &Lit {
-        #[cfg(feature = "unsafe_access")]
-        unsafe {
-            self.lits.get_unchecked(i)
-        }
-        #[cfg(not(feature = "unsafe_access"))]
-        &self.lits[i]
+        unsafe { self.lits.get_unchecked(i) }
     }
 }
 
 impl IndexMut<usize> for Clause {
     #[inline]
     fn index_mut(&mut self, i: usize) -> &mut Lit {
-        #[cfg(feature = "unsafe_access")]
-        unsafe {
-            self.lits.get_unchecked_mut(i)
-        }
-        #[cfg(not(feature = "unsafe_access"))]
-        &mut self.lits[i]
+        unsafe { self.lits.get_unchecked_mut(i) }
     }
 }
 
@@ -100,12 +90,7 @@ impl Index<Range<usize>> for Clause {
     type Output = [Lit];
     #[inline]
     fn index(&self, r: Range<usize>) -> &[Lit] {
-        #[cfg(feature = "unsafe_access")]
-        unsafe {
-            self.lits.get_unchecked(r)
-        }
-        #[cfg(not(feature = "unsafe_access"))]
-        &self.lits[r]
+        unsafe { self.lits.get_unchecked(r) }
     }
 }
 
@@ -113,36 +98,21 @@ impl Index<RangeFrom<usize>> for Clause {
     type Output = [Lit];
     #[inline]
     fn index(&self, r: RangeFrom<usize>) -> &[Lit] {
-        #[cfg(feature = "unsafe_access")]
-        unsafe {
-            self.lits.get_unchecked(r)
-        }
-        #[cfg(not(feature = "unsafe_access"))]
-        &self.lits[r]
+        unsafe { self.lits.get_unchecked(r) }
     }
 }
 
 impl IndexMut<Range<usize>> for Clause {
     #[inline]
     fn index_mut(&mut self, r: Range<usize>) -> &mut [Lit] {
-        #[cfg(feature = "unsafe_access")]
-        unsafe {
-            self.lits.get_unchecked_mut(r)
-        }
-        #[cfg(not(feature = "unsafe_access"))]
-        &mut self.lits[r]
+        unsafe { self.lits.get_unchecked_mut(r) }
     }
 }
 
 impl IndexMut<RangeFrom<usize>> for Clause {
     #[inline]
     fn index_mut(&mut self, r: RangeFrom<usize>) -> &mut [Lit] {
-        #[cfg(feature = "unsafe_access")]
-        unsafe {
-            self.lits.get_unchecked_mut(r)
-        }
-        #[cfg(not(feature = "unsafe_access"))]
-        &mut self.lits[r]
+        unsafe { self.lits.get_unchecked_mut(r) }
     }
 }
 
@@ -180,21 +150,11 @@ impl ClauseIF for Clause {
     }
     #[inline]
     fn lit0(&self) -> Lit {
-        #[cfg(feature = "unsafe_access")]
-        unsafe {
-            *self.lits.get_unchecked(0)
-        }
-        #[cfg(not(feature = "unsafe_access"))]
-        self.lits[0]
+        unsafe { *self.lits.get_unchecked(0) }
     }
     #[inline]
     fn lit1(&self) -> Lit {
-        #[cfg(feature = "unsafe_access")]
-        unsafe {
-            *self.lits.get_unchecked(1)
-        }
-        #[cfg(not(feature = "unsafe_access"))]
-        self.lits[1]
+        unsafe { *self.lits.get_unchecked(1) }
     }
     fn contains(&self, lit: Lit) -> bool {
         self.lits.contains(&lit)

--- a/src/types/histogram.rs
+++ b/src/types/histogram.rs
@@ -1,12 +1,12 @@
 pub struct Histogram {
-    pub bands: [usize; 100],
+    pub bands: [usize; 128],
     pub samples: usize,
 }
 
 impl Default for Histogram {
     fn default() -> Self {
         Self {
-            bands: [0; 100],
+            bands: [0; 128],
             samples: 0,
         }
     }
@@ -14,15 +14,15 @@ impl Default for Histogram {
 
 impl Histogram {
     pub fn add(&mut self, d: f64) -> f64 {
-        let index = ((100.0 * d) as usize).clamp(0, 99);
+        let index = ((128.0 * d) as usize).clamp(0, 127);
         self.bands[index] += 1;
         self.samples += 1;
-        if index < 50 {
+        if index < 64 {
             let med = (0..index).map(|l| self.bands[l]).sum::<usize>() + self.bands[index] / 2;
             med as f64 / (self.samples as f64)
         } else {
             let med =
-                (index + 1..100).map(|l| self.bands[l]).sum::<usize>() + self.bands[index] / 2;
+                (index + 1..128).map(|l| self.bands[l]).sum::<usize>() + self.bands[index] / 2;
             1.0 - med as f64 / (self.samples as f64)
         }
     }

--- a/src/types/lit.rs
+++ b/src/types/lit.rs
@@ -166,24 +166,14 @@ impl Index<Lit> for [bool] {
     type Output = bool;
     #[inline]
     fn index(&self, l: Lit) -> &Self::Output {
-        #[cfg(feature = "unsafe_access")]
-        unsafe {
-            self.get_unchecked(usize::from(l))
-        }
-        #[cfg(not(feature = "unsafe_access"))]
-        &self[usize::from(l)]
+        unsafe { self.get_unchecked(usize::from(l)) }
     }
 }
 
 impl IndexMut<Lit> for [bool] {
     #[inline]
     fn index_mut(&mut self, l: Lit) -> &mut Self::Output {
-        #[cfg(feature = "unsafe_access")]
-        unsafe {
-            self.get_unchecked_mut(usize::from(l))
-        }
-        #[cfg(not(feature = "unsafe_access"))]
-        &mut self[usize::from(l)]
+        unsafe { self.get_unchecked_mut(usize::from(l)) }
     }
 }
 
@@ -191,24 +181,14 @@ impl Index<Lit> for Vec<bool> {
     type Output = bool;
     #[inline]
     fn index(&self, l: Lit) -> &Self::Output {
-        #[cfg(feature = "unsafe_access")]
-        unsafe {
-            self.get_unchecked(usize::from(l))
-        }
-        #[cfg(not(feature = "unsafe_access"))]
-        &self[usize::from(l)]
+        unsafe { self.get_unchecked(usize::from(l)) }
     }
 }
 
 impl IndexMut<Lit> for Vec<bool> {
     #[inline]
     fn index_mut(&mut self, l: Lit) -> &mut Self::Output {
-        #[cfg(feature = "unsafe_access")]
-        unsafe {
-            self.get_unchecked_mut(usize::from(l))
-        }
-        #[cfg(not(feature = "unsafe_access"))]
-        &mut self[usize::from(l)]
+        unsafe { self.get_unchecked_mut(usize::from(l)) }
     }
 }
 

--- a/src/types/var.rs
+++ b/src/types/var.rs
@@ -8,8 +8,6 @@ use {
 /// Object representing a variable.
 #[derive(Clone, Debug)]
 pub struct Var {
-    /// assignment
-    pub(crate) assign: Option<bool>,
     /// decision level
     pub(crate) level: DecisionLevel,
     /// assign Reason
@@ -28,7 +26,6 @@ pub struct Var {
 impl Default for Var {
     fn default() -> Var {
         Var {
-            assign: None,
             level: 0,
             reason: AssignReason::None,
             #[cfg(feature = "trail_saving")]


### PR DESCRIPTION
### AI-driven refactoring

- [ ] Switch to `unsafe { ...get_unchecked }` without feature setting
- [ ] define `assign: Vector<Option<bool>>` to reduce cache pressure
- [ ] use lit-indexed `lit_val` instead of varId-index `var_val` 

### [1f30f52c]

```
  1,"0a8a4c28d27228e954354ea0a6e7f16c-sum_of_three_cubes_42_kno", TIMEOUT
  2,"1a936d41e3439d602c3ddcf96458a38c-arles_thres10_p10_r8185.c",   2.560
  3,"2b4467a5ac4ac41b36d4c3432b07f767-oddball_69_5_tto_zp.norma", 212.835
  4,"3a1f1b4b9a521737cc760017fe9d8b43-MVRoundRobin_n16_d10_v3.c", TIMEOUT
  5,"4ba2c1aa580b6497df6baf5e7e2c87be-at-least-two-vmpc_28.cnf" ,  36.837
  6,"5aed29ce52192a55ffbd2a6f340017e7-oisc-subrv-and-nested-12.", TIMEOUT
  7,"6cb995b1c550beb579c53e27f6ca881a-RoundRobin_n16_d13.cnf"   , TIMEOUT
  8,"7a044c997ede14d00002f1db39d45170-sum_of_3_cubes_37_bits_87",1634.082
  9,"8a05f9b6bf49285e40d0a197967ea5d3-arles_thres10_p10_r7466.c",   0.014
 10,"9a839badecb20dcf505ec79eedd3753a-anbul-dated-5-15-u.cnf"   ,  60.391
 11,"a0bcdaffb0ea36b678899fd86bdc7f18-arles_thres10_p10_r8186.c",   0.016
 12,"b1c8eaa002ac2fa1c8bfd1002738e78e-cliquecolouring_n15_k7_c6", TIMEOUT
 13,"c0bd86bd7ca2c65e44311de374168150-goldcrest-and-14.cnf"     , TIMEOUT
 14,"d0298807e51730261ef65db827dcd70f-Break_triple_16_70.xml.cn",  91.030
 15,"e2d2b011b0805782df6adba648db92e8-59-129706.cnf"            ,1923.323
 16,"f0bafebdcce23ccfbaf6c27a7522069b-div-mitern172.cnf"        , 423.085
"splr"    , med:    75.710, max:  1923.323,total except 6 timeouts:4384.173
```
This is not the best, but acceptable.