### PR TITLE
Var activity is the number of clauses

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ default = [
     ### Heuristics
 
     # "clause_rewarding",
-    # "reason_side_rewarding",
+    "reason_side_rewarding",
     # "rephase",
     # "stochastic_local_search",
 

--- a/src/assign/heap.rs
+++ b/src/assign/heap.rs
@@ -93,56 +93,28 @@ impl VarHeapIF for AssignStack {
         let mut q = start;
         let vq = self.var_order.heap[q as usize];
         debug_assert!(0 < vq, "size of heap is too small");
-        if self.ordering_by_conflict {
-            let aq = self.var[vq as usize].last_conflict;
-            loop {
-                let p = q / 2;
-                if p == 0 {
+        let aq = self.activity(vq as usize);
+        loop {
+            let p = q / 2;
+            if p == 0 {
+                self.var_order.heap[q as usize] = vq;
+                debug_assert!(vq != 0, "Invalid index in percolate_up");
+                self.var_order.idxs[vq as usize] = q;
+                return;
+            } else {
+                let vp = self.var_order.heap[p as usize];
+                let ap = self.activity(vp as usize);
+                if ap < aq {
+                    // move down the current parent, and make it empty
+                    self.var_order.heap[q as usize] = vp;
+                    debug_assert!(vq != 0, "Invalid index in percolate_up");
+                    self.var_order.idxs[vp as usize] = q;
+                    q = p;
+                } else {
                     self.var_order.heap[q as usize] = vq;
                     debug_assert!(vq != 0, "Invalid index in percolate_up");
                     self.var_order.idxs[vq as usize] = q;
                     return;
-                } else {
-                    let vp = self.var_order.heap[p as usize];
-                    let ap = self.var[vp as usize].last_conflict;
-                    if ap < aq {
-                        // move down the current parent, and make it empty
-                        self.var_order.heap[q as usize] = vp;
-                        debug_assert!(vq != 0, "Invalid index in percolate_up");
-                        self.var_order.idxs[vp as usize] = q;
-                        q = p;
-                    } else {
-                        self.var_order.heap[q as usize] = vq;
-                        debug_assert!(vq != 0, "Invalid index in percolate_up");
-                        self.var_order.idxs[vq as usize] = q;
-                        return;
-                    }
-                }
-            }
-        } else {
-            let aq = self.activity(vq as usize);
-            loop {
-                let p = q / 2;
-                if p == 0 {
-                    self.var_order.heap[q as usize] = vq;
-                    debug_assert!(vq != 0, "Invalid index in percolate_up");
-                    self.var_order.idxs[vq as usize] = q;
-                    return;
-                } else {
-                    let vp = self.var_order.heap[p as usize];
-                    let ap = self.activity(vp as usize);
-                    if ap < aq {
-                        // move down the current parent, and make it empty
-                        self.var_order.heap[q as usize] = vp;
-                        debug_assert!(vq != 0, "Invalid index in percolate_up");
-                        self.var_order.idxs[vp as usize] = q;
-                        q = p;
-                    } else {
-                        self.var_order.heap[q as usize] = vq;
-                        debug_assert!(vq != 0, "Invalid index in percolate_up");
-                        self.var_order.idxs[vq as usize] = q;
-                        return;
-                    }
                 }
             }
         }
@@ -151,71 +123,36 @@ impl VarHeapIF for AssignStack {
         let n = self.var_order.len();
         let mut i = start;
         let vi = self.var_order.heap[i as usize];
-        if self.ordering_by_conflict {
-            let ai = self.var[vi as usize].last_conflict;
-            loop {
-                let l = 2 * i; // left
-                if l < n as u32 {
-                    let vl = self.var_order.heap[l as usize];
-                    let al = self.var[vl as usize].last_conflict;
-                    let r = l + 1; // right
-                    let (target, vc, ac) = if r < (n as u32)
-                        && al < self.var[self.var_order.heap[r as usize] as usize].last_conflict
-                    {
-                        let vr = self.var_order.heap[r as usize];
-                        (r, vr, self.var[vr as usize].last_conflict)
-                    } else {
-                        (l, vl, al)
-                    };
-                    if ai < ac {
-                        self.var_order.heap[i as usize] = vc;
-                        self.var_order.idxs[vc as usize] = i;
-                        i = target;
-                    } else {
-                        self.var_order.heap[i as usize] = vi;
-                        debug_assert!(vi != 0, "invalid index");
-                        self.var_order.idxs[vi as usize] = i;
-                        return;
-                    }
+        let ai = self.activity(vi as usize);
+        loop {
+            let l = 2 * i; // left
+            if l < n as u32 {
+                let vl = self.var_order.heap[l as usize];
+                let al = self.activity(vl as usize);
+                let r = l + 1; // right
+                let (target, vc, ac) = if r < (n as u32)
+                    && al < self.activity(self.var_order.heap[r as usize] as usize)
+                {
+                    let vr = self.var_order.heap[r as usize];
+                    (r, vr, self.activity(vr as usize))
+                } else {
+                    (l, vl, al)
+                };
+                if ai < ac {
+                    self.var_order.heap[i as usize] = vc;
+                    self.var_order.idxs[vc as usize] = i;
+                    i = target;
                 } else {
                     self.var_order.heap[i as usize] = vi;
                     debug_assert!(vi != 0, "invalid index");
                     self.var_order.idxs[vi as usize] = i;
                     return;
                 }
-            }
-        } else {
-            let ai = self.activity(vi as usize);
-            loop {
-                let l = 2 * i; // left
-                if l < n as u32 {
-                    let vl = self.var_order.heap[l as usize];
-                    let al = self.activity(vl as usize);
-                    let r = l + 1; // right
-                    let (target, vc, ac) = if r < (n as u32)
-                        && al < self.activity(self.var_order.heap[r as usize] as usize)
-                    {
-                        let vr = self.var_order.heap[r as usize];
-                        (r, vr, self.activity(vr as usize))
-                    } else {
-                        (l, vl, al)
-                    };
-                    if ai < ac {
-                        self.var_order.heap[i as usize] = vc;
-                        self.var_order.idxs[vc as usize] = i;
-                        i = target;
-                    } else {
-                        self.var_order.heap[i as usize] = vi;
-                        debug_assert!(vi != 0, "invalid index");
-                        self.var_order.idxs[vi as usize] = i;
-                        return;
-                    }
-                } else {
-                    self.var_order.heap[i as usize] = vi;
-                    debug_assert!(vi != 0, "invalid index");
-                    self.var_order.idxs[vi as usize] = i;
-                    return;
-                }
+            } else {
+                self.var_order.heap[i as usize] = vi;
+                debug_assert!(vi != 0, "invalid index");
+                self.var_order.idxs[vi as usize] = i;
+                return;
             }
         }
     }

--- a/src/assign/learning_rate.rs
+++ b/src/assign/learning_rate.rs
@@ -5,7 +5,8 @@ impl ActivityIF<VarId> for AssignStack {
     #[inline]
     fn activity(&self, vi: VarId) -> f64 {
         match self.activity_scheme {
-            VarActivityScheme::CR => self.var[vi].num_clauses as f64 / self.cdb_num_clauses as f64,
+            // VarActivityScheme::CR => self.var[vi].num_clauses as f64 / self.cdb_num_clauses as f64,
+            VarActivityScheme::CR => self.var[vi].last_conflict as f64 / self.num_conflict as f64,
             VarActivityScheme::LRB => self.var[vi].lrb_reward,
             VarActivityScheme::VMTF => self.var[vi].last_conflict as f64 / self.num_conflict as f64,
         }

--- a/src/assign/learning_rate.rs
+++ b/src/assign/learning_rate.rs
@@ -1,18 +1,13 @@
 /// Var Rewarding based on Learning Rate Rewarding and Reason Side Rewarding
-use {
-    super::{stack::AssignStack, var::Var},
-    crate::types::*,
-};
+use {super::stack::AssignStack, crate::types::*};
 
 impl ActivityIF<VarId> for AssignStack {
     #[inline]
     fn activity(&self, vi: VarId) -> f64 {
         match self.activity_scheme {
+            VarActivityScheme::CR => self.var[vi].num_clauses as f64 / self.cdb_num_clauses as f64,
             VarActivityScheme::LRB => self.var[vi].lrb_reward,
-            VarActivityScheme::VMTF => self.var[vi].last_conflict as f64,
-            VarActivityScheme::CR => {
-                self.var[vi].num_clauses as f64 / self.cdb_num_clauses.max(1) as f64
-            }
+            VarActivityScheme::VMTF => self.var[vi].last_conflict as f64 / self.num_conflict as f64,
         }
     }
     // fn activity_slow(&self, vi: VarId) -> f64 {
@@ -25,12 +20,32 @@ impl ActivityIF<VarId> for AssignStack {
         self.var[vi].turn_on(FlagVar::USED);
     }
     #[inline]
+    fn reward_at(&mut self, vi: VarId) -> f64 {
+        // Note: why the condition can be broken.
+        //
+        // 1. asg.ordinal += 1;
+        // 1. handle_conflict -> cancel_until -> reward_at_unassign
+        // 1. assign_by_implication -> v.timestamp = asg.ordinal
+        // 1. restart
+        // 1. cancel_until -> reward_at_unassign -> assertion failed
+        //
+        let decay = self.activity_stay_rate;
+        let reward = self.activity_learning_rate;
+        self.var[vi].lrb_reward *= decay;
+        if self.var[vi].is(FlagVar::USED) {
+            self.var[vi].lrb_reward += reward;
+            self.var[vi].turn_off(FlagVar::USED);
+        }
+        // self.var[vi].reward_ema.update(self.var[vi].reward);
+        self.var[vi].lrb_reward
+    }
+    #[inline]
     fn reward_at_assign(&mut self, _vi: VarId) {}
     #[inline]
     fn reward_at_propagation(&mut self, _vi: VarId) {}
     #[inline]
     fn reward_at_unassign(&mut self, vi: VarId) {
-        self.var[vi].update_activity(self.activity_stay_rate, self.activity_learning_rate);
+        self.reward_at(vi);
     }
     fn set_learning_rate(&mut self, scaling: f64) {
         self.activity_stay_rate = 1.0 - scaling;
@@ -70,24 +85,4 @@ impl AssignStack {
     //     // println!("inc rate:{:>6.4}", self.cwss);
     //     self.cwss
     // }
-}
-
-impl Var {
-    fn update_activity(&mut self, decay: f64, reward: f64) -> f64 {
-        // Note: why the condition can be broken.
-        //
-        // 1. asg.ordinal += 1;
-        // 1. handle_conflict -> cancel_until -> reward_at_unassign
-        // 1. assign_by_implication -> v.timestamp = asg.ordinal
-        // 1. restart
-        // 1. cancel_until -> reward_at_unassign -> assertion failed
-        //
-        self.lrb_reward *= decay;
-        if self.is(FlagVar::USED) {
-            self.lrb_reward += reward;
-            self.turn_off(FlagVar::USED);
-        }
-        // self.reward_ema.update(self.reward);
-        self.lrb_reward
-    }
 }

--- a/src/assign/learning_rate.rs
+++ b/src/assign/learning_rate.rs
@@ -7,13 +7,19 @@ use {
 impl ActivityIF<VarId> for AssignStack {
     #[inline]
     fn activity(&self, vi: VarId) -> f64 {
-        self.var[vi].reward
+        match self.activity_scheme {
+            VarActivityScheme::LRB => self.var[vi].lrb_reward,
+            VarActivityScheme::VMTF => self.var[vi].last_conflict as f64,
+            VarActivityScheme::CR => {
+                self.var[vi].num_clauses as f64 / self.cdb_num_clauses.max(1) as f64
+            }
+        }
     }
     // fn activity_slow(&self, vi: VarId) -> f64 {
     //     self.var[vi].reward_ema.get()
     // }
     fn set_activity(&mut self, vi: VarId, val: f64) {
-        self.var[vi].reward = val;
+        self.var[vi].lrb_reward = val;
     }
     fn reward_at_analysis(&mut self, vi: VarId) {
         self.var[vi].turn_on(FlagVar::USED);
@@ -40,7 +46,7 @@ impl ActivityIF<VarId> for AssignStack {
 impl AssignStack {
     pub fn rescale_activity(&mut self, scaling: f64) {
         for v in self.var.iter_mut().skip(1) {
-            v.reward *= scaling;
+            v.lrb_reward *= scaling;
         }
     }
     // pub fn set_activity_trend(&mut self) -> f64 {
@@ -76,12 +82,12 @@ impl Var {
         // 1. restart
         // 1. cancel_until -> reward_at_unassign -> assertion failed
         //
-        self.reward *= decay;
+        self.lrb_reward *= decay;
         if self.is(FlagVar::USED) {
-            self.reward += reward;
+            self.lrb_reward += reward;
             self.turn_off(FlagVar::USED);
         }
         // self.reward_ema.update(self.reward);
-        self.reward
+        self.lrb_reward
     }
 }

--- a/src/assign/learning_rate.rs
+++ b/src/assign/learning_rate.rs
@@ -5,10 +5,9 @@ impl ActivityIF<VarId> for AssignStack {
     #[inline]
     fn activity(&self, vi: VarId) -> f64 {
         match self.activity_scheme {
-            // VarActivityScheme::CR => self.var[vi].num_clauses as f64 / self.cdb_num_clauses as f64,
-            VarActivityScheme::CR => self.var[vi].last_conflict as f64 / self.num_conflict as f64,
+            VarActivityScheme::CR => self.var[vi].num_clauses as f64,
             VarActivityScheme::LRB => self.var[vi].lrb_reward,
-            VarActivityScheme::VMTF => self.var[vi].last_conflict as f64 / self.num_conflict as f64,
+            VarActivityScheme::VMTF => self.var[vi].last_conflict as f64,
         }
     }
     // fn activity_slow(&self, vi: VarId) -> f64 {

--- a/src/assign/mod.rs
+++ b/src/assign/mod.rs
@@ -77,6 +77,8 @@ pub trait AssignIF:
     fn extend_model(&mut self, c: &mut impl ClauseDBIF) -> Vec<Option<bool>>;
     /// return `true` if the set of literals is satisfiable under the current assignment.
     fn satisfies(&self, c: &[Lit]) -> bool;
+    /// return activity scheme
+    fn activity_scheme(&self) -> &VarActivityScheme;
 }
 
 /// Reasons of assignments

--- a/src/assign/mod.rs
+++ b/src/assign/mod.rs
@@ -77,8 +77,6 @@ pub trait AssignIF:
     fn extend_model(&mut self, c: &mut impl ClauseDBIF) -> Vec<Option<bool>>;
     /// return `true` if the set of literals is satisfiable under the current assignment.
     fn satisfies(&self, c: &[Lit]) -> bool;
-    /// return ordering mode
-    fn ordering_by_reward(&self) -> bool;
 }
 
 /// Reasons of assignments

--- a/src/assign/propagate.rs
+++ b/src/assign/propagate.rs
@@ -694,7 +694,7 @@ impl AssignStack {
                         debug_assert!(self.assigned(lit).is_none());
                         cdb.certificate_add_assertion(lit);
                         self.assign_at_root_level(cdb, lit)?;
-                        cdb.remove_clause(cid);
+                        cdb.remove_clause(self, cid);
                     }
                 }
             }

--- a/src/assign/propagate.rs
+++ b/src/assign/propagate.rs
@@ -310,12 +310,12 @@ impl PropagateIF for AssignStack {
                 self.dpc_ema.update(self.num_decision);
                 self.ppc_ema.update(self.num_propagation);
                 self.num_conflict += 1;
-                {
-                    let d = self.num_conflict - self.var[$lit.vi()].last_conflict;
-                    let f: f64 = 1.0 / ((d + 1) as f64).log2();
-                    self.conflict_interval_average.0.update(f);
-                    self.conflict_interval_average.1.update(f);
-                }
+                // {
+                //     let d = self.num_conflict - self.var[$lit.vi()].last_conflict;
+                //     let f: f64 = 1.0 / ((d + 1) as f64).log2();
+                //     self.conflict_interval_average.0.update(f);
+                //     self.conflict_interval_average.1.update(f);
+                // }
                 self.var[$lit.vi()].last_conflict = self.num_conflict;
                 return Err(($lit, $reason));
             };

--- a/src/assign/select.rs
+++ b/src/assign/select.rs
@@ -47,8 +47,6 @@ pub trait VarSelectIF {
     fn update_order(&mut self, v: VarId);
     /// rebuild the internal var_order
     fn rebuild_order(&mut self);
-    /// change ordering criteria
-    fn use_conflict_order(&mut self, to_reward_order: bool);
 }
 
 impl VarSelectIF for AssignStack {
@@ -90,8 +88,8 @@ impl VarSelectIF for AssignStack {
             if v.is(FlagVar::PHASE) != *b {
                 num_flipped += 1;
                 v.set(FlagVar::PHASE, *b);
-                v.reward *= self.activity_stay_rate;
-                v.reward += self.activity_learning_rate;
+                v.lrb_reward *= self.activity_stay_rate;
+                v.lrb_reward += self.activity_learning_rate;
                 self.update_heap(*vi);
             }
         }
@@ -142,12 +140,6 @@ impl VarSelectIF for AssignStack {
             if var_assign!(self, vi).is_none() && !self.var[vi].is(FlagVar::ELIMINATED) {
                 self.insert_heap(vi);
             }
-        }
-    }
-    fn use_conflict_order(&mut self, activate: bool) {
-        if self.ordering_by_conflict != activate {
-            self.ordering_by_conflict = activate;
-            self.rebuild_order();
         }
     }
 }

--- a/src/assign/stack.rs
+++ b/src/assign/stack.rs
@@ -138,7 +138,7 @@ impl Default for AssignStack {
             tick: 0,
             var: Vec::new(),
 
-            activity_scheme: VarActivityScheme::LRB,
+            activity_scheme: VarActivityScheme::default(),
             activity_stay_rate: 0.94,
             activity_learning_rate: 0.06,
             cdb_num_clauses: 0,
@@ -295,6 +295,9 @@ impl AssignIF for AssignStack {
             }
         }
         false
+    }
+    fn activity_scheme(&self) -> &VarActivityScheme {
+        &self.activity_scheme
     }
 }
 

--- a/src/assign/stack.rs
+++ b/src/assign/stack.rs
@@ -85,12 +85,14 @@ pub struct AssignStack {
     //
     //## Var Rewarding
     //
-    /// var activity decay
+    /// activity mode
+    pub(crate) activity_scheme: VarActivityScheme,
+    /// var activity decay for LRB
     pub(super) activity_stay_rate: f64,
-    /// its diff
+    /// its complimentary
     pub(super) activity_learning_rate: f64,
-    /// ordering_mode
-    pub(crate) ordering_by_conflict: bool,
+    /// number of clauses in the clause database (for occurrence-ratio activity)
+    pub(crate) cdb_num_clauses: usize,
 }
 
 impl Default for AssignStack {
@@ -136,10 +138,10 @@ impl Default for AssignStack {
             tick: 0,
             var: Vec::new(),
 
+            activity_scheme: VarActivityScheme::LRB,
             activity_stay_rate: 0.94,
-
             activity_learning_rate: 0.06,
-            ordering_by_conflict: false,
+            cdb_num_clauses: 0,
         }
     }
 }
@@ -169,13 +171,9 @@ impl Instantiate for AssignStack {
             trail_saved: Vec::with_capacity(nv),
 
             num_vars: cnf.num_of_variables,
-
             var: Var::new_vars(nv),
-
             activity_stay_rate: 1.0 - config.vrw_learning_rate,
-
             activity_learning_rate: config.vrw_learning_rate,
-
             ..AssignStack::default()
         }
     }
@@ -297,9 +295,6 @@ impl AssignIF for AssignStack {
             }
         }
         false
-    }
-    fn ordering_by_reward(&self) -> bool {
-        !self.ordering_by_conflict
     }
 }
 

--- a/src/assign/trail_saving.rs
+++ b/src/assign/trail_saving.rs
@@ -21,7 +21,7 @@ impl TrailSavingIF for AssignStack {
         self.clear_saved_trail();
         if 2 <= dl {
             let lim2 = self.trail_lim[dl - 2];
-            let activity_threshold = self.var[self.trail[lim2].vi()].reward;
+            let activity_threshold = self.activity(self.trail[lim2].vi());
             for i in (lim..lim2).rev() {
                 let l = self.trail[i];
                 let vi = l.vi();
@@ -38,7 +38,7 @@ impl TrailSavingIF for AssignStack {
                 self.trail_saved.push(l);
                 self.var[vi].reason_saved = self.var[vi].reason;
                 self.reward_at_unassign(vi);
-                if activity_threshold <= self.var[vi].reward {
+                if activity_threshold <= self.activity(vi) {
                     self.insert_heap(vi);
                 }
             }

--- a/src/cdb/db.rs
+++ b/src/cdb/db.rs
@@ -421,6 +421,9 @@ impl ClauseDBIF for ClauseDB {
             watch_cache[!l0].insert_watch(cid, l1);
             watch_cache[!l1].insert_watch(cid, l0);
         }
+        for l in c.lits.iter() {
+            asg.var_mut(l.vi()).num_clauses += 1;
+        }
         RefClause::Clause(cid)
     }
     fn new_clause_sandbox(&mut self, asg: &mut impl AssignIF, vec: &mut Vec<Lit>) -> RefClause {
@@ -485,10 +488,14 @@ impl ClauseDBIF for ClauseDB {
     }
     /// ## Warning
     /// this function is the only function that makes dead clauses
-    fn remove_clause(&mut self, cid: ClauseId) {
-        // assert_eq!(self.clause.iter().skip(1).filter(|c| !c.is_dead()).count(), self.num_clause);
-        // if !self.clause[NonZeroU32::get(cid.ordinal) as usize].is_dead() {
-        // }
+    fn remove_clause(&mut self, asg: &mut impl AssignIF, cid: ClauseId) {
+        {
+            let c = &self.clause[NonZeroU32::get(cid.ordinal) as usize];
+            for l in c.lits.iter() {
+                let v = asg.var_mut(l.vi());
+                v.num_clauses = v.num_clauses.saturating_sub(1);
+            }
+        }
         let c = &mut self.clause[NonZeroU32::get(cid.ordinal) as usize];
         debug_assert!(!c.is_dead());
         debug_assert!(1 < c.lits.len());
@@ -782,7 +789,7 @@ impl ClauseDBIF for ClauseDB {
             debug_assert!(!asg.var(l.vi()).is(FlagVar::ELIMINATED));
             match asg.assigned(*l) {
                 Some(true) => {
-                    self.remove_clause(cid);
+                    self.remove_clause(asg, cid);
                     return RefClause::Dead;
                 }
                 Some(false) => {
@@ -826,7 +833,7 @@ impl ClauseDBIF for ClauseDB {
                     //
                     //## Case:3-0
                     //
-                    self.remove_clause(cid);
+                    self.remove_clause(asg, cid);
                     return RefClause::RegisteredClause(bid);
                 }
                 //
@@ -963,7 +970,7 @@ impl ClauseDBIF for ClauseDB {
         learnt
     }
     /// reduce the number of 'learnt' or *removable* clauses.
-    fn reduce(&mut self, _asg: &mut impl AssignIF, envelope: usize) {
+    fn reduce(&mut self, asg: &mut impl AssignIF, envelope: usize) {
         let ClauseDB {
             clause,
             // lbd_temp,
@@ -1015,7 +1022,7 @@ impl ClauseDBIF for ClauseDB {
         self.reduction_threshold = keep as f64 / self.num_learnt as f64;
         perm.sort();
         for i in perm.iter().skip(keep) {
-            self.remove_clause(ClauseId::from(i.to()));
+            self.remove_clause(asg, ClauseId::from(i.to()));
         }
     }
     fn reset(&mut self) {

--- a/src/cdb/db.rs
+++ b/src/cdb/db.rs
@@ -2,7 +2,6 @@ use {
     super::{
         BinaryLinkDB, CertificationStore, ClauseDBIF, ClauseId, RefClause,
         binary::{BinaryLinkIF, BinaryLinkList},
-        ema::ProgressLBD,
         property,
         watch_cache::*,
     },
@@ -59,7 +58,7 @@ pub struct ClauseDB {
     //
     /// a working buffer for LBD calculation
     lbd_temp: Vec<usize>,
-    pub(crate) lbd: ProgressLBD,
+    pub(crate) lbd: Ema2,
 
     //## Reduction
     leanrt_limit_ema: Ema,
@@ -108,7 +107,7 @@ impl Default for ClauseDB {
             activity_anti_decay: 0.01,
 
             lbd_temp: Vec::new(),
-            lbd: ProgressLBD::default(),
+            lbd: Ema2::default(),
             leanrt_limit_ema: Ema::default().with_value(40_000.0),
 
             num_clause: 0,
@@ -247,7 +246,7 @@ impl Instantiate for ClauseDB {
             watch_cache: watcher,
             certification_store: CertificationStore::instantiate(config, cnf),
             soft_limit: config.c_cls_lim,
-            lbd: ProgressLBD::instantiate(config, cnf),
+            lbd: Ema2::default(),
 
             #[cfg(feature = "clause_rewarding")]
             activity_decay: config.crw_dcy_rat,

--- a/src/cdb/ema.rs
+++ b/src/cdb/ema.rs
@@ -39,6 +39,12 @@ impl EmaMutIF for ProgressLBD {
     fn reset_to(&mut self, val: f64) {
         self.ema.reset_to(val);
     }
+    fn set_spans(&mut self, f: f64, s: f64) {
+        self.ema.set_spans(f, s);
+    }
+    fn rescale_span(&mut self, r: f64) {
+        self.ema.rescale_span(r)
+    }
     fn as_view(&self) -> &EmaView {
         self.ema.as_view()
     }

--- a/src/cdb/mod.rs
+++ b/src/cdb/mod.rs
@@ -94,7 +94,7 @@ pub trait ClauseDBIF:
     fn new_clause(&mut self, asg: &mut impl AssignIF, v: &mut Vec<Lit>, learnt: bool) -> RefClause;
     fn new_clause_sandbox(&mut self, asg: &mut impl AssignIF, v: &mut Vec<Lit>) -> RefClause;
     /// un-register a clause `cid` from clause database and make the clause dead.
-    fn remove_clause(&mut self, cid: ClauseId);
+    fn remove_clause(&mut self, asg: &mut impl AssignIF, cid: ClauseId);
     /// un-register a clause `cid` from clause database and make the clause dead.
     fn remove_clause_sandbox(&mut self, cid: ClauseId);
     /// update watches of the clause

--- a/src/cdb/mod.rs
+++ b/src/cdb/mod.rs
@@ -4,8 +4,6 @@ mod activity;
 mod binary;
 /// methods on `ClauseDB`
 mod db;
-/// EMA
-mod ema;
 /// methods for Stochastic Local Search
 mod sls;
 /// methods for UNSAT certification

--- a/src/cdb/vivify.rs
+++ b/src/cdb/vivify.rs
@@ -139,7 +139,7 @@ impl VivifyIF for ClauseDB {
                                     }
                                     #[cfg(not(feature = "clause_rewarding"))]
                                     self.new_clause(asg, &mut vec, is_learnt);
-                                    self.remove_clause(cid);
+                                    self.remove_clause(asg, cid);
                                     num_shrink += 1;
                                 }
                             }

--- a/src/config.rs
+++ b/src/config.rs
@@ -116,7 +116,7 @@ impl Default for Config {
             elm_grw_lim: 0,
             elm_var_occ: 20000,
 
-            vrw_learning_rate: 0.04,
+            vrw_learning_rate: 0.001,
         }
     }
 }

--- a/src/processor/eliminate.rs
+++ b/src/processor/eliminate.rs
@@ -120,14 +120,14 @@ pub fn eliminate_var(
             continue;
         }
         elim.remove_cid_occur(asg, *cid, &mut cdb[*cid]);
-        cdb.remove_clause(*cid);
+        cdb.remove_clause(asg, *cid);
     }
     for cid in neg.iter() {
         if cdb[*cid].is_dead() {
             continue;
         }
         elim.remove_cid_occur(asg, *cid, &mut cdb[*cid]);
-        cdb.remove_clause(*cid);
+        cdb.remove_clause(asg, *cid);
     }
     elim[vi].clear();
     asg.handle(SolverEvent::Eliminate(vi));

--- a/src/processor/subsume.rs
+++ b/src/processor/subsume.rs
@@ -31,7 +31,7 @@ impl Eliminator {
                     cdb[cid].turn_off(FlagClause::LEARNT);
                 }
                 self.remove_cid_occur(asg, did, &mut cdb[did]);
-                cdb.remove_clause(did);
+                cdb.remove_clause(asg, did);
                 self.num_subsumed += 1;
             }
             // To avoid making a big clause, we have to add a condition for combining them.
@@ -99,19 +99,20 @@ fn strengthen_clause(
             #[cfg(feature = "trace_elimination")]
             println!("cid {} drops literal {}", cid, l);
 
+            asg.var_mut(l.vi()).num_clauses = asg.var_mut(l.vi()).num_clauses.saturating_sub(1);
             elim.enqueue_clause(cid, &mut cdb[cid]);
             elim.remove_lit_occur(asg, l, cid);
             Ok(())
         }
         RefClause::RegisteredClause(_) => {
             elim.remove_cid_occur(asg, cid, &mut cdb[cid]);
-            cdb.remove_clause(cid);
+            cdb.remove_clause(asg, cid);
             Ok(())
         }
         RefClause::UnitClause(l0) => {
             cdb.certificate_add_assertion(l0);
             elim.remove_cid_occur(asg, cid, &mut cdb[cid]);
-            cdb.remove_clause(cid);
+            cdb.remove_clause(asg, cid);
             match asg.assigned(l0) {
                 None => asg.assign_at_root_level(cdb, l0),
                 Some(true) => Ok(()),

--- a/src/solver/conflict.rs
+++ b/src/solver/conflict.rs
@@ -158,7 +158,7 @@ pub fn handle_conflict(
     {
         Some(true)
     } else if cfg!(feature = "BT_deepen")
-        && !asg.ordering_by_conflict
+        && asg.activity_scheme == VarActivityScheme::LRB
         && assign_level > 0
         && new_learnt.len() > 2
         && new_learnt

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -218,16 +218,19 @@ fn search(
 
     // monotonic increment counter
     let mut span_len: usize = 1;
-    let cooling_len: usize = 20;
+    let cooling_len: usize = 0;
     let mut processing_pressure: usize = 0;
     let mut ruduction_pressure: usize = 0;
     let processing_interval: usize = 40_000;
     let mut progress_pressure: usize = 0;
     let progress_interval: usize = 10_000;
-    let mut switch_pressure: usize = 0;
-    let switch_interval: usize = 20_000;
+    // let mut switch_pressure: usize = 0;
+    // let switch_interval: usize = 2_000;
 
-    state.span_manager.reset();
+    asg.activity_scheme = VarActivityScheme::LRB;
+    asg.set_learning_rate(state.config.vrw_learning_rate);
+    asg.rebuild_order();
+
     while 0 < asg.derefer(assign::property::Tusize::NumUnassignedVar) || asg.remains() {
         if !asg.remains() {
             let lit = asg.select_decision_literal();
@@ -238,7 +241,8 @@ fn search(
         };
         progress_pressure += 1;
         span_len += 1;
-        if asg.decision_level() == asg.root_level() {
+        let conflicting_level: DecisionLevel = asg.decision_level();
+        if conflicting_level == asg.root_level() {
             return Err(SolverError::RootLevelConflict(cc));
         }
         asg.cdb_num_clauses = cdb.derefer(cdb::property::Tusize::NumClause);
@@ -249,7 +253,23 @@ fn search(
         }
         let lbd = handle_conflict(asg, cdb, state, &cc)?;
         match lbd.cmp(&1) {
-            std::cmp::Ordering::Less => (),
+            std::cmp::Ordering::Less => match asg.activity_scheme {
+                VarActivityScheme::CR => {
+                    state.search_mode_ratio.0.update(1.0);
+                    state.search_mode_ratio.1.update(0.0);
+                    state.search_mode_ratio.2.update(0.0);
+                }
+                VarActivityScheme::LRB => {
+                    state.search_mode_ratio.0.update(0.0);
+                    state.search_mode_ratio.1.update(1.0);
+                    state.search_mode_ratio.2.update(0.0);
+                }
+                VarActivityScheme::VMTF => {
+                    state.search_mode_ratio.0.update(0.0);
+                    state.search_mode_ratio.1.update(0.0);
+                    state.search_mode_ratio.2.update(1.0);
+                }
+            },
             std::cmp::Ordering::Equal => (),
             std::cmp::Ordering::Greater => {
                 ruduction_pressure += 1;
@@ -261,97 +281,77 @@ fn search(
             cdb.reduce(asg, state.span_manager.envelop_index());
             ruduction_pressure = 0;
         }
-        switch_pressure += 1;
+        // switch_pressure += 1;
 
-        if switch_pressure.is_multiple_of(1000) {
-            match asg.activity_scheme {
-                VarActivityScheme::LRB => {
-                    state.search_mode_ratio.0.update(1.0);
-                    state.search_mode_ratio.1.update(0.0);
-                    state.search_mode_ratio.2.update(0.0);
-                }
-                VarActivityScheme::VMTF => {
-                    state.search_mode_ratio.0.update(0.0);
-                    state.search_mode_ratio.1.update(1.0);
-                    state.search_mode_ratio.2.update(0.0);
-                }
-                VarActivityScheme::CR => {
-                    state.search_mode_ratio.0.update(0.0);
-                    state.search_mode_ratio.1.update(0.0);
-                    state.search_mode_ratio.2.update(1.0);
-                }
-            }
-        }
         if state
             .span_manager
             .span_ended(span_len.saturating_sub(cooling_len))
         {
-            match asg.activity_scheme {
-                VarActivityScheme::LRB if switch_pressure >= 2 * switch_interval => {
+            /* match asg.activity_scheme {
+                VarActivityScheme::CR if switch_pressure >= switch_interval => {
                     asg.activity_scheme = VarActivityScheme::VMTF;
                     asg.set_learning_rate(state.config.vrw_learning_rate);
                     asg.rebuild_order();
                     switch_pressure = 0;
                 }
-                VarActivityScheme::VMTF if switch_pressure >= switch_interval => {
-                    asg.activity_scheme = VarActivityScheme::CR;
+                VarActivityScheme::LRB if switch_pressure >= switch_interval => {
+                    // asg.activity_scheme = VarActivityScheme::CR;
+                    asg.activity_scheme = VarActivityScheme::VMTF;
+                    // asg.set_learning_rate(state.config.vrw_learning_rate);
                     // asg.set_learning_rate(0.0);
                     asg.rebuild_order();
                     switch_pressure = 0;
                 }
-                VarActivityScheme::CR if switch_pressure >= switch_interval => {
-                    asg.activity_scheme = VarActivityScheme::LRB;
-                    // asg.set_learning_rate(0.0);
+                VarActivityScheme::VMTF if switch_pressure >= 10 * switch_interval => {
+                    asg.activity_scheme = VarActivityScheme::CR;
+                    asg.set_learning_rate(state.config.vrw_learning_rate);
                     asg.rebuild_order();
                     switch_pressure = 0;
                 }
                 _ => (),
-            }
-            // let cia = asg.conflict_interval_average.0.trend();
-            // let cil = asg.conflict_interval_average.1.trend();
-            // if cia + cil < 1.96 {
-            if cdb.lbd.trend() > 1.5 && asg.activity_scheme != VarActivityScheme::VMTF {
-                RESTART!(asg, cdb, state);
-                asg.clear_asserted_literals(cdb)?;
-            }
-            /*
-            if (!focusing && cia + cil >= 2.2) || (focusing && cia + cil >= 2.0) {
-                // if (!focusing && cia <= 1.0 && cil > 1.0) || (focusing && cia >= 1.0 && cil < 1.0) {
-                if !focusing {
-                    focusing = true;
-                    asg.set_learning_rate(0.0);
-                    asg.use_conflict_order(focusing);
+            } */
+            if span_len >= conflicting_level as usize {
+                if asg.activity_scheme != VarActivityScheme::VMTF && cdb.lbd.trend() > 1.25
+                // conflicting_level >= state.c_lvl.get_slow() as DecisionLevel
+                {
+                    RESTART!(asg, cdb, state);
+                    asg.clear_asserted_literals(cdb)?;
                 }
-                RESTART!(asg, cdb, state);
-                asg.clear_asserted_literals(cdb)?;
-                state.search_mode_ratio.0.update(1.0);
-                state.search_mode_ratio.1.update(0.0);
-                state.search_mode_ratio.2.update(0.0);
-            } else if cia + cil >= 1.96 {
-                if focusing {
-                    focusing = false;
-                    asg.set_learning_rate(state.config.vrw_learning_rate);
-                    asg.use_conflict_order(focusing);
+                match asg.activity_scheme {
+                    VarActivityScheme::CR if state.c_lvl.trend() <= 1.1 => {
+                        asg.activity_scheme = VarActivityScheme::LRB;
+                        asg.set_learning_rate(state.config.vrw_learning_rate);
+                        asg.rebuild_order();
+                        // switch_pressure = 0;
+                    }
+                    VarActivityScheme::LRB if cdb.lbd.trend() <= 0.6 => {
+                        asg.activity_scheme = VarActivityScheme::VMTF;
+                        asg.set_learning_rate(0.0);
+                        asg.rebuild_order();
+                        // switch_pressure = 0;
+                    }
+                    VarActivityScheme::LRB if cdb.lbd.trend() >= 2.2 => {
+                        asg.activity_scheme = VarActivityScheme::CR;
+                        asg.set_learning_rate(0.0);
+                        asg.rebuild_order();
+                        // switch_pressure = 0;
+                    }
+                    VarActivityScheme::VMTF if cdb.lbd.trend() >= 1.1 => {
+                        asg.activity_scheme = VarActivityScheme::LRB;
+                        asg.set_learning_rate(state.config.vrw_learning_rate);
+                        asg.rebuild_order();
+                        // switch_pressure = 0;
+                    }
+                    _ => (),
                 }
-                state.search_mode_ratio.0.update(0.0);
-                state.search_mode_ratio.1.update(1.0);
-                state.search_mode_ratio.2.update(0.0);
-            } else {
-                if focusing {
-                    focusing = false;
-                    asg.set_learning_rate(state.config.vrw_learning_rate);
-                    asg.use_conflict_order(focusing);
+                span_len = 0;
+                let new_span = state.span_manager.prepare_new_span(span_len);
+                if new_span == Some(true) {
+                    state.config.vrw_learning_rate *= 0.999;
                 }
-                RESTART!(asg, cdb, state);
-                asg.clear_asserted_literals(cdb)?;
-                state.search_mode_ratio.0.update(0.0);
-                state.search_mode_ratio.1.update(0.0);
-                state.search_mode_ratio.2.update(1.0);
+
+                dump_stage(asg, cdb, state, new_span);
             }
-            */
-            span_len = 0;
-            let new_span = state.span_manager.prepare_new_span(span_len);
-            dump_stage(asg, cdb, state, new_span);
             if asg.decision_level() == asg.root_level {
                 #[cfg(feature = "rephase")]
                 {
@@ -374,6 +374,9 @@ fn search(
             }
         }
         if progress_pressure >= progress_interval {
+            state.search_mode_ratio.0.update(0.0);
+            state.search_mode_ratio.1.update(0.0);
+            state.search_mode_ratio.2.update(0.0);
             state.progress(asg, cdb);
             if let Some(p) = state.elapsed() {
                 if 1.0 <= p {

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -226,6 +226,7 @@ fn search(
     let progress_interval: usize = 10_000;
     // let mut switch_pressure: usize = 0;
     // let switch_interval: usize = 2_000;
+    let mut last_activity: f64 = 0.0;
 
     asg.activity_scheme = VarActivityScheme::LRB;
     asg.set_learning_rate(state.config.vrw_learning_rate);
@@ -274,7 +275,7 @@ fn search(
             std::cmp::Ordering::Greater => {
                 ruduction_pressure += 1;
                 processing_pressure += 1;
-                cdb.lbd.update(lbd);
+                cdb.lbd.update(lbd as f64);
             }
         }
         if ruduction_pressure >= processing_interval {
@@ -310,15 +311,24 @@ fn search(
                 }
                 _ => (),
             } */
-            if span_len >= conflicting_level as usize {
-                if asg.activity_scheme != VarActivityScheme::VMTF && cdb.lbd.trend() > 1.25
-                // conflicting_level >= state.c_lvl.get_slow() as DecisionLevel
+            /*if span_len >= conflicting_level as usize / 2 {
+            if (asg.activity_scheme == VarActivityScheme::CR && cdb.lbd.trend() > 1.5)
+                || (asg.activity_scheme == VarActivityScheme::LRB && cdb.lbd.trend() > 1.15)
+                || asg.activity_scheme == VarActivityScheme::VMTF
+            // conflicting_level >= state.c_lvl.get_slow() as DecisionLevel
+            */
+            if (asg.activity_scheme == VarActivityScheme::CR && cdb.lbd.trend() > 1.5)
+                || (asg.activity_scheme == VarActivityScheme::LRB
+                    && asg.activity(cc.0.vi()) < last_activity)
+                || (asg.activity_scheme == VarActivityScheme::VMTF && cdb.lbd.trend() > 1.25)
+            {
                 {
                     RESTART!(asg, cdb, state);
                     asg.clear_asserted_literals(cdb)?;
+                    last_activity = 0.0;
                 }
                 match asg.activity_scheme {
-                    VarActivityScheme::CR if state.c_lvl.trend() <= 1.1 => {
+                    VarActivityScheme::CR if cdb.lbd.trend() <= 1.4 => {
                         asg.activity_scheme = VarActivityScheme::LRB;
                         asg.set_learning_rate(state.config.vrw_learning_rate);
                         asg.rebuild_order();
@@ -330,12 +340,12 @@ fn search(
                         asg.rebuild_order();
                         // switch_pressure = 0;
                     }
-                    VarActivityScheme::LRB if cdb.lbd.trend() >= 2.2 => {
-                        asg.activity_scheme = VarActivityScheme::CR;
-                        asg.set_learning_rate(0.0);
-                        asg.rebuild_order();
-                        // switch_pressure = 0;
-                    }
+                    // VarActivityScheme::LRB if cdb.lbd.trend() >= 2.0 => {
+                    //     asg.activity_scheme = VarActivityScheme::CR;
+                    //     // asg.set_learning_rate(0.0);
+                    //     // asg.rebuild_order();
+                    //     // switch_pressure = 0;
+                    // }
                     VarActivityScheme::VMTF if cdb.lbd.trend() >= 1.1 => {
                         asg.activity_scheme = VarActivityScheme::LRB;
                         asg.set_learning_rate(state.config.vrw_learning_rate);
@@ -348,9 +358,13 @@ fn search(
                 let new_span = state.span_manager.prepare_new_span(span_len);
                 if new_span == Some(true) {
                     state.config.vrw_learning_rate *= 0.999;
+                    cdb.lbd
+                        .set_spans(0.5 * state.c_lvl.get_slow(), 8.0 * state.c_lvl.get_slow());
                 }
 
                 dump_stage(asg, cdb, state, new_span);
+            } else {
+                last_activity = asg.activity(cc.0.vi());
             }
             if asg.decision_level() == asg.root_level {
                 #[cfg(feature = "rephase")]

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -287,23 +287,30 @@ fn search(
             .span_ended(span_len.saturating_sub(cooling_len))
         {
             match asg.activity_scheme {
-                VarActivityScheme::CR if switch_pressure >= switch_interval => {
-                    asg.activity_scheme = VarActivityScheme::LRB;
-                    asg.set_learning_rate(0.0);
+                VarActivityScheme::LRB if switch_pressure >= 2 * switch_interval => {
+                    asg.activity_scheme = VarActivityScheme::VMTF;
+                    asg.set_learning_rate(state.config.vrw_learning_rate);
                     asg.rebuild_order();
                     switch_pressure = 0;
                 }
-                VarActivityScheme::LRB if switch_pressure >= 2 * switch_interval => {
+                VarActivityScheme::VMTF if switch_pressure >= switch_interval => {
                     asg.activity_scheme = VarActivityScheme::CR;
-                    asg.set_learning_rate(state.config.vrw_learning_rate);
+                    // asg.set_learning_rate(0.0);
+                    asg.rebuild_order();
+                    switch_pressure = 0;
+                }
+                VarActivityScheme::CR if switch_pressure >= switch_interval => {
+                    asg.activity_scheme = VarActivityScheme::LRB;
+                    // asg.set_learning_rate(0.0);
                     asg.rebuild_order();
                     switch_pressure = 0;
                 }
                 _ => (),
             }
-            let cia = asg.conflict_interval_average.0.trend();
-            let cil = asg.conflict_interval_average.1.trend();
-            if cia + cil < 1.96 {
+            // let cia = asg.conflict_interval_average.0.trend();
+            // let cil = asg.conflict_interval_average.1.trend();
+            // if cia + cil < 1.96 {
+            if cdb.lbd.trend() > 1.5 && asg.activity_scheme != VarActivityScheme::VMTF {
                 RESTART!(asg, cdb, state);
                 asg.clear_asserted_literals(cdb)?;
             }

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -224,7 +224,8 @@ fn search(
     let processing_interval: usize = 40_000;
     let mut progress_pressure: usize = 0;
     let progress_interval: usize = 10_000;
-    let mut focusing = false;
+    let mut switch_pressure: usize = 0;
+    let switch_interval: usize = 20_000;
 
     state.span_manager.reset();
     while 0 < asg.derefer(assign::property::Tusize::NumUnassignedVar) || asg.remains() {
@@ -240,6 +241,7 @@ fn search(
         if asg.decision_level() == asg.root_level() {
             return Err(SolverError::RootLevelConflict(cc));
         }
+        asg.cdb_num_clauses = cdb.derefer(cdb::property::Tusize::NumClause);
         asg.update_activity_tick();
         #[cfg(feature = "clause_rewarding")]
         {
@@ -259,43 +261,90 @@ fn search(
             cdb.reduce(asg, state.span_manager.envelop_index());
             ruduction_pressure = 0;
         }
+        switch_pressure += 1;
 
+        if switch_pressure.is_multiple_of(1000) {
+            match asg.activity_scheme {
+                VarActivityScheme::LRB => {
+                    state.search_mode_ratio.0.update(1.0);
+                    state.search_mode_ratio.1.update(0.0);
+                    state.search_mode_ratio.2.update(0.0);
+                }
+                VarActivityScheme::VMTF => {
+                    state.search_mode_ratio.0.update(0.0);
+                    state.search_mode_ratio.1.update(1.0);
+                    state.search_mode_ratio.2.update(0.0);
+                }
+                VarActivityScheme::CR => {
+                    state.search_mode_ratio.0.update(0.0);
+                    state.search_mode_ratio.1.update(0.0);
+                    state.search_mode_ratio.2.update(1.0);
+                }
+            }
+        }
         if state
             .span_manager
             .span_ended(span_len.saturating_sub(cooling_len))
         {
+            match asg.activity_scheme {
+                VarActivityScheme::CR if switch_pressure >= switch_interval => {
+                    asg.activity_scheme = VarActivityScheme::LRB;
+                    asg.set_learning_rate(0.0);
+                    asg.rebuild_order();
+                    switch_pressure = 0;
+                }
+                VarActivityScheme::LRB if switch_pressure >= 2 * switch_interval => {
+                    asg.activity_scheme = VarActivityScheme::CR;
+                    asg.set_learning_rate(state.config.vrw_learning_rate);
+                    asg.rebuild_order();
+                    switch_pressure = 0;
+                }
+                _ => (),
+            }
             let cia = asg.conflict_interval_average.0.trend();
             let cil = asg.conflict_interval_average.1.trend();
-            if (!focusing && cia <= 1.0 && cil > 1.0) || (focusing && cia >= 1.0 && cil < 1.0) {
-                focusing = true;
+            if cia + cil < 1.96 {
+                RESTART!(asg, cdb, state);
+                asg.clear_asserted_literals(cdb)?;
+            }
+            /*
+            if (!focusing && cia + cil >= 2.2) || (focusing && cia + cil >= 2.0) {
+                // if (!focusing && cia <= 1.0 && cil > 1.0) || (focusing && cia >= 1.0 && cil < 1.0) {
+                if !focusing {
+                    focusing = true;
+                    asg.set_learning_rate(0.0);
+                    asg.use_conflict_order(focusing);
+                }
                 RESTART!(asg, cdb, state);
                 asg.clear_asserted_literals(cdb)?;
                 state.search_mode_ratio.0.update(1.0);
                 state.search_mode_ratio.1.update(0.0);
                 state.search_mode_ratio.2.update(0.0);
             } else if cia + cil >= 1.96 {
-                focusing = false;
+                if focusing {
+                    focusing = false;
+                    asg.set_learning_rate(state.config.vrw_learning_rate);
+                    asg.use_conflict_order(focusing);
+                }
                 state.search_mode_ratio.0.update(0.0);
                 state.search_mode_ratio.1.update(1.0);
                 state.search_mode_ratio.2.update(0.0);
             } else {
-                focusing = false;
+                if focusing {
+                    focusing = false;
+                    asg.set_learning_rate(state.config.vrw_learning_rate);
+                    asg.use_conflict_order(focusing);
+                }
                 RESTART!(asg, cdb, state);
                 asg.clear_asserted_literals(cdb)?;
                 state.search_mode_ratio.0.update(0.0);
                 state.search_mode_ratio.1.update(0.0);
                 state.search_mode_ratio.2.update(1.0);
             }
+            */
             span_len = 0;
             let new_span = state.span_manager.prepare_new_span(span_len);
             dump_stage(asg, cdb, state, new_span);
-            if focusing {
-                asg.set_learning_rate(0.0);
-            } else {
-                asg.set_learning_rate(state.config.vrw_learning_rate);
-            };
-            asg.use_conflict_order(focusing);
-
             if asg.decision_level() == asg.root_level {
                 #[cfg(feature = "rephase")]
                 {

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -221,14 +221,16 @@ fn search(
     let cooling_len: usize = 0;
     let mut processing_pressure: usize = 0;
     let mut ruduction_pressure: usize = 0;
-    let processing_interval: usize = 40_000;
+    let processing_interval: usize = 30_000;
     let mut progress_pressure: usize = 0;
     let progress_interval: usize = 10_000;
-    // let mut switch_pressure: usize = 0;
-    // let switch_interval: usize = 2_000;
+    let mut switch_pressure: usize = 0;
+    let switch_interval: usize = 20_000;
     let mut last_activity: f64 = 0.0;
+    let _restart_pressure: usize = 0;
+    let mut lbd_ema: Ema2 = Ema2::default().has_long().with_value(10.0);
 
-    asg.activity_scheme = VarActivityScheme::LRB;
+    asg.activity_scheme = VarActivityScheme::VMTF;
     asg.set_learning_rate(state.config.vrw_learning_rate);
     asg.rebuild_order();
 
@@ -276,14 +278,33 @@ fn search(
                 ruduction_pressure += 1;
                 processing_pressure += 1;
                 cdb.lbd.update(lbd as f64);
+                if asg.activity_scheme != VarActivityScheme::VMTF {
+                    lbd_ema.update(lbd as f64);
+                }
             }
         }
         if ruduction_pressure >= processing_interval {
             cdb.reduce(asg, state.span_manager.envelop_index());
             ruduction_pressure = 0;
         }
-        // switch_pressure += 1;
+        switch_pressure += 1;
 
+        if
+        // (asg.activity_scheme == VarActivityScheme::CR && cdb.lbd.trend() > 1.5)
+        (asg.activity_scheme == VarActivityScheme::CR && asg.activity(cc.0.vi()) < last_activity)
+            || (asg.activity_scheme == VarActivityScheme::LRB
+                && asg.activity(cc.0.vi()) <= last_activity)
+        // || (asg.activity_scheme == VarActivityScheme::VMTF && asg.activity(cc.0.vi()) < last_activity)
+        // || (asg.activity_scheme == VarActivityScheme::VMTF && cdb.lbd.trend() > 1.25)
+        {
+            RESTART!(asg, cdb, state);
+            asg.clear_asserted_literals(cdb)?;
+            // restart_pressure = 0;
+            last_activity *= 0.8;
+        } else {
+            // restart_pressure += 1;
+            last_activity = asg.activity(cc.0.vi());
+        }
         if state
             .span_manager
             .span_ended(span_len.saturating_sub(cooling_len))
@@ -317,54 +338,53 @@ fn search(
                 || asg.activity_scheme == VarActivityScheme::VMTF
             // conflicting_level >= state.c_lvl.get_slow() as DecisionLevel
             */
-            if (asg.activity_scheme == VarActivityScheme::CR && cdb.lbd.trend() > 1.5)
+            if
+            // (asg.activity_scheme == VarActivityScheme::CR && cdb.lbd.trend() > 1.5)
+            (asg.activity_scheme == VarActivityScheme::CR
+                && asg.activity(cc.0.vi()) < last_activity)
                 || (asg.activity_scheme == VarActivityScheme::LRB
-                    && asg.activity(cc.0.vi()) < last_activity)
-                || (asg.activity_scheme == VarActivityScheme::VMTF && cdb.lbd.trend() > 1.25)
+                    && (lbd_ema.trend() > 0.9 + last_activity
+                        || asg.activity(cc.0.vi()) < last_activity))
+            // || (asg.activity_scheme == VarActivityScheme::VMTF && asg.activity(cc.0.vi()) < last_activity)
+            // || (asg.activity_scheme == VarActivityScheme::VMTF && cdb.lbd.trend() > 1.25)
             {
-                {
-                    RESTART!(asg, cdb, state);
-                    asg.clear_asserted_literals(cdb)?;
-                    last_activity = 0.0;
-                }
-                match asg.activity_scheme {
-                    VarActivityScheme::CR if cdb.lbd.trend() <= 1.4 => {
-                        asg.activity_scheme = VarActivityScheme::LRB;
-                        asg.set_learning_rate(state.config.vrw_learning_rate);
-                        asg.rebuild_order();
-                        // switch_pressure = 0;
-                    }
-                    VarActivityScheme::LRB if cdb.lbd.trend() <= 0.6 => {
-                        asg.activity_scheme = VarActivityScheme::VMTF;
-                        asg.set_learning_rate(0.0);
-                        asg.rebuild_order();
-                        // switch_pressure = 0;
-                    }
-                    // VarActivityScheme::LRB if cdb.lbd.trend() >= 2.0 => {
-                    //     asg.activity_scheme = VarActivityScheme::CR;
-                    //     // asg.set_learning_rate(0.0);
-                    //     // asg.rebuild_order();
-                    //     // switch_pressure = 0;
-                    // }
-                    VarActivityScheme::VMTF if cdb.lbd.trend() >= 1.1 => {
-                        asg.activity_scheme = VarActivityScheme::LRB;
-                        asg.set_learning_rate(state.config.vrw_learning_rate);
-                        asg.rebuild_order();
-                        // switch_pressure = 0;
-                    }
-                    _ => (),
-                }
-                span_len = 0;
-                let new_span = state.span_manager.prepare_new_span(span_len);
-                if new_span == Some(true) {
-                    state.config.vrw_learning_rate *= 0.999;
-                    cdb.lbd
-                        .set_spans(0.5 * state.c_lvl.get_slow(), 8.0 * state.c_lvl.get_slow());
-                }
-
-                dump_stage(asg, cdb, state, new_span);
+                RESTART!(asg, cdb, state);
+                asg.clear_asserted_literals(cdb)?;
+                // restart_pressure = 0;
+                last_activity *= 0.8;
             } else {
+                // restart_pressure += 1;
                 last_activity = asg.activity(cc.0.vi());
+            }
+            span_len = 0;
+            let new_span = state.span_manager.prepare_new_span(span_len);
+            // if new_span == Some(true) {
+            //     state.config.vrw_learning_rate *= 0.999;
+            //     cdb.lbd
+            //         .set_spans(0.5 * state.c_lvl.get_slow(), 8.0 * state.c_lvl.get_slow());
+            // }
+            dump_stage(asg, cdb, state, new_span);
+            match asg.activity_scheme {
+                VarActivityScheme::CR if switch_pressure >= switch_interval => {
+                    asg.activity_scheme = VarActivityScheme::LRB;
+                    asg.set_learning_rate(state.config.vrw_learning_rate * 0.1);
+                    asg.rebuild_order();
+                    switch_pressure = 0;
+                }
+                VarActivityScheme::LRB if switch_pressure >= switch_interval => {
+                    asg.activity_scheme = VarActivityScheme::VMTF;
+                    // asg.set_learning_rate(state.config.vrw_learning_rate);
+                    asg.set_learning_rate(0.0);
+                    asg.rebuild_order();
+                    switch_pressure = 0;
+                }
+                VarActivityScheme::VMTF if switch_pressure >= switch_interval => {
+                    asg.activity_scheme = VarActivityScheme::LRB;
+                    asg.set_learning_rate(state.config.vrw_learning_rate);
+                    asg.rebuild_order();
+                    switch_pressure = 0;
+                }
+                _ => (),
             }
             if asg.decision_level() == asg.root_level {
                 #[cfg(feature = "rephase")]

--- a/src/state.rs
+++ b/src/state.rs
@@ -462,7 +462,7 @@ impl StateIF for State {
         let asg_num_propagation = asg.derefer(assign::property::Tusize::NumPropagation);
         // let asg_cwss: f64 = asg.derefer(assign::property::Tf64::CurrentWorkingSetSize);
         let asg_dpc_ema = asg.refer(assign::property::TEma::DecisionPerConflict);
-        let asg_ppc_ema = asg.refer(assign::property::TEma::PropagationPerConflict);
+        // let asg_ppc_ema = asg.refer(assign::property::TEma::PropagationPerConflict);
         let asg_cpr_ema = asg.refer(assign::property::TEma::ConflictPerRestart);
 
         let cdb_num_clause = cdb.derefer(cdb::property::Tusize::NumClause);
@@ -576,42 +576,76 @@ impl StateIF for State {
             ),
         );
         println!(
-            "\x1B[2K {}|fcs%:{}, exp%:{}, core:{}, /ppc:{}",
+            "\x1B[2K {}|  CR:{},  LRB:{}, VMTF:{}, core:{}",
+            // "\x1B[2K {}|VMTF:{},   CR:{}, core:{}, /ppc:{}",
             {
-                let s0 = self.search_mode_ratio.0.get();
-                let s1 = self.search_mode_ratio.1.get();
-                let s2 = self.search_mode_ratio.2.get();
-                if s0 >= s1 && s0 >= s2 {
-                    if self.span_manager.current_span() >= 16384 {
-                        " Long focus"
-                    } else {
-                        "      Focus"
+                match asg.activity_scheme() {
+                    VarActivityScheme::CR => {
+                        if self.span_manager.current_span() >= 16384 {
+                            "    Long CR"
+                        } else {
+                            "         CR"
+                        }
                     }
-                } else if s1 >= s2 {
-                    "     Pursue"
-                } else {
-                    "    Explore"
+                    VarActivityScheme::LRB => {
+                        if self.span_manager.current_span() >= 16384 {
+                            "   Long LRB"
+                        } else {
+                            "        LRB"
+                        }
+                    }
+                    VarActivityScheme::VMTF => {
+                        if self.span_manager.current_span() >= 16384 {
+                            "  Long VMTF"
+                        } else {
+                            "       VMTF"
+                        }
+                    }
                 }
             },
-            // fm!(
-            //     "{:>9.2}",
-            //     self,
-            //     LogF64Id::ConflictDistanceAverage,
-            //     asg.refer(assign::property::TEma::ConlictDistanceAverage)
-            //         .trend()
-            // ),
+            // {
+            //     let s0 = self.search_mode_ratio.0.get();
+            //     let s1 = self.search_mode_ratio.1.get();
+            //     let s2 = self.search_mode_ratio.2.get();
+            //     if s0 >= s1 && s0 >= s2 {
+            //         if self.span_manager.current_span() >= 16384 {
+            //             "   Long LRB"
+            //         } else {
+            //             "        LRB"
+            //         }
+            //     } else if s1 >= s2 {
+            //         if self.span_manager.current_span() >= 16384 {
+            //             "  Long VMTF"
+            //         } else {
+            //             "       VMTF"
+            //         }
+            //     } else {
+            //         if self.span_manager.current_span() >= 16384 {
+            //             "    Long CR"
+            //         } else {
+            //             "         CR"
+            //         }
+            //     }
+            // },
             fm!(
                 "{:>9.2}",
                 self,
                 LogF64Id::ConflictDistanceAverage0,
-                100.0 * self.search_mode_ratio.0.get(),
+                100.0 * self.search_mode_ratio.0.get_slow(),
+                10.0
+            ),
+            fm!(
+                "{:>9.2}",
+                self,
+                LogF64Id::ConflictDistanceAverage1,
+                100.0 * self.search_mode_ratio.1.get_slow(),
                 10.0
             ),
             fm!(
                 "{:>9.2}",
                 self,
                 LogF64Id::ConflictDistanceAverage2,
-                100.0 * self.search_mode_ratio.2.get(),
+                100.0 * self.search_mode_ratio.2.get_slow(),
                 10.0
             ),
             // fm!(
@@ -632,13 +666,13 @@ impl StateIF for State {
                     asg_num_unreachables
                 }
             ),
-            fm!(
-                "{:>9.2}",
-                self,
-                LogF64Id::PropagationPerConflict,
-                asg_ppc_ema.get(),
-                0.01
-            ),
+            // fm!(
+            //     "{:>9.2}",
+            //     self,
+            //     LogF64Id::PropagationPerConflict,
+            //     asg_ppc_ema.get(),
+            //     0.01
+            // ),
         );
         self[LogUsizeId::LubySpan] = self.span_manager.current_segment();
         self[LogUsizeId::StageCycle] = self.span_manager.envelop_index();

--- a/src/state.rs
+++ b/src/state.rs
@@ -158,8 +158,14 @@ impl Default for State {
                 Ema2::default().with_value(0.33),
                 Ema2::default().with_value(0.33),
             ),
-            b_lvl: Ema2::default(),
-            c_lvl: Ema2::default(),
+            b_lvl: Ema2::default()
+                .with_fast(8_000)
+                .with_slow(80_000)
+                .with_value(100.0),
+            c_lvl: Ema2::default()
+                .with_fast(8_000)
+                .with_slow(80_000)
+                .with_value(200.0),
             bt_drift_average: Ema::default().with_span(1000),
 
             #[cfg(feature = "chrono_BT")]
@@ -632,21 +638,21 @@ impl StateIF for State {
                 self,
                 LogF64Id::ConflictDistanceAverage0,
                 100.0 * self.search_mode_ratio.0.get_slow(),
-                10.0
+                1.0
             ),
             fm!(
                 "{:>9.2}",
                 self,
                 LogF64Id::ConflictDistanceAverage1,
                 100.0 * self.search_mode_ratio.1.get_slow(),
-                10.0
+                1.0
             ),
             fm!(
                 "{:>9.2}",
                 self,
                 LogF64Id::ConflictDistanceAverage2,
                 100.0 * self.search_mode_ratio.2.get_slow(),
-                10.0
+                1.0
             ),
             // fm!(
             //     "{:>9.4}",

--- a/src/types/ema.rs
+++ b/src/types/ema.rs
@@ -2,7 +2,7 @@
 
 const SPAN_FST: usize = 40;
 const SPAN_MID: usize = 800;
-// const _SPAN_SLW: usize = 8192;
+const SPAN_SLW: usize = 16384;
 
 pub trait EmaIF {
     /// return the fast averate value.
@@ -36,8 +36,8 @@ pub trait EmaMutIF: EmaIF {
     type Input;
     /// reset internal data.
     fn reset_to(&mut self, _: f64) {}
-    fn reset_fast(&mut self) {}
-    fn reset_slow(&mut self) {}
+    fn set_spans(&mut self, f: f64, s: f64);
+    fn rescale_span(&mut self, r: f64);
     /// catch up with the current state.
     fn update(&mut self, x: Self::Input);
     /// return a view.
@@ -119,6 +119,12 @@ impl EmaMutIF for Ema {
         self.val.fast = x;
         self.val.slow = x;
     }
+    fn set_spans(&mut self, f: f64, _: f64) {
+        self.sca = 1.0 / f;
+    }
+    fn rescale_span(&mut self, r: f64) {
+        self.sca *= r;
+    }
 }
 
 impl Ema {
@@ -132,6 +138,10 @@ impl Ema {
             cal: 0.0,
             sca: 1.0 / (s as f64),
         }
+    }
+    pub fn has_long(mut self) -> Self {
+        self.sca = 1.0 * SPAN_MID as f64;
+        self
     }
     /// set value.
     pub fn with_value(mut self, x: f64) -> Ema {
@@ -211,23 +221,13 @@ impl EmaMutIF for Ema2 {
     fn reset_to(&mut self, val: f64) {
         self.ema.fast = val;
     }
-    #[cfg(not(feature = "EMA_calibration"))]
-    fn reset_fast(&mut self) {
-        self.ema.fast = self.ema.slow;
+    fn set_spans(&mut self, f: f64, s: f64) {
+        self.fe = 1.0 / f;
+        self.se = 1.0 / s;
     }
-    #[cfg(feature = "EMA_calibration")]
-    fn reset_fast(&mut self) {
-        self.ema.fast = self.ema.slow;
-        self.calf = self.cals;
-    }
-    #[cfg(not(feature = "EMA_calibration"))]
-    fn reset_slow(&mut self) {
-        self.ema.slow = self.ema.fast;
-    }
-    #[cfg(feature = "EMA_calibration")]
-    fn reset_slow(&mut self) {
-        self.ema.slow = self.ema.fast;
-        self.cals = self.calf;
+    fn rescale_span(&mut self, r: f64) {
+        self.fe *= r;
+        self.se *= r;
     }
     fn as_view(&self) -> &EmaView {
         &self.ema
@@ -248,6 +248,11 @@ impl Ema2 {
             fe: 1.0 / (len as f64),
             se: 1.0 / (len as f64),
         }
+    }
+    pub fn has_long(mut self) -> Self {
+        self.fe = 1.0 * SPAN_MID as f64;
+        self.se = 1.0 * SPAN_SLW as f64;
+        self
     }
     // set first EMA parameter
     pub fn with_fast(mut self, f: usize) -> Ema2 {
@@ -272,10 +277,6 @@ impl Ema2 {
             self.cals = 1.0;
         }
         self
-    }
-    pub fn set_spans(&mut self, ls: usize, ll: usize) {
-        self.fe = 1.0 / ls as f64;
-        self.se = 1.0 / ll as f64;
     }
 }
 
@@ -307,6 +308,12 @@ impl EmaMutIF for EmaSU {
     }
     fn as_view(&self) -> &EmaView {
         self.ema.as_view()
+    }
+    fn set_spans(&mut self, f: f64, s: f64) {
+        self.ema.set_spans(f, s);
+    }
+    fn rescale_span(&mut self, r: f64) {
+        self.ema.rescale_span(r);
     }
 }
 
@@ -350,6 +357,12 @@ impl<const N: usize> EmaMutIF for Ewa<N> {
     }
     fn as_view(&self) -> &EmaView {
         &self.ema
+    }
+    fn set_spans(&mut self, _: f64, _: f64) {
+        unimplemented!()
+    }
+    fn rescale_span(&mut self, _: f64) {
+        unimplemented!()
     }
 }
 
@@ -406,28 +419,17 @@ impl<const N: usize> EmaMutIF for Ewa2<N> {
             self.cals = self.se + self.sx * self.cals;
         }
     }
+    fn set_spans(&mut self, _: f64, _: f64) {
+        unimplemented!()
+    }
     fn reset_to(&mut self, val: f64) {
         self.ema.fast = val;
     }
-    #[cfg(not(feature = "EMA_calibration"))]
-    fn reset_fast(&mut self) {
-        unimplemented!();
-    }
-    #[cfg(feature = "EMA_calibration")]
-    fn reset_fast(&mut self) {
-        unimplemented!();
-    }
-    #[cfg(not(feature = "EMA_calibration"))]
-    fn reset_slow(&mut self) {
-        self.ema.slow = self.ema.fast;
-    }
-    #[cfg(feature = "EMA_calibration")]
-    fn reset_slow(&mut self) {
-        self.ema.slow = self.fast.get();
-        self.cals = self.calf;
-    }
     fn as_view(&self) -> &EmaView {
         &self.ema
+    }
+    fn rescale_span(&mut self, _: f64) {
+        unimplemented!()
     }
 }
 

--- a/src/types/ema.rs
+++ b/src/types/ema.rs
@@ -250,8 +250,8 @@ impl Ema2 {
         }
     }
     pub fn has_long(mut self) -> Self {
-        self.fe = 1.0 * SPAN_MID as f64;
-        self.se = 1.0 * SPAN_SLW as f64;
+        self.fe = 1.0 / SPAN_MID as f64;
+        self.se = 1.0 / SPAN_SLW as f64;
         self
     }
     // set first EMA parameter

--- a/src/types/ema.rs
+++ b/src/types/ema.rs
@@ -1,11 +1,11 @@
 //! API for observing EMA.
 
-const SPAN_FST: usize = 16;
-const SPAN_MID: usize = 256;
-const _SPAN_SLW: usize = 16384;
+const SPAN_FST: usize = 40;
+const SPAN_MID: usize = 800;
+// const _SPAN_SLW: usize = 8192;
 
 pub trait EmaIF {
-    /// return the current value.
+    /// return the fast averate value.
     fn get_fast(&self) -> f64 {
         unimplemented!()
     }
@@ -13,6 +13,7 @@ pub trait EmaIF {
     fn get(&self) -> f64 {
         self.get_fast()
     }
+    /// return the slow average value
     fn get_slow(&self) -> f64 {
         unimplemented!()
     }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -47,6 +47,8 @@ pub trait ActivityIF<Ix> {
     /// set activity
     fn set_activity(&mut self, ix: Ix, val: f64);
     /// modify one's activity at conflict analysis in `conflict_analyze` in [`solver`](`crate::solver`).
+    /// reward vi
+    fn reward_at(&mut self, vi: VarId) -> f64;
     fn reward_at_analysis(&mut self, _ix: Ix) {}
     /// modify one's activity at value assignment in assign.
     fn reward_at_assign(&mut self, _ix: Ix) {}

--- a/src/types/var.rs
+++ b/src/types/var.rs
@@ -97,8 +97,8 @@ pub enum VarActivityScheme {
     /// The number of clauses which include var per the number of all clauses
     CR,
     /// LearningRate Based
-    #[default]
     LRB,
     /// last conflict Var Moves To the queue First
+    #[default]
     VMTF,
 }

--- a/src/types/var.rs
+++ b/src/types/var.rs
@@ -20,7 +20,9 @@ pub struct Var {
     /// the `Flag`s (8 bits)
     pub(crate) flags: FlagVar,
     /// a dynamic evaluation criterion.
-    pub(crate) reward: f64,
+    pub(crate) lrb_reward: f64,
+    /// the number of clauses this var appears in.
+    pub(crate) num_clauses: usize,
     /// the last conflict by this
     pub(crate) last_conflict: usize,
 }
@@ -34,7 +36,8 @@ impl Default for Var {
             #[cfg(feature = "trail_saving")]
             reason_saved: AssignReason::None,
             flags: FlagVar::empty(),
-            reward: 0.0,
+            lrb_reward: 0.0,
+            num_clauses: 0,
             last_conflict: 0,
         }
     }
@@ -58,9 +61,6 @@ impl Var {
                 }
             })
             .collect::<Vec<_>>()
-    }
-    pub fn activity(&self) -> f64 {
-        self.reward
     }
 }
 
@@ -86,4 +86,15 @@ impl FlagIF for Var {
     fn toggle(&mut self, flag: Self::FlagType) {
         self.flags.toggle(flag);
     }
+}
+
+/// Object representing a variable.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum VarActivityScheme {
+    /// LearningRate Based
+    LRB,
+    /// last conflict Var Moves To the queue First
+    VMTF,
+    /// The number of clauses which include var per the number of all clauses
+    CR,
 }

--- a/src/types/var.rs
+++ b/src/types/var.rs
@@ -95,9 +95,9 @@ impl FlagIF for Var {
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub enum VarActivityScheme {
     /// The number of clauses which include var per the number of all clauses
-    #[default]
     CR,
     /// LearningRate Based
+    #[default]
     LRB,
     /// last conflict Var Moves To the queue First
     VMTF,

--- a/src/types/var.rs
+++ b/src/types/var.rs
@@ -1,7 +1,10 @@
 //! Var struct and Database management API
 use {
     // super::{heap::VarHeapIF, stack::AssignStack, AssignIF},
-    crate::types::{AssignReason, DecisionLevel, flags::FlagIF, flags::FlagVar},
+    crate::types::{
+        AssignReason, DecisionLevel,
+        flags::{FlagIF, FlagVar},
+    },
     std::fmt,
 };
 
@@ -89,12 +92,13 @@ impl FlagIF for Var {
 }
 
 /// Object representing a variable.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub enum VarActivityScheme {
+    /// The number of clauses which include var per the number of all clauses
+    #[default]
+    CR,
     /// LearningRate Based
     LRB,
     /// last conflict Var Moves To the queue First
     VMTF,
-    /// The number of clauses which include var per the number of all clauses
-    CR,
 }


### PR DESCRIPTION
## Motivation for Occurrence-Ratio Var Activity and Three-Heuristic Mixture

### What changed

The var activity system was extended from a single EMA-based metric (Learning Rate Branching, LRB) to a three-way rotating scheme across LRB, VMTF, and CR (Clause Ratio / occurrence ratio).

**CR** counts how many live clauses contain each variable and normalises by the total live clause count: `num_clauses / total_live_clauses`. Every time a clause is added the counters for its variables are incremented; every time a clause is removed they are decremented. The ratio is recomputed on demand using a snapshot of the total clause count taken once per conflict.


### What each metric measures

**LRB** measures recent causal involvement: how often has this variable appeared in the resolution chain that produced recent learnt clauses? It is retrospective and operates on a medium timescale — exponential decay forgets old events at a tunable rate.

### The case for CR

**Centrality equals propagation power.** A variable appearing in many clauses will, when assigned, immediately reduce or satisfy a large number of constraints. Branching on it has high leverage — it does a lot of work per decision. This is the same intuition behind the classic DLIS heuristic, but computed over the live clause database rather than the original problem.

**It self-corrects through clause reduction.** After each reduction pass, low-quality learnt clauses are deleted. Variables in those deleted clauses lose count automatically — their score falls in step with the cleanup. LRB has no equivalent mechanism: its decay continues on a fixed
schedule regardless of whether the clauses that caused the bumps were ever useful or have since been discarded. CR is always a faithful snapshot of the current constraint graph; LRB is a noisy integral over a past search trajectory.

**Learnt clauses versus resolved-away literals.** In conflict analysis the bump set — variables marked USED — is the full conflict side of the resolution graph, substantially larger than the final learnt clause. Most bumped variables were resolved away: they do not appear in the clause that actually enters the database. LRB therefore rewards variables for structural roles they played during resolution but that left no persistent trace. CR only credits variables that ended up in a surviving clause, which is the signal that actually matters going forward.

### The case for VMTF alongside CR

One concern is that CR is blind to a variable that appears in few clauses but is a current search bottleneck — repeatedly involved in conflicts despite low structural degree. LRB would have kept such a variable visible through its decay.

VMTF handles this case more cleanly than LRB did. When such a variable causes a conflict it moves to the front of the decision order immediately and unconditionally. LRB would have bumped it by a small decay-scaled increment and then eroded that bump straight away. VMTF gives a stronger short-term signal on active bottlenecks than LRB ever did.

CR and VMTF also age correctly and independently. CR ages through clause deletion; VMTF ages through displacement — a variable that was hot but has gone quiet drifts back down the order as newer conflicts push other variables ahead.

**Cycling provides structured diversification.**

Switching the ordering criterion periodically is a soft restart: it changes decision priorities without discarding learnt clauses. Each scheme will lead the search into a different region of the decision space before handing off. When one scheme's favoured variables lead into a hard subproblem,
the transition to another scheme provides a fresh perspective. A three-way cycle provides strictly more diversification than any two-way cycle, reducing the chance that all phases stall on the same difficult region simultaneously.

**Search phases align naturally with timescales.**

Different phases of CDCL resolution tend to benefit from different ordering criteria. In early search, when the original problem structure dominates and learnt knowledge is sparse, CR's
structural signal is most reliable. During a focused run on a narrow subspace, LRB's trend signal identifies which variables are currently driving conflict loops. Immediately after a restart or deep backjump, VMTF's recency signal preserves the most relevant context from the conflict that triggered the restart. Rotating through all three means each phase is more likely to spend time under its most effective heuristic.
