### PR TITLE
An orchestration of Luby restart, re-phasing selection and decision literal selection 20250507

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ default = [
     ### Heuristics
 
     # "clause_rewarding",
-    # "reason_side_rewarding",
+    "reason_side_rewarding",
     "rephase",
     # "stochastic_local_search",
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ default = [
 
     # "clause_rewarding",
     # "reason_side_rewarding",
-    # "rephase",
+    "rephase",
     # "stochastic_local_search",
 
     ### Logic formula processor

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,8 +40,6 @@ default = [
     # "platform_wasm"
 ]
 
-best_phases_tracking = []       # save the best-so-far assignment, used by 'rephase'
-
 BT_deepen = []                   # backtrack drift
 chrono_BT = []                  # NOT WORK
 clause_elimination = []         # pre(in)-processor setting
@@ -53,12 +51,10 @@ platform_wasm = [
     "instant",                  # use instant::Duration instead of std::time::Duration
 ]
 reason_side_rewarding = []      # an idea used in Learning-rate based rewarding
-rephase = [                     # search around the best-so-far candidate repeatedly
-    "best_phases_tracking",
-]
-stochastic_local_search = [     # since 0.17
-    "rephase",
-]
+rephase = []                    # search around the best-so-far candidate repeatedly
+# stochastic_local_search = [     # since 0.17
+#     "rephase",
+# ]
 
 trace_analysis = []             # for debug
 trace_elimination = []          # for debug

--- a/src/assign/mod.rs
+++ b/src/assign/mod.rs
@@ -79,8 +79,10 @@ pub trait AssignIF:
     fn literal_block_distance(&mut self, lits: &[Lit]) -> DecisionLevel;
     /// compute Literal Block Distance (LBD) of a slice of literals under the current immutable assignment.
     fn literal_block_distance_(&self, lits: &[Lit]) -> usize;
-    /// return current var activity scheme
+    /// return the current var activity scheme
     fn activity_scheme(&self) -> &VarActivityScheme;
+    /// return the current rephase scheme
+    fn phase_mode(&self) -> PhaseRotation;
 }
 
 /// Reasons of assignments

--- a/src/assign/mod.rs
+++ b/src/assign/mod.rs
@@ -18,7 +18,7 @@ pub use self::{
     learning_rate::VarActivityScheme,
     propagate::PropagateIF,
     property::*,
-    select::VarSelectIF,
+    select::{PhaseRotation, VarSelectIF},
     stack::{AssignStack, VarManipulateIF},
 };
 use {
@@ -117,7 +117,6 @@ pub mod property {
         NumConflict,
         NumDecision,
         NumPropagation,
-        NumRephase,
         NumRestart,
         //
         //## var stat
@@ -134,11 +133,10 @@ pub mod property {
         RootLevel,
     }
 
-    pub const USIZES: [Tusize; 14] = [
+    pub const USIZES: [Tusize; 13] = [
         Tusize::NumConflict,
         Tusize::NumDecision,
         Tusize::NumPropagation,
-        Tusize::NumRephase,
         Tusize::NumRestart,
         Tusize::NumVar,
         Tusize::NumAssertedVar,
@@ -158,7 +156,6 @@ pub mod property {
                 Tusize::NumConflict => self.num_conflict,
                 Tusize::NumDecision => self.num_decision,
                 Tusize::NumPropagation => self.num_propagation,
-                Tusize::NumRephase => self.num_rephase,
                 Tusize::NumRestart => self.num_restart,
                 Tusize::NumVar => self.num_vars,
                 Tusize::NumAssertedVar => self.num_asserted_vars,
@@ -210,16 +207,14 @@ pub mod property {
         PropagationPerConflict,
         ConflictPerRestart,
         ConflictPerBaseRestart,
-        BestPhaseDivergenceRate,
         ConlictDistanceAverage,
     }
 
-    pub const EMAS: [TEma; 6] = [
+    pub const EMAS: [TEma; 5] = [
         TEma::DecisionPerConflict,
         TEma::PropagationPerConflict,
         TEma::ConflictPerRestart,
         TEma::ConflictPerBaseRestart,
-        TEma::BestPhaseDivergenceRate,
         TEma::ConlictDistanceAverage,
     ];
 
@@ -231,7 +226,6 @@ pub mod property {
                 TEma::PropagationPerConflict => self.ppc_ema.as_view(),
                 TEma::ConflictPerRestart => self.cpr_ema.as_view(),
                 TEma::ConflictPerBaseRestart => self.cpr_ema.as_view(),
-                TEma::BestPhaseDivergenceRate => self.bp_divergence_ema.as_view(),
                 TEma::ConlictDistanceAverage => self.conflict_interval_average.0.as_view(),
             }
         }

--- a/src/assign/mod.rs
+++ b/src/assign/mod.rs
@@ -71,9 +71,6 @@ pub trait AssignIF:
     fn assign_ref(&self) -> Vec<Option<bool>>;
     /// return the largest number of assigned vars.
     fn best_assigned(&mut self) -> Option<usize>;
-    /// return `true` if no best_phases
-    #[cfg(feature = "rephase")]
-    fn best_phases_invalid(&self) -> bool;
     /// inject assignments for eliminated vars.
     fn extend_model(&mut self, c: &mut impl ClauseDBIF) -> Vec<Option<bool>>;
     /// return `true` if the set of literals is satisfiable under the current assignment.

--- a/src/assign/propagate.rs
+++ b/src/assign/propagate.rs
@@ -237,29 +237,31 @@ impl PropagateIF for AssignStack {
             let v = &mut self.var[vi];
             #[cfg(feature = "trace_propagation")]
             v.turn_off(FlagVar::PROPAGATED);
-            if cfg!(feature = "rephase") {
-                if !v.is(FlagVar::ELIMINATED) && v.reason != AssignReason::Decision(0) {
+            if !v.is(FlagVar::ELIMINATED) && v.reason != AssignReason::Decision(0) {
+                if cfg!(feature = "rephase")
+                // && self.num_conflict - v.last_conflict <= 1000
+                {
                     v.set(
                         FlagVar::PHASE,
                         match self.phase_mode {
-                            PhaseRotation::Walk => v.assign.unwrap(),
-                            PhaseRotation::Original => false,
-                            PhaseRotation::Inverted => true,
+                            PhaseRotation::Last => v.assign.unwrap(),
+                            PhaseRotation::False => false,
+                            PhaseRotation::True => true,
                             PhaseRotation::Best => {
                                 self.best_phases
                                     .get(&vi)
-                                    .unwrap_or(&(false, AssignReason::None))
+                                    .unwrap_or(&(v.assign.unwrap(), AssignReason::None))
                                     .0
                             }
-                            PhaseRotation::Random => {
-                                ((v.reward * 1313.13) as usize).is_multiple_of(2)
-                            }
-                            PhaseRotation::Flipped => !v.assign.unwrap(),
+                            PhaseRotation::Random => ((v.last_conflict as f64 + 1.0 / v.reward)
+                                as usize)
+                                .is_multiple_of(2),
+                            PhaseRotation::Inverted => !v.assign.unwrap(),
                         },
                     );
+                } else {
+                    v.set(FlagVar::PHASE, v.assign.unwrap());
                 }
-            } else {
-                v.set(FlagVar::PHASE, v.assign.unwrap());
             }
 
             unset_assign!(self, vi);

--- a/src/assign/propagate.rs
+++ b/src/assign/propagate.rs
@@ -718,9 +718,5 @@ impl AssignStack {
             }
         }
         self.build_best_at = self.num_propagation;
-        #[cfg(feature = "rephase")]
-        {
-            self.phase_age = 0;
-        }
     }
 }

--- a/src/assign/propagate.rs
+++ b/src/assign/propagate.rs
@@ -1,7 +1,7 @@
 // implement boolean constraint propagation, backjump
 // This version can handle Chronological and Non Chronological Backtrack.
 use {
-    super::{AssignIF, AssignStack, VarManipulateIF, heap::VarHeapIF},
+    super::{AssignIF, AssignStack, PhaseRotation, VarManipulateIF, heap::VarHeapIF},
     crate::{cdb::ClauseDBIF, types::*},
 };
 
@@ -237,7 +237,30 @@ impl PropagateIF for AssignStack {
             let v = &mut self.var[vi];
             #[cfg(feature = "trace_propagation")]
             v.turn_off(FlagVar::PROPAGATED);
-            v.set(FlagVar::PHASE, v.assign.unwrap());
+            if cfg!(feature = "rephase") {
+                if !v.is(FlagVar::ELIMINATED) && v.reason != AssignReason::Decision(0) {
+                    v.set(
+                        FlagVar::PHASE,
+                        match self.phase_mode {
+                            PhaseRotation::Walk => v.assign.unwrap(),
+                            PhaseRotation::Original => false,
+                            PhaseRotation::Inverted => true,
+                            PhaseRotation::Best => {
+                                self.best_phases
+                                    .get(&vi)
+                                    .unwrap_or(&(false, AssignReason::None))
+                                    .0
+                            }
+                            PhaseRotation::Random => {
+                                ((v.reward * 1313.13) as usize).is_multiple_of(2)
+                            }
+                            PhaseRotation::Flipped => !v.assign.unwrap(),
+                        },
+                    );
+                }
+            } else {
+                v.set(FlagVar::PHASE, v.assign.unwrap());
+            }
 
             unset_assign!(self, vi);
             if let AssignReason::Implication(cid) = self.var[vi].reason {
@@ -707,14 +730,11 @@ impl AssignStack {
     }
     /// save the current assignments as the best phases
     fn save_best_phases(&mut self) {
-        #[cfg(feature = "best_phases_tracking")]
-        {
-            self.best_phases.clear();
-            for l in self.trail.iter().skip(self.len_upto(self.root_level)) {
-                let vi = l.vi();
-                if let Some(b) = self.var[vi].assign {
-                    self.best_phases.insert(vi, (b, self.var[vi].reason));
-                }
+        self.best_phases.clear();
+        for l in self.trail.iter().skip(self.len_upto(self.root_level)) {
+            let vi = l.vi();
+            if let Some(b) = self.var[vi].assign {
+                self.best_phases.insert(vi, (b, self.var[vi].reason));
             }
         }
         self.build_best_at = self.num_propagation;

--- a/src/assign/propagate.rs
+++ b/src/assign/propagate.rs
@@ -244,7 +244,7 @@ impl PropagateIF for AssignStack {
                     v.set(
                         FlagVar::PHASE,
                         match self.phase_mode {
-                            PhaseRotation::Last => v.assign.unwrap(),
+                            PhaseRotation::Walk => v.assign.unwrap(),
                             PhaseRotation::False => false,
                             PhaseRotation::True => true,
                             PhaseRotation::Best => {

--- a/src/assign/select.rs
+++ b/src/assign/select.rs
@@ -8,12 +8,25 @@ use {
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub enum PhaseRotation {
     #[default]
-    Walk,
-    Original,
-    Inverted,
+    Last,
     Best,
+    False,
+    True,
     Random,
-    Flipped,
+    Inverted,
+}
+
+impl PhaseRotation {
+    pub fn as_mnemonic(&self) -> &str {
+        match self {
+            PhaseRotation::Last => "*",
+            PhaseRotation::Best => "B",
+            PhaseRotation::False => "F",
+            PhaseRotation::True => "T",
+            PhaseRotation::Random => "R",
+            PhaseRotation::Inverted => "I",
+        }
+    }
 }
 
 /// ```ignore

--- a/src/assign/select.rs
+++ b/src/assign/select.rs
@@ -26,8 +26,16 @@ macro_rules! var_assign {
 
 /// API for var selection, depending on an internal heap.
 pub trait VarSelectIF {
-    // fn save_current_assignment(&self, phases: &mut [bool]);
-    // fn load_assignment(&mut self, phases: &[bool], flip: bool) -> Vec<bool>;
+    /// return a new vector to store phases.
+    fn new_phases_store(&self) -> Vec<Option<bool>>;
+    /// copy the current best phases to `phases`.
+    fn save_best_phases(&self, phases: &mut [bool]);
+    /// copy the current assignments to `phases`.
+    fn save_current_phases(&self, phases: &mut [bool]);
+    /// set `VarFlag::PHASE`s from `phases`.
+    fn load_phases(&mut self, phases: &[bool], flip: bool);
+    /// randomize `VarFlag::PHASE`s.
+    fn randomize_phases(&mut self);
     /// select rephasing target
     fn select_rephasing_target(&mut self);
     /// check the consistency
@@ -41,6 +49,39 @@ pub trait VarSelectIF {
 }
 
 impl VarSelectIF for AssignStack {
+    fn new_phases_store(&self) -> Vec<Option<bool>> {
+        vec![None; self.num_vars + 1]
+    }
+    fn save_best_phases(&self, phases: &mut [bool]) {
+        for (i, (a, _)) in self.best_phases.iter() {
+            phases[*i] = *a;
+        }
+    }
+    fn save_current_phases(&self, phases: &mut [bool]) {
+        for (i, v) in self.var.iter().enumerate().skip(1) {
+            phases[i] = v.assign.unwrap_or_default();
+        }
+    }
+    fn load_phases(&mut self, phases: &[bool], flip: bool) {
+        for (i, v) in self.var.iter_mut().enumerate().skip(1) {
+            if !v.is(FlagVar::ELIMINATED) && v.reason != AssignReason::Decision(0) {
+                v.assign = Some(phases[i] ^ flip);
+            }
+        }
+    }
+    fn randomize_phases(&mut self) {
+        let mut seed = self.num_vars + self.num_conflict;
+        seed = seed.saturating_mul(seed);
+        for (i, v) in self.var.iter_mut().enumerate().skip(1) {
+            if v.is(FlagVar::ELIMINATED) || v.reason == AssignReason::Decision(0) {
+                seed = seed.saturating_mul(7);
+            } else {
+                seed = seed.saturating_add(i + v.level as usize);
+                seed = seed.rotate_left(13);
+                v.assign = Some(seed.is_multiple_of(2));
+            }
+        }
+    }
     fn select_rephasing_target(&mut self) {
         if self.best_phases.is_empty() {
             return;

--- a/src/assign/select.rs
+++ b/src/assign/select.rs
@@ -6,7 +6,6 @@ use super::property;
 use {
     super::{heap::VarHeapIF, stack::AssignStack},
     crate::types::*,
-    std::collections::HashMap,
 };
 
 /// ```ignore
@@ -27,18 +26,10 @@ macro_rules! var_assign {
 
 /// API for var selection, depending on an internal heap.
 pub trait VarSelectIF {
-    #[cfg(feature = "rephase")]
-    /// return best phases
-    fn best_phases_ref(&mut self, default_value: Option<bool>) -> HashMap<VarId, bool>;
-    #[cfg(feature = "rephase")]
-    /// force an assignment obtained by SLS
-    fn override_rephasing_target(&mut self, assignment: &HashMap<VarId, bool>) -> usize;
-    /// give rewards to vars selected by SLS
-    fn reward_by_sls(&mut self, assignment: &HashMap<VarId, bool>) -> usize;
-    #[cfg(feature = "rephase")]
+    // fn save_current_assignment(&self, phases: &mut [bool]);
+    // fn load_assignment(&mut self, phases: &[bool], flip: bool) -> Vec<bool>;
     /// select rephasing target
     fn select_rephasing_target(&mut self);
-    #[cfg(feature = "rephase")]
     /// check the consistency
     fn check_consistency_of_best_phases(&mut self);
     /// select a new decision variable.
@@ -50,52 +41,6 @@ pub trait VarSelectIF {
 }
 
 impl VarSelectIF for AssignStack {
-    #[cfg(feature = "rephase")]
-    fn best_phases_ref(&mut self, default_value: Option<bool>) -> HashMap<VarId, bool> {
-        self.var
-            .iter()
-            .enumerate()
-            .filter_map(|(vi, v)| {
-                if v.level == self.root_level || v.is(FlagVar::ELIMINATED) {
-                    default_value.map(|b| (vi, b))
-                } else {
-                    Some((
-                        vi,
-                        self.best_phases.get(&vi).map_or(
-                            self.var[vi].assign.unwrap_or_else(|| v.is(FlagVar::PHASE)),
-                            |(b, _)| *b,
-                        ),
-                    ))
-                }
-            })
-            .collect::<HashMap<VarId, bool>>()
-    }
-    #[cfg(feature = "rephase")]
-    fn override_rephasing_target(&mut self, assignment: &HashMap<VarId, bool>) -> usize {
-        let mut num_flipped = 0;
-        for (vi, b) in assignment.iter() {
-            if self.best_phases.get(vi).is_none_or(|(p, _)| *p != *b) {
-                num_flipped += 1;
-                self.best_phases.insert(*vi, (*b, AssignReason::None));
-            }
-        }
-        num_flipped
-    }
-    fn reward_by_sls(&mut self, assignment: &HashMap<VarId, bool>) -> usize {
-        let mut num_flipped = 0;
-        for (vi, b) in assignment.iter() {
-            let v = &mut self.var[*vi];
-            if v.is(FlagVar::PHASE) != *b {
-                num_flipped += 1;
-                v.set(FlagVar::PHASE, *b);
-                v.reward *= self.activity_stay_rate;
-                v.reward += self.activity_learning_rate;
-                self.update_heap(*vi);
-            }
-        }
-        num_flipped
-    }
-    #[cfg(feature = "rephase")]
     fn select_rephasing_target(&mut self) {
         if self.best_phases.is_empty() {
             return;
@@ -116,7 +61,6 @@ impl VarSelectIF for AssignStack {
             v.set(FlagVar::PHASE, *b);
         }
     }
-    #[cfg(feature = "rephase")]
     fn check_consistency_of_best_phases(&mut self) {
         if self
             .best_phases

--- a/src/assign/select.rs
+++ b/src/assign/select.rs
@@ -1,12 +1,20 @@
-// Decision var selection
-
-#[cfg(feature = "rephase")]
-use super::property;
+//! Decision var selection
 
 use {
     super::{heap::VarHeapIF, stack::AssignStack},
     crate::types::*,
 };
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum PhaseRotation {
+    #[default]
+    Walk,
+    Original,
+    Inverted,
+    Best,
+    Random,
+    Flipped,
+}
 
 /// ```ignore
 /// let x: Option<bool> = var_assign!(self, lit.vi());
@@ -26,19 +34,6 @@ macro_rules! var_assign {
 
 /// API for var selection, depending on an internal heap.
 pub trait VarSelectIF {
-    /// return a new vector to store phases.
-    fn new_phases_store(&self) -> Vec<Option<bool>>;
-    /// copy the current best phases to `phases`.
-    fn save_best_phases(&self, phases: &mut [bool]);
-    /// copy the current assignments to `phases`.
-    fn save_current_phases(&self, phases: &mut [bool]);
-    /// set `VarFlag::PHASE`s from `phases`.
-    fn load_phases(&mut self, phases: &[bool], flip: bool);
-    /// randomize `VarFlag::PHASE`s.
-    fn randomize_phases(&mut self);
-    /// select rephasing target
-    fn select_rephasing_target(&mut self);
-    /// check the consistency
     fn check_consistency_of_best_phases(&mut self);
     /// select a new decision variable.
     fn select_decision_literal(&mut self) -> Lit;
@@ -49,59 +44,6 @@ pub trait VarSelectIF {
 }
 
 impl VarSelectIF for AssignStack {
-    fn new_phases_store(&self) -> Vec<Option<bool>> {
-        vec![None; self.num_vars + 1]
-    }
-    fn save_best_phases(&self, phases: &mut [bool]) {
-        for (i, (a, _)) in self.best_phases.iter() {
-            phases[*i] = *a;
-        }
-    }
-    fn save_current_phases(&self, phases: &mut [bool]) {
-        for (i, v) in self.var.iter().enumerate().skip(1) {
-            phases[i] = v.assign.unwrap_or_default();
-        }
-    }
-    fn load_phases(&mut self, phases: &[bool], flip: bool) {
-        for (i, v) in self.var.iter_mut().enumerate().skip(1) {
-            if !v.is(FlagVar::ELIMINATED) && v.reason != AssignReason::Decision(0) {
-                v.assign = Some(phases[i] ^ flip);
-            }
-        }
-    }
-    fn randomize_phases(&mut self) {
-        let mut seed = self.num_vars + self.num_conflict;
-        seed = seed.saturating_mul(seed);
-        for (i, v) in self.var.iter_mut().enumerate().skip(1) {
-            if v.is(FlagVar::ELIMINATED) || v.reason == AssignReason::Decision(0) {
-                seed = seed.saturating_mul(7);
-            } else {
-                seed = seed.saturating_add(i + v.level as usize);
-                seed = seed.rotate_left(13);
-                v.assign = Some(seed.is_multiple_of(2));
-            }
-        }
-    }
-    fn select_rephasing_target(&mut self) {
-        if self.best_phases.is_empty() {
-            return;
-        }
-        self.check_consistency_of_best_phases();
-        if self.derefer(property::Tusize::NumUnassertedVar) <= self.best_phases.len() {
-            self.best_phases.clear();
-            return;
-        }
-        debug_assert!(
-            self.best_phases
-                .iter()
-                .all(|(vi, b)| self.var[*vi].assign != Some(!b.0))
-        );
-        self.num_rephase += 1;
-        for (vi, (b, _)) in self.best_phases.iter() {
-            let v = &mut self.var[*vi];
-            v.set(FlagVar::PHASE, *b);
-        }
-    }
     fn check_consistency_of_best_phases(&mut self) {
         if self
             .best_phases

--- a/src/assign/select.rs
+++ b/src/assign/select.rs
@@ -8,7 +8,7 @@ use {
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub enum PhaseRotation {
     #[default]
-    Last,
+    Walk,
     Best,
     False,
     True,
@@ -19,12 +19,12 @@ pub enum PhaseRotation {
 impl PhaseRotation {
     pub fn as_mnemonic(&self) -> &str {
         match self {
-            PhaseRotation::Last => "*",
-            PhaseRotation::Best => "B",
-            PhaseRotation::False => "F",
-            PhaseRotation::True => "T",
-            PhaseRotation::Random => "R",
-            PhaseRotation::Inverted => "I",
+            PhaseRotation::Walk => "→",
+            PhaseRotation::Best => "*",
+            PhaseRotation::False => "⊥",
+            PhaseRotation::True => "⊤",
+            PhaseRotation::Random => "?",
+            PhaseRotation::Inverted => "¬",
         }
     }
 }

--- a/src/assign/stack.rs
+++ b/src/assign/stack.rs
@@ -326,6 +326,9 @@ impl AssignIF for AssignStack {
     fn activity_scheme(&self) -> &VarActivityScheme {
         &self.activity_scheme
     }
+    fn phase_mode(&self) -> PhaseRotation {
+        self.phase_mode
+    }
 }
 
 impl fmt::Display for AssignStack {

--- a/src/assign/stack.rs
+++ b/src/assign/stack.rs
@@ -49,8 +49,6 @@ pub struct AssignStack {
 
     #[cfg(feature = "best_phases_tracking")]
     pub(super) best_phases: HashMap<VarId, (bool, AssignReason)>,
-    #[cfg(feature = "rephase")]
-    pub(super) phase_age: usize,
 
     //## Elimanated vars
     //
@@ -125,8 +123,6 @@ impl Default for AssignStack {
 
             #[cfg(feature = "best_phases_tracking")]
             best_phases: HashMap::new(),
-            #[cfg(feature = "rephase")]
-            phase_age: 0,
 
             eliminated: Vec::new(),
 
@@ -249,10 +245,6 @@ impl AssignIF for AssignStack {
     }
     fn best_assigned(&mut self) -> Option<usize> {
         (self.build_best_at == self.num_propagation).then_some(self.num_vars - self.num_best_assign)
-    }
-    #[cfg(feature = "rephase")]
-    fn best_phases_invalid(&self) -> bool {
-        self.best_phases.is_empty()
     }
     #[allow(unused_variables)]
     fn extend_model(&mut self, cdb: &mut impl ClauseDBIF) -> Vec<Option<bool>> {

--- a/src/assign/stack.rs
+++ b/src/assign/stack.rs
@@ -1,19 +1,17 @@
 //! main struct AssignStack
 use {
     super::{
-        AssignIF, Var,
+        AssignIF, PhaseRotation, Var,
         heap::{VarHeapIF, VarIdHeap},
     },
     crate::{assign::learning_rate::VarActivityScheme, cdb::ClauseDBIF, types::*},
     std::{
+        collections::HashMap,
         fmt,
         ops::Range,
         slice::{Iter, IterMut},
     },
 };
-
-#[cfg(any(feature = "best_phases_tracking", feature = "rephase"))]
-use std::collections::HashMap;
 
 /// A record of assignment. It's called 'trail' in Glucose.
 #[derive(Clone, Debug)]
@@ -41,13 +39,10 @@ pub struct AssignStack {
     //
     //## Phase handling
     //
+    pub(crate) phase_mode: PhaseRotation,
     pub(super) best_assign: bool,
     pub(super) build_best_at: usize,
     pub(super) num_best_assign: usize,
-    pub(super) num_rephase: usize,
-    pub(super) bp_divergence_ema: Ema,
-
-    #[cfg(feature = "best_phases_tracking")]
     pub(super) best_phases: HashMap<VarId, (bool, AssignReason)>,
 
     //## Elimanated vars
@@ -115,13 +110,11 @@ impl Default for AssignStack {
             num_reconflict: 0,
             num_repropagation: 0,
             conflict_interval_average: (Ema2::default(), Ema2::default_extended()),
+
+            phase_mode: PhaseRotation::default(),
             best_assign: false,
             build_best_at: 0,
             num_best_assign: 0,
-            num_rephase: 0,
-            bp_divergence_ema: Ema::default(),
-
-            #[cfg(feature = "best_phases_tracking")]
             best_phases: HashMap::new(),
 
             eliminated: Vec::new(),
@@ -464,7 +457,6 @@ impl VarManipulateIF for AssignStack {
         self.set_activity(vi, 0.0);
         self.remove_from_heap(vi);
 
-        #[cfg(feature = "best_phases_tracking")]
         self.check_best_phase(vi);
     }
     fn make_var_eliminated(&mut self, vi: VarId) {
@@ -500,7 +492,6 @@ impl VarManipulateIF for AssignStack {
     }
 }
 
-#[cfg(feature = "best_phases_tracking")]
 impl AssignStack {
     /// check usability of the saved best phase.
     /// return `true` if the current best phase got invalid.

--- a/src/cdb/db.rs
+++ b/src/cdb/db.rs
@@ -5,7 +5,7 @@ use {
         property,
         watch_cache::*,
     },
-    crate::{SEEK_SPAN, assign::AssignIF, types::*},
+    crate::{assign::AssignIF, types::*},
     std::{
         collections::HashMap,
         num::NonZeroU32,
@@ -903,7 +903,7 @@ impl ClauseDBIF for ClauseDB {
 
         let mut perm: Vec<OrderedProxy<usize>> = Vec::with_capacity(clause.len());
         self.leanrt_limit_ema
-            .update(SEEK_SPAN as f64 * 2_usize.pow(envelope as u32) as f64);
+            .update(1.2 * 2_usize.pow(envelope as u32) as f64);
         let limit: usize = self.leanrt_limit_ema.get() as usize;
         if self.num_learnt < limit {
             return;
@@ -928,6 +928,7 @@ impl ClauseDBIF for ClauseDB {
             }
             if c.used > 0 {
                 c.used -= 1;
+                c.used = 0;
                 continue;
             }
             let lbd = asg.literal_block_distance(&c.lits);

--- a/src/cdb/db.rs
+++ b/src/cdb/db.rs
@@ -5,7 +5,7 @@ use {
         property,
         watch_cache::*,
     },
-    crate::{assign::AssignIF, types::*},
+    crate::{SEEK_SPAN, assign::AssignIF, types::*},
     std::{
         collections::HashMap,
         num::NonZeroU32,
@@ -83,8 +83,6 @@ pub struct ClauseDB {
     /// Literal Block Entanglement
     /// EMA of LBD of clauses used in conflict analysis (dependency graph)
     pub(crate) lb_entanglement: Ema2,
-    /// cutoff value used in the last `reduce`
-    pub(crate) reduction_threshold: f64,
 }
 
 impl Default for ClauseDB {
@@ -121,7 +119,6 @@ impl Default for ClauseDB {
                 .with_fast(1_000)
                 .with_slow(80_000)
                 .with_value(2.0),
-            reduction_threshold: 0.0,
         }
     }
 }
@@ -906,7 +903,7 @@ impl ClauseDBIF for ClauseDB {
 
         let mut perm: Vec<OrderedProxy<usize>> = Vec::with_capacity(clause.len());
         self.leanrt_limit_ema
-            .update(2_usize.pow(envelope as u32) as f64);
+            .update(SEEK_SPAN as f64 * 2_usize.pow(envelope as u32) as f64);
         let limit: usize = self.leanrt_limit_ema.get() as usize;
         if self.num_learnt < limit {
             return;
@@ -922,28 +919,29 @@ impl ClauseDBIF for ClauseDB {
             c.update_activity(*tick, *activity_decay, 0.0);
 
             if c.is(FlagClause::ASSIGN_REASON) {
-                c.used = 0;
+                // c.used = 0;
                 continue;
             }
             if !c.is(FlagClause::LEARNT) {
-                c.used = 0;
+                // c.used = 0;
                 continue;
             }
             if c.used > 0 {
-                c.used = 0;
+                c.used -= 1;
                 continue;
             }
             let lbd = asg.literal_block_distance(&c.lits);
             perm.push(OrderedProxy::new(i, lbd as f64));
-            c.used = 0;
+            // c.used = 0;
         }
-        let keep = perm
-            .len()
-            .saturating_sub(self.num_learnt.saturating_sub(limit));
-        self.reduction_threshold = keep as f64 / self.num_learnt as f64;
-        perm.sort();
-        for i in perm.iter().skip(keep) {
-            self.remove_clause(ClauseId::from(i.to()));
+        // let keep = perm
+        //     .len()
+        //     .saturating_sub(self.num_learnt.saturating_sub(limit));
+        if perm.len() > limit {
+            perm.sort();
+            for i in perm.iter().skip(limit) {
+                self.remove_clause(ClauseId::from(i.to()));
+            }
         }
     }
     fn reset(&mut self) {

--- a/src/cdb/db.rs
+++ b/src/cdb/db.rs
@@ -903,7 +903,7 @@ impl ClauseDBIF for ClauseDB {
 
         let mut perm: Vec<OrderedProxy<usize>> = Vec::with_capacity(clause.len());
         self.leanrt_limit_ema
-            .update(1.2 * 2_usize.pow(envelope as u32) as f64);
+            .update(10.0 * 2_usize.pow(envelope as u32) as f64);
         let limit: usize = self.leanrt_limit_ema.get() as usize;
         if self.num_learnt < limit {
             return;
@@ -919,25 +919,18 @@ impl ClauseDBIF for ClauseDB {
             c.update_activity(*tick, *activity_decay, 0.0);
 
             if c.is(FlagClause::ASSIGN_REASON) {
-                // c.used = 0;
                 continue;
             }
             if !c.is(FlagClause::LEARNT) {
-                // c.used = 0;
                 continue;
             }
             if c.used > 0 {
                 c.used -= 1;
-                c.used = 0;
                 continue;
             }
             let lbd = asg.literal_block_distance(&c.lits);
             perm.push(OrderedProxy::new(i, lbd as f64));
-            // c.used = 0;
         }
-        // let keep = perm
-        //     .len()
-        //     .saturating_sub(self.num_learnt.saturating_sub(limit));
         if perm.len() > limit {
             perm.sort();
             for i in perm.iter().skip(limit) {

--- a/src/cdb/mod.rs
+++ b/src/cdb/mod.rs
@@ -188,14 +188,9 @@ pub mod property {
     pub enum Tf64 {
         LiteralBlockDistance,
         LiteralBlockEntanglement,
-        ReductionThreshold,
     }
 
-    pub const F64S: [Tf64; 3] = [
-        Tf64::LiteralBlockDistance,
-        Tf64::LiteralBlockEntanglement,
-        Tf64::ReductionThreshold,
-    ];
+    pub const F64S: [Tf64; 2] = [Tf64::LiteralBlockDistance, Tf64::LiteralBlockEntanglement];
 
     impl PropertyDereference<Tf64, f64> for ClauseDB {
         #[inline]
@@ -203,7 +198,6 @@ pub mod property {
             match k {
                 Tf64::LiteralBlockDistance => self.lbd.get(),
                 Tf64::LiteralBlockEntanglement => self.lb_entanglement.get(),
-                Tf64::ReductionThreshold => self.reduction_threshold,
             }
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -116,7 +116,7 @@ impl Default for Config {
             elm_grw_lim: 0,
             elm_var_occ: 20000,
 
-            vrw_learning_rate: 0.01,
+            vrw_learning_rate: 0.02,
         }
     }
 }
@@ -246,8 +246,6 @@ impl Config {
         }
         if help {
             let features = [
-                #[cfg(feature = "best_phases_tracking")]
-                "best phase tracking",
                 #[cfg(feature = "chrono_BT")]
                 "chrono BT",
                 #[cfg(feature = "clause_elimination")]

--- a/src/config.rs
+++ b/src/config.rs
@@ -116,7 +116,7 @@ impl Default for Config {
             elm_grw_lim: 0,
             elm_var_occ: 20000,
 
-            vrw_learning_rate: 0.025,
+            vrw_learning_rate: 0.02,
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -116,7 +116,7 @@ impl Default for Config {
             elm_grw_lim: 0,
             elm_var_occ: 20000,
 
-            vrw_learning_rate: 0.02,
+            vrw_learning_rate: 0.025,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,3 +74,5 @@ pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[macro_use]
 extern crate bitflags;
+
+pub(crate) const SEEK_SPAN: usize = 8;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,5 +74,3 @@ pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[macro_use]
 extern crate bitflags;
-
-pub(crate) const SEEK_SPAN: usize = 8;

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -4,7 +4,6 @@ use crate::assign::TrailSavingIF;
 use {
     super::{Certificate, Solver, SolverEvent, SolverResult, conflict::handle_conflict},
     crate::{
-        SEEK_SPAN,
         assign::{
             self, AssignIF, AssignStack, PhaseRotation, PropagateIF, VarActivityScheme,
             VarManipulateIF, VarSelectIF,
@@ -226,7 +225,7 @@ const PR_TBL: [(PhaseRotation, usize, usize); 5] = [
     (PhaseRotation::False, 40_000, 2),
     (PhaseRotation::True, 40_000, 3),
     (PhaseRotation::Inverted, 40_000, 4),
-    (PhaseRotation::Walk, 80_000, 4),
+    (PhaseRotation::Walk, 1_000_000, 0),
 ];
 
 /// main loop; returns `Ok(true)` for SAT, `Ok(false)` for UNSAT.
@@ -244,15 +243,10 @@ fn search(
     let reduction_interval: usize = 40_000;
     let mut phase_rotation_pressure: usize = 0;
     let mut current_phase: &(PhaseRotation, usize, usize) = &PR_TBL[0];
-    let mut current_core: usize = asg.derefer(assign::property::Tusize::NumUnassignedVar);
-    let mut core_was_rebuilt: Option<usize> = None;
-    let mut current_envelop_height: usize = state.span_manager.envelop_index();
-    let mut luby_scale: usize = 8;
-    let mut lbd_ema: Ema = Ema::default().with_span(SEEK_SPAN);
-    let mut vmtf_pressure: usize = 0;
-    let vmtf_interval: usize = 10_000;
-    let mut reinitialization_goal = asg.derefer(assign::property::Tusize::NumUnassignedVar) / 2;
+    let mut vmtf_span: usize = 0;
+    let vmtf_interval: usize = 40_000;
     let mut assign_peak: usize = 0;
+    let mut luby_scale: usize = 2;
 
     macro_rules! to_vmtf {
         () => {
@@ -260,15 +254,18 @@ fn search(
                 asg.activity_scheme = VarActivityScheme::VMTF;
                 asg.set_learning_rate(0.0); // Don't change this
                 asg.rebuild_order();
-                vmtf_pressure = 0;
+                vmtf_span = 0;
             }
         };
     }
-    macro_rules! from_vmtf {
+    macro_rules! reset_rephase_cycle {
         () => {
-            asg.activity_scheme = VarActivityScheme::LRB;
-            asg.set_learning_rate(state.config.vrw_learning_rate);
-            asg.rebuild_order();
+            if asg.activity_scheme != VarActivityScheme::LRB {
+                asg.activity_scheme = VarActivityScheme::LRB;
+                asg.set_learning_rate(state.config.vrw_learning_rate);
+                asg.rebuild_order();
+                vmtf_span = 0;
+            }
             current_phase = &PR_TBL[0];
             asg.phase_mode = current_phase.0;
             asg.set_learning_rate(state.config.vrw_learning_rate);
@@ -290,14 +287,14 @@ fn search(
         if asg.decision_level() == asg.root_level() {
             return Err(SolverError::RootLevelConflict(cc));
         }
+        if assign_peak <= asg.stack_len() {
+            assign_peak = asg.stack_len();
+            to_vmtf!();
+        }
         asg.update_activity_tick();
         #[cfg(feature = "clause_rewarding")]
         {
             cdb.update_activity_tick();
-        }
-        if asg.stack_len() >= assign_peak {
-            assign_peak = asg.stack_len();
-            // to_vmtf!();
         }
         let (cid, lbd) = handle_conflict(asg, cdb, state, &cc)?;
         if cid == ClauseId::default() {
@@ -311,26 +308,17 @@ fn search(
                     state.search_mode_ratio.1.update(1.0);
                 }
             }
-            if asg.derefer(assign::property::Tusize::NumUnassignedVar) < reinitialization_goal {
-                state.span_manager.reset();
-                reinitialization_goal = asg.derefer(assign::property::Tusize::NumUnassignedVar) / 2;
-            }
         } else {
-            debug_assert_ne!(lbd, 0);
             reduction_pressure += 1;
             cdb.lbd.update(lbd as f64);
-            if cdb[cid].len() == 2 {
-                to_vmtf!();
-            }
         }
-        lbd_ema.update(lbd as f64);
+
         processing_pressure += (lbd <= 5) as usize;
         if reduction_pressure >= reduction_interval {
-            cdb.reduce(asg, current_envelop_height);
+            cdb.reduce(asg, state.span_manager.envelop_index());
             reduction_pressure = 0;
             state.search_mode_ratio.0.update(0.0);
             state.search_mode_ratio.1.update(0.0);
-            state.search_mode_ratio.2.update(0.0);
         }
         if asg.activity_scheme != VarActivityScheme::VMTF {
             phase_rotation_pressure += 1;
@@ -340,44 +328,31 @@ fn search(
                 asg.set_learning_rate(state.config.vrw_learning_rate);
                 phase_rotation_pressure = 0;
             }
-        } else if vmtf_pressure >= vmtf_interval {
-            from_vmtf!();
+        } else if vmtf_span >= vmtf_interval {
+            reset_rephase_cycle!();
         } else {
-            vmtf_pressure += 1;
+            vmtf_span += 1;
         }
-        if state
-            .span_manager
-            .span_ended(span_len.saturating_sub(SEEK_SPAN) / luby_scale)
-        {
+        if asg.decision_level() == asg.root_level && processing_pressure >= processing_interval {
+            if cfg!(feature = "clause_vivification") {
+                cdb.vivify(asg, state)?;
+            }
+            if cfg!(feature = "clause_elimination") {
+                let mut elim = Eliminator::instantiate(&state.config, &state.cnf);
+                state.flush("clause subsumption, ");
+                elim.simplify(asg, cdb, state, false)?;
+                asg.eliminated.append(elim.eliminated_lits());
+            }
+            processing_pressure = 0;
+        }
+        if state.span_manager.span_ended(span_len / luby_scale) {
+            RESTART!(asg, cdb, state)?;
             span_len = 0;
             let new_segment = state.span_manager.prepare_new_span(span_len);
             dump_stage(asg, state, new_segment);
-            match asg.activity_scheme {
-                VarActivityScheme::LRB
-                    if lbd_ema.get() >= cdb.lb_entanglement.get_slow() && lbd_ema.get() > 4.0 =>
-                {
-                    RESTART!(asg, cdb, state)?;
-                }
-                _ => {}
-            }
-            if asg.decision_level() == asg.root_level && processing_pressure >= processing_interval
-            {
-                if cfg!(feature = "clause_vivification") {
-                    cdb.vivify(asg, state)?;
-                }
-                if cfg!(feature = "clause_elimination") {
-                    let mut elim = Eliminator::instantiate(&state.config, &state.cnf);
-                    state.flush("clause subsumption, ");
-                    elim.simplify(asg, cdb, state, false)?;
-                    asg.eliminated.append(elim.eliminated_lits());
-                }
-                processing_pressure = 0;
-            }
             if new_segment == Some(true) {
-                current_envelop_height = state.span_manager.envelop_index();
                 // state.config.vrw_learning_rate *= 0.99;
-                luby_scale = current_envelop_height;
-                state.config.vrw_learning_rate *= 1.0 - state.config.vrw_learning_rate;
+                luby_scale = 2 * state.span_manager.envelop_index();
             }
         }
         if progress_pressure >= progress_interval {
@@ -391,14 +366,11 @@ fn search(
             }
             progress_pressure = 0;
         }
-        if let Some(na) = asg.best_assigned() {
-            if current_core < na && core_was_rebuilt.is_none() {
-                core_was_rebuilt = Some(current_core);
-            }
-            current_core = na;
+        if let Some(core_size) = asg.best_assigned() {
+            // reset_rephase_cycle!();
             assign_peak = 0;
             state.flush("");
-            state.flush(format!("unreachable core: {na} "));
+            state.flush(format!("unreachable core: {core_size} "));
         }
     }
     state.log(

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -221,53 +221,13 @@ impl SolveIF for Solver {
     }
 }
 
-// const PR_TBL: [(PhaseRotation, usize, usize); 15] = [
-//     // 1st wave
-//     (PhaseRotation::Best, 20000, 1),
-//     (PhaseRotation::Walk, 20000, 2),
-//     (PhaseRotation::False, 20000, 3),
-//     // 2nd wave
-//     (PhaseRotation::Best, 20000, 4),
-//     (PhaseRotation::Walk, 20000, 5),
-//     (PhaseRotation::True, 20000, 6),
-//     // 3rd wave
-//     (PhaseRotation::Best, 20000, 7),
-//     (PhaseRotation::Walk, 20000, 8),
-//     (PhaseRotation::Random, 20000, 9),
-//     // 4th wave
-//     (PhaseRotation::Best, 20000, 10),
-//     (PhaseRotation::Walk, 20000, 11),
-//     (PhaseRotation::Inverted, 20000, 12),
-//     // exxtra wave
-//     (PhaseRotation::Best, 20000, 13),
-//     (PhaseRotation::Walk, 20000, 14),
-//     (PhaseRotation::VMTF, 40000, 0),
-// ];
-//
-const PR_TBL: [(PhaseRotation, usize, usize); 9] = [
-    // 1st wave
-    (PhaseRotation::False, 10_000, 1),
-    (PhaseRotation::Best, 10_000, 2),
-    (PhaseRotation::Walk, 40_000, 3),
-    // 2nd wave
-    (PhaseRotation::True, 10_000, 4),
-    (PhaseRotation::Best, 10_000, 5),
-    (PhaseRotation::Walk, 40_000, 6),
-    // 3rd wave
-    // (PhaseRotation::Random, 10000, 5),
-    // (PhaseRotation::Walk, 10_000, 6),
-    (PhaseRotation::Inverted, 10_000, 7),
-    (PhaseRotation::Best, 10_000, 8),
-    (PhaseRotation::Walk, 40_000, 0),
+const PR_TBL: [(PhaseRotation, usize, usize); 5] = [
+    (PhaseRotation::Best, 40_000, 1),
+    (PhaseRotation::False, 40_000, 2),
+    (PhaseRotation::True, 40_000, 3),
+    (PhaseRotation::Inverted, 40_000, 4),
+    (PhaseRotation::Walk, 80_000, 4),
 ];
-
-// const PR_TBL: [(PhaseRotation, usize, usize); 4] = [
-//     // 1st wave
-//     (PhaseRotation::False, 80000, 1),
-//     (PhaseRotation::True, 80000, 2),
-//     (PhaseRotation::Walk, 40000, 3),
-//     (PhaseRotation::Best, 20000, 2),
-// ];
 
 /// main loop; returns `Ok(true)` for SAT, `Ok(false)` for UNSAT.
 fn search(
@@ -284,15 +244,37 @@ fn search(
     let reduction_interval: usize = 40_000;
     let mut phase_rotation_pressure: usize = 0;
     let mut current_phase: &(PhaseRotation, usize, usize) = &PR_TBL[0];
-
     let mut current_core: usize = asg.derefer(assign::property::Tusize::NumUnassignedVar);
     let mut core_was_rebuilt: Option<usize> = None;
     let mut current_envelop_height: usize = state.span_manager.envelop_index();
     let mut luby_scale: usize = 8;
     let mut lbd_ema: Ema = Ema::default().with_span(SEEK_SPAN);
     let mut vmtf_pressure: usize = 0;
-    let vmtf_interval: usize = 40_000;
+    let vmtf_interval: usize = 10_000;
     let mut reinitialization_goal = asg.derefer(assign::property::Tusize::NumUnassignedVar) / 2;
+    let mut assign_peak: usize = 0;
+
+    macro_rules! to_vmtf {
+        () => {
+            if asg.activity_scheme != VarActivityScheme::VMTF {
+                asg.activity_scheme = VarActivityScheme::VMTF;
+                asg.set_learning_rate(0.0); // Don't change this
+                asg.rebuild_order();
+                vmtf_pressure = 0;
+            }
+        };
+    }
+    macro_rules! from_vmtf {
+        () => {
+            asg.activity_scheme = VarActivityScheme::LRB;
+            asg.set_learning_rate(state.config.vrw_learning_rate);
+            asg.rebuild_order();
+            current_phase = &PR_TBL[0];
+            asg.phase_mode = current_phase.0;
+            asg.set_learning_rate(state.config.vrw_learning_rate);
+            phase_rotation_pressure = 0;
+        };
+    }
 
     state.span_manager.reset();
     while 0 < asg.derefer(assign::property::Tusize::NumUnassignedVar) || asg.remains() {
@@ -313,6 +295,10 @@ fn search(
         {
             cdb.update_activity_tick();
         }
+        if asg.stack_len() >= assign_peak {
+            assign_peak = asg.stack_len();
+            // to_vmtf!();
+        }
         let (cid, lbd) = handle_conflict(asg, cdb, state, &cc)?;
         if cid == ClauseId::default() {
             match asg.activity_scheme {
@@ -325,17 +311,17 @@ fn search(
                     state.search_mode_ratio.1.update(1.0);
                 }
             }
-            //
             if asg.derefer(assign::property::Tusize::NumUnassignedVar) < reinitialization_goal {
                 state.span_manager.reset();
-                reinitialization_goal =
-                    64.max(asg.derefer(assign::property::Tusize::NumUnassignedVar) / 2);
-                // FIXME
+                reinitialization_goal = asg.derefer(assign::property::Tusize::NumUnassignedVar) / 2;
             }
         } else {
             debug_assert_ne!(lbd, 0);
             reduction_pressure += 1;
             cdb.lbd.update(lbd as f64);
+            if cdb[cid].len() == 2 {
+                to_vmtf!();
+            }
         }
         lbd_ema.update(lbd as f64);
         processing_pressure += (lbd <= 5) as usize;
@@ -351,16 +337,11 @@ fn search(
             if cfg!(feature = "rephase") && phase_rotation_pressure >= current_phase.1 {
                 current_phase = &PR_TBL[current_phase.2];
                 asg.phase_mode = current_phase.0;
+                asg.set_learning_rate(state.config.vrw_learning_rate);
                 phase_rotation_pressure = 0;
             }
         } else if vmtf_pressure >= vmtf_interval {
-            asg.activity_scheme = VarActivityScheme::LRB;
-            // phase_rotation_pressure = current_phase.1;
-            asg.set_learning_rate(state.config.vrw_learning_rate);
-            asg.rebuild_order();
-            current_phase = &PR_TBL[0];
-            asg.phase_mode = current_phase.0;
-            phase_rotation_pressure = 0;
+            from_vmtf!();
         } else {
             vmtf_pressure += 1;
         }
@@ -372,10 +353,9 @@ fn search(
             let new_segment = state.span_manager.prepare_new_span(span_len);
             dump_stage(asg, state, new_segment);
             match asg.activity_scheme {
-                VarActivityScheme::LRB if lbd_ema.get() >= 5.0 => {
-                    RESTART!(asg, cdb, state)?;
-                }
-                VarActivityScheme::VMTF if lbd_ema.get() >= state.b_lvl.get_slow() * 1.25 => {
+                VarActivityScheme::LRB
+                    if lbd_ema.get() >= cdb.lb_entanglement.get_slow() && lbd_ema.get() > 4.0 =>
+                {
                     RESTART!(asg, cdb, state)?;
                 }
                 _ => {}
@@ -395,7 +375,7 @@ fn search(
             }
             if new_segment == Some(true) {
                 current_envelop_height = state.span_manager.envelop_index();
-                state.config.vrw_learning_rate *= 0.99;
+                // state.config.vrw_learning_rate *= 0.99;
                 luby_scale = current_envelop_height;
                 state.config.vrw_learning_rate *= 1.0 - state.config.vrw_learning_rate;
             }
@@ -416,14 +396,9 @@ fn search(
                 core_was_rebuilt = Some(current_core);
             }
             current_core = na;
+            assign_peak = 0;
             state.flush("");
             state.flush(format!("unreachable core: {na} "));
-            {
-                asg.activity_scheme = VarActivityScheme::VMTF;
-                asg.set_learning_rate(0.0); // Don't change this
-                asg.rebuild_order();
-                vmtf_pressure = 0;
-            }
         }
     }
     state.log(

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -5,8 +5,8 @@ use {
     super::{Certificate, Solver, SolverEvent, SolverResult, conflict::handle_conflict},
     crate::{
         assign::{
-            self, AssignIF, AssignStack, PropagateIF, VarActivityScheme, VarManipulateIF,
-            VarSelectIF,
+            self, AssignIF, AssignStack, PhaseRotation, PropagateIF, VarActivityScheme,
+            VarManipulateIF, VarSelectIF,
         },
         cdb::{self, ClauseDB, ClauseDBIF, VivifyIF},
         processor::{EliminateIF, Eliminator},
@@ -210,6 +210,21 @@ impl SolveIF for Solver {
     }
 }
 
+const PR_TBL: [(PhaseRotation, usize, usize); 12] = [
+    (PhaseRotation::Best, 4, 1),
+    (PhaseRotation::Walk, 20, 2),
+    (PhaseRotation::Original, 2, 3),
+    (PhaseRotation::Best, 4, 4),
+    (PhaseRotation::Walk, 20, 5),
+    (PhaseRotation::Inverted, 2, 6),
+    (PhaseRotation::Best, 4, 7),
+    (PhaseRotation::Walk, 20, 8),
+    (PhaseRotation::Random, 2, 9),
+    (PhaseRotation::Best, 4, 11),
+    (PhaseRotation::Walk, 20, 12),
+    (PhaseRotation::Flipped, 2, 0),
+];
+
 /// main loop; returns `Ok(true)` for SAT, `Ok(false)` for UNSAT.
 fn search(
     asg: &mut AssignStack,
@@ -223,8 +238,11 @@ fn search(
     let progress_interval: usize = 10_000;
     let mut reduction_pressure: usize = 0;
     let reduction_interval: usize = 40_000;
-    let mut switch_pressure: usize = 0;
-    let switch_interval: usize = 10_000;
+    // var activity scheme
+    let mut vas_switch_pressure: usize = 0;
+    let vas_switch_interval: usize = 10_000;
+    let mut phase_rotation_pressure: usize = 0;
+    let mut current_phase: &(PhaseRotation, usize, usize) = &PR_TBL[0];
 
     let mut lbd_ema: Ema2 = Ema2::default().with_fast(4).with_slow(10);
     let mut current_core: usize = asg.derefer(assign::property::Tusize::NumUnassignedVar);
@@ -274,7 +292,7 @@ fn search(
                     biclause_at = asg.num_conflict;
                 }
             }
-            switch_pressure += 1;
+            vas_switch_pressure += 1;
             cdb.lbd.update(lbd as f64);
         }
         lbd_ema.update(lbd as f64);
@@ -294,40 +312,45 @@ fn search(
             match asg.activity_scheme {
                 VarActivityScheme::LRB if asg.num_conflict - biclause_at <= 3 => {
                     asg.activity_scheme = VarActivityScheme::VMTF;
-                    switch_pressure = 0;
+                    vas_switch_pressure = 0;
                     asg.set_learning_rate(0.0); // Don't change this
                     asg.rebuild_order();
-                    state.flush("");
-                    state.flush("to VMTF");
+                    // state.flush("");
+                    // state.flush("to VMTF");
                 }
-                VarActivityScheme::VMTF if switch_pressure >= switch_interval => {
+                VarActivityScheme::VMTF if vas_switch_pressure >= vas_switch_interval => {
                     asg.activity_scheme = VarActivityScheme::LRB;
                     asg.set_learning_rate(state.config.vrw_learning_rate);
                     asg.rebuild_order();
-                    state.flush("");
-                    state.flush("to LRB");
+                    // state.flush("");
+                    // state.flush("to LRB");
                 }
                 VarActivityScheme::VMTF => {}
-                VarActivityScheme::LRB if lbd_ema.trend() > 1.0 => {
+                VarActivityScheme::LRB if lbd_ema.trend() > 0.98 => {
                     RESTART!(asg, cdb, state);
                     asg.clear_asserted_literals(cdb)?;
                 }
                 _ => (),
             }
-            if asg.decision_level() == asg.root_level {
-                if cfg!(feature = "rephase")
-                    && asg.activity_scheme == VarActivityScheme::LRB
-                    && state.span_manager.current_span() == 1
-                {
-                    asg.select_rephasing_target();
+            if cfg!(feature = "rephase") && new_span.is_some() {
+                phase_rotation_pressure += 1;
+                if phase_rotation_pressure >= current_phase.1 {
+                    current_phase = &PR_TBL[current_phase.2];
+                    asg.phase_mode = current_phase.0;
+                    phase_rotation_pressure = 0;
+                    if current_phase.0 == PhaseRotation::default() {
+                        state.flush(".");
+                    }
                 }
+            }
+            if asg.decision_level() == asg.root_level {
                 if processing_pressure >= processing_interval {
                     if cfg!(feature = "clause_vivification") {
                         cdb.vivify(asg, state)?;
                     }
                     if cfg!(feature = "clause_elimination") {
                         let mut elim = Eliminator::instantiate(&state.config, &state.cnf);
-                        state.flush("clause subsumption, ");
+                        // state.flush("clause subsumption, ");
                         elim.simplify(asg, cdb, state, false)?;
                         asg.eliminated.append(elim.eliminated_lits());
                     }

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -4,11 +4,12 @@ use crate::assign::TrailSavingIF;
 use {
     super::{Certificate, Solver, SolverEvent, SolverResult, conflict::handle_conflict},
     crate::{
+        SEEK_SPAN,
         assign::{
             self, AssignIF, AssignStack, PhaseRotation, PropagateIF, VarActivityScheme,
             VarManipulateIF, VarSelectIF,
         },
-        cdb::{self, ClauseDB, ClauseDBIF, VivifyIF},
+        cdb::{ClauseDB, ClauseDBIF, VivifyIF},
         processor::{EliminateIF, Eliminator},
         state::{Stat, State, StateIF},
         types::*,
@@ -26,7 +27,17 @@ pub trait SolveIF {
 }
 
 macro_rules! RESTART {
-    ($asg: expr, $cdb: expr, $state: expr) => {
+    ($asg: expr, $cdb: expr, $state: expr) => {{
+        $asg.cancel_until($cdb, $asg.root_level());
+        #[cfg(feature = "trail_saving")]
+        {
+            $asg.clear_saved_trail();
+        }
+        $cdb.handle(SolverEvent::Restart);
+        $state.handle(SolverEvent::Restart);
+        $asg.clear_asserted_literals($cdb)
+    }};
+    ($asg: expr, $cdb: expr, $state: expr, $_: expr) => {
         $asg.cancel_until($cdb, $asg.root_level());
         #[cfg(feature = "trail_saving")]
         {
@@ -194,15 +205,15 @@ impl SolveIF for Solver {
                         v.turn_off(FlagVar::ELIMINATED);
                     }
                 }
-                RESTART!(asg, cdb, state);
+                RESTART!(asg, cdb, state, {});
                 Ok(Certificate::SAT(vals))
             }
             Ok(false) | Err(SolverError::EmptyClause | SolverError::RootLevelConflict(_)) => {
-                RESTART!(asg, cdb, state);
+                RESTART!(asg, cdb, state, {});
                 Ok(Certificate::UNSAT)
             }
             Err(e) => {
-                RESTART!(asg, cdb, state);
+                RESTART!(asg, cdb, state, {});
                 state.progress(asg, cdb);
                 Err(e)
             }
@@ -210,36 +221,53 @@ impl SolveIF for Solver {
     }
 }
 
-// const PR_TBL: [(PhaseRotation, usize, usize); 4] = [
-//     (PhaseRotation::Last, 300, 1),
-//     (PhaseRotation::Best, 300, 2),
-//     (PhaseRotation::Last, 300, 3),
-//     (PhaseRotation::Random, 300, 0),
+// const PR_TBL: [(PhaseRotation, usize, usize); 15] = [
+//     // 1st wave
+//     (PhaseRotation::Best, 20000, 1),
+//     (PhaseRotation::Walk, 20000, 2),
+//     (PhaseRotation::False, 20000, 3),
+//     // 2nd wave
+//     (PhaseRotation::Best, 20000, 4),
+//     (PhaseRotation::Walk, 20000, 5),
+//     (PhaseRotation::True, 20000, 6),
+//     // 3rd wave
+//     (PhaseRotation::Best, 20000, 7),
+//     (PhaseRotation::Walk, 20000, 8),
+//     (PhaseRotation::Random, 20000, 9),
+//     // 4th wave
+//     (PhaseRotation::Best, 20000, 10),
+//     (PhaseRotation::Walk, 20000, 11),
+//     (PhaseRotation::Inverted, 20000, 12),
+//     // exxtra wave
+//     (PhaseRotation::Best, 20000, 13),
+//     (PhaseRotation::Walk, 20000, 14),
+//     (PhaseRotation::VMTF, 40000, 0),
 // ];
-
-// const PR_TBL: [(PhaseRotation, usize, usize); 12] = [
-//     (PhaseRotation::Best, 10000, 1),
-//     (PhaseRotation::Last, 10000, 2),
-//     (PhaseRotation::False, 10000, 3),
-//     (PhaseRotation::Best, 10000, 4),
-//     (PhaseRotation::Last, 10000, 5),
-//     (PhaseRotation::True, 10000, 6),
-//     (PhaseRotation::Best, 10000, 7),
-//     (PhaseRotation::Last, 10000, 8),
-//     (PhaseRotation::Random, 10000, 9),
-//     (PhaseRotation::Best, 10000, 10),
-//     (PhaseRotation::Last, 10000, 11),
-//     (PhaseRotation::Inverted, 10000, 0),
-// ];
-
-const PR_TBL: [(PhaseRotation, usize, usize); 6] = [
-    (PhaseRotation::Last, 20000, 1),
-    (PhaseRotation::False, 20000, 2),
-    (PhaseRotation::True, 20000, 3),
-    (PhaseRotation::Random, 20000, 4),
-    (PhaseRotation::Inverted, 20000, 5),
-    (PhaseRotation::Best, 20000, 0),
+//
+const PR_TBL: [(PhaseRotation, usize, usize); 9] = [
+    // 1st wave
+    (PhaseRotation::False, 10_000, 1),
+    (PhaseRotation::Best, 10_000, 2),
+    (PhaseRotation::Walk, 40_000, 3),
+    // 2nd wave
+    (PhaseRotation::True, 10_000, 4),
+    (PhaseRotation::Best, 10_000, 5),
+    (PhaseRotation::Walk, 40_000, 6),
+    // 3rd wave
+    // (PhaseRotation::Random, 10000, 5),
+    // (PhaseRotation::Walk, 10_000, 6),
+    (PhaseRotation::Inverted, 10_000, 7),
+    (PhaseRotation::Best, 10_000, 8),
+    (PhaseRotation::Walk, 40_000, 0),
 ];
+
+// const PR_TBL: [(PhaseRotation, usize, usize); 4] = [
+//     // 1st wave
+//     (PhaseRotation::False, 80000, 1),
+//     (PhaseRotation::True, 80000, 2),
+//     (PhaseRotation::Walk, 40000, 3),
+//     (PhaseRotation::Best, 20000, 2),
+// ];
 
 /// main loop; returns `Ok(true)` for SAT, `Ok(false)` for UNSAT.
 fn search(
@@ -257,12 +285,14 @@ fn search(
     let mut phase_rotation_pressure: usize = 0;
     let mut current_phase: &(PhaseRotation, usize, usize) = &PR_TBL[0];
 
-    let mut lbd_ema: Ema2 = Ema2::default().with_fast(4).with_slow(10);
-    // let mut extention_pressure: bool = false;
     let mut current_core: usize = asg.derefer(assign::property::Tusize::NumUnassignedVar);
     let mut core_was_rebuilt: Option<usize> = None;
     let mut current_envelop_height: usize = state.span_manager.envelop_index();
-    let mut luby_scale: usize = 512;
+    let mut luby_scale: usize = 8;
+    let mut lbd_ema: Ema = Ema::default().with_span(SEEK_SPAN);
+    let mut vmtf_pressure: usize = 0;
+    let vmtf_interval: usize = 40_000;
+    let mut reinitialization_goal = asg.derefer(assign::property::Tusize::NumUnassignedVar) / 2;
 
     state.span_manager.reset();
     while 0 < asg.derefer(assign::property::Tusize::NumUnassignedVar) || asg.remains() {
@@ -287,25 +317,27 @@ fn search(
         if cid == ClauseId::default() {
             match asg.activity_scheme {
                 VarActivityScheme::LRB => {
-                    state.search_mode_ratio.0.update(0.0);
-                    state.search_mode_ratio.1.update(1.0);
-                    state.search_mode_ratio.2.update(0.0);
+                    state.search_mode_ratio.0.update(1.0);
+                    state.search_mode_ratio.1.update(0.0);
                 }
                 VarActivityScheme::VMTF => {
                     state.search_mode_ratio.0.update(0.0);
-                    state.search_mode_ratio.1.update(0.0);
-                    state.search_mode_ratio.2.update(1.0);
+                    state.search_mode_ratio.1.update(1.0);
                 }
+            }
+            //
+            if asg.derefer(assign::property::Tusize::NumUnassignedVar) < reinitialization_goal {
+                state.span_manager.reset();
+                reinitialization_goal =
+                    64.max(asg.derefer(assign::property::Tusize::NumUnassignedVar) / 2);
+                // FIXME
             }
         } else {
             debug_assert_ne!(lbd, 0);
             reduction_pressure += 1;
-            // if cdb[cid].len() <= 3 {
-            //     extention_pressure = true;
-            // }
             cdb.lbd.update(lbd as f64);
-            lbd_ema.update(lbd as f64);
         }
+        lbd_ema.update(lbd as f64);
         processing_pressure += (lbd <= 5) as usize;
         if reduction_pressure >= reduction_interval {
             cdb.reduce(asg, current_envelop_height);
@@ -314,54 +346,40 @@ fn search(
             state.search_mode_ratio.1.update(0.0);
             state.search_mode_ratio.2.update(0.0);
         }
-        let sp = if asg.activity_scheme == VarActivityScheme::VMTF {
-            span_len
-        } else {
-            span_len / luby_scale
-        };
-        phase_rotation_pressure += 1;
-        if cfg!(feature = "rephase") && phase_rotation_pressure >= current_phase.1 {
-            let last_phase = current_phase.0;
-            current_phase = &PR_TBL[current_phase.2];
+        if asg.activity_scheme != VarActivityScheme::VMTF {
+            phase_rotation_pressure += 1;
+            if cfg!(feature = "rephase") && phase_rotation_pressure >= current_phase.1 {
+                current_phase = &PR_TBL[current_phase.2];
+                asg.phase_mode = current_phase.0;
+                phase_rotation_pressure = 0;
+            }
+        } else if vmtf_pressure >= vmtf_interval {
+            asg.activity_scheme = VarActivityScheme::LRB;
+            // phase_rotation_pressure = current_phase.1;
+            asg.set_learning_rate(state.config.vrw_learning_rate);
+            asg.rebuild_order();
+            current_phase = &PR_TBL[0];
             asg.phase_mode = current_phase.0;
             phase_rotation_pressure = 0;
-            match (last_phase, current_phase.0) {
-                (PhaseRotation::Best, PhaseRotation::Best) => {
-                    panic!();
+        } else {
+            vmtf_pressure += 1;
+        }
+        if state
+            .span_manager
+            .span_ended(span_len.saturating_sub(SEEK_SPAN) / luby_scale)
+        {
+            span_len = 0;
+            let new_segment = state.span_manager.prepare_new_span(span_len);
+            dump_stage(asg, state, new_segment);
+            match asg.activity_scheme {
+                VarActivityScheme::LRB if lbd_ema.get() >= 5.0 => {
+                    RESTART!(asg, cdb, state)?;
                 }
-                (_, PhaseRotation::Best) => {
-                    asg.activity_scheme = VarActivityScheme::VMTF;
-                    asg.set_learning_rate(0.0); // Don't change this
-                    asg.rebuild_order();
-                }
-                (PhaseRotation::Best, _) => {
-                    asg.activity_scheme = VarActivityScheme::LRB;
-                    asg.set_learning_rate(state.config.vrw_learning_rate);
-                    asg.rebuild_order();
+                VarActivityScheme::VMTF if lbd_ema.get() >= state.b_lvl.get_slow() * 1.25 => {
+                    RESTART!(asg, cdb, state)?;
                 }
                 _ => {}
             }
-            state.flush(current_phase.0.as_mnemonic());
-        }
-        if state.span_manager.span_ended(sp) {
-            span_len = 0;
-            let new_segment = state.span_manager.prepare_new_span(span_len);
-            dump_stage(asg, cdb, state, new_segment);
-            match asg.activity_scheme {
-                VarActivityScheme::LRB => {
-                    RESTART!(asg, cdb, state);
-                    asg.clear_asserted_literals(cdb)?;
-                }
-                // VarActivityScheme::VMTF if extention_pressure => {
-                //     phase_rotation_pressure = 0;
-                // }
-                VarActivityScheme::VMTF if lbd_ema.get() > 8.0 => {
-                    RESTART!(asg, cdb, state);
-                    asg.clear_asserted_literals(cdb)?;
-                }
-                _ => (),
-            }
-            // extention_pressure = false;
             if asg.decision_level() == asg.root_level && processing_pressure >= processing_interval
             {
                 if cfg!(feature = "clause_vivification") {
@@ -377,10 +395,9 @@ fn search(
             }
             if new_segment == Some(true) {
                 current_envelop_height = state.span_manager.envelop_index();
+                state.config.vrw_learning_rate *= 0.99;
+                luby_scale = current_envelop_height;
                 state.config.vrw_learning_rate *= 1.0 - state.config.vrw_learning_rate;
-                luby_scale =
-                    32 * (state.c_lvl.get_slow().log2() + state.b_lvl.get_slow().log2()) as usize;
-                assert!(luby_scale < 10_000);
             }
         }
         if progress_pressure >= progress_interval {
@@ -401,6 +418,12 @@ fn search(
             current_core = na;
             state.flush("");
             state.flush(format!("unreachable core: {na} "));
+            {
+                asg.activity_scheme = VarActivityScheme::VMTF;
+                asg.set_learning_rate(0.0); // Don't change this
+                asg.rebuild_order();
+                vmtf_pressure = 0;
+            }
         }
     }
     state.log(
@@ -418,20 +441,19 @@ fn search(
 }
 
 /// display the current stats. before updating stabiliation parameters
-fn dump_stage(asg: &AssignStack, cdb: &mut ClauseDB, state: &mut State, shift: Option<bool>) {
+fn dump_stage(asg: &AssignStack, state: &mut State, shift: Option<bool>) {
     let cycle = state.span_manager.envelop_index();
     let span = state.span_manager.current_span();
     let stage = state.span_manager.current_segment();
     let segment = state.span_manager.current_segment();
     let cpr = asg.refer(assign::property::TEma::ConflictPerRestart).get();
     let vlr = asg.derefer(assign::property::Tf64::VarLearningRate);
-    let cdt = cdb.derefer(cdb::property::Tf64::ReductionThreshold);
     state.log(
         match shift {
             None => Some((None, None, stage)),
             Some(false) => Some((None, Some(cycle), stage)),
             Some(true) => Some((Some(segment), Some(cycle), stage)),
         },
-        format!("{span:>7}, cpr:{cpr:>8.2}, vlr:{vlr:>3.2}, cdt:{cdt:>5.2}"),
+        format!("{span:>7}, cpr:{cpr:>8.2}, vlr:{vlr:>3.2}"),
     );
 }

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -210,19 +210,35 @@ impl SolveIF for Solver {
     }
 }
 
-const PR_TBL: [(PhaseRotation, usize, usize); 12] = [
-    (PhaseRotation::Best, 4, 1),
-    (PhaseRotation::Walk, 20, 2),
-    (PhaseRotation::Original, 2, 3),
-    (PhaseRotation::Best, 4, 4),
-    (PhaseRotation::Walk, 20, 5),
-    (PhaseRotation::Inverted, 2, 6),
-    (PhaseRotation::Best, 4, 7),
-    (PhaseRotation::Walk, 20, 8),
-    (PhaseRotation::Random, 2, 9),
-    (PhaseRotation::Best, 4, 11),
-    (PhaseRotation::Walk, 20, 12),
-    (PhaseRotation::Flipped, 2, 0),
+// const PR_TBL: [(PhaseRotation, usize, usize); 4] = [
+//     (PhaseRotation::Last, 300, 1),
+//     (PhaseRotation::Best, 300, 2),
+//     (PhaseRotation::Last, 300, 3),
+//     (PhaseRotation::Random, 300, 0),
+// ];
+
+// const PR_TBL: [(PhaseRotation, usize, usize); 12] = [
+//     (PhaseRotation::Best, 10000, 1),
+//     (PhaseRotation::Last, 10000, 2),
+//     (PhaseRotation::False, 10000, 3),
+//     (PhaseRotation::Best, 10000, 4),
+//     (PhaseRotation::Last, 10000, 5),
+//     (PhaseRotation::True, 10000, 6),
+//     (PhaseRotation::Best, 10000, 7),
+//     (PhaseRotation::Last, 10000, 8),
+//     (PhaseRotation::Random, 10000, 9),
+//     (PhaseRotation::Best, 10000, 10),
+//     (PhaseRotation::Last, 10000, 11),
+//     (PhaseRotation::Inverted, 10000, 0),
+// ];
+
+const PR_TBL: [(PhaseRotation, usize, usize); 6] = [
+    (PhaseRotation::Last, 20000, 1),
+    (PhaseRotation::False, 20000, 2),
+    (PhaseRotation::True, 20000, 3),
+    (PhaseRotation::Random, 20000, 4),
+    (PhaseRotation::Inverted, 20000, 5),
+    (PhaseRotation::Best, 20000, 0),
 ];
 
 /// main loop; returns `Ok(true)` for SAT, `Ok(false)` for UNSAT.
@@ -238,16 +254,15 @@ fn search(
     let progress_interval: usize = 10_000;
     let mut reduction_pressure: usize = 0;
     let reduction_interval: usize = 40_000;
-    // var activity scheme
-    let mut vas_switch_pressure: usize = 0;
-    let vas_switch_interval: usize = 10_000;
     let mut phase_rotation_pressure: usize = 0;
     let mut current_phase: &(PhaseRotation, usize, usize) = &PR_TBL[0];
 
     let mut lbd_ema: Ema2 = Ema2::default().with_fast(4).with_slow(10);
+    // let mut extention_pressure: bool = false;
     let mut current_core: usize = asg.derefer(assign::property::Tusize::NumUnassignedVar);
     let mut core_was_rebuilt: Option<usize> = None;
-    let mut biclause_at: usize = 0;
+    let mut current_envelop_height: usize = state.span_manager.envelop_index();
+    let mut luby_scale: usize = 512;
 
     state.span_manager.reset();
     while 0 < asg.derefer(assign::property::Tusize::NumUnassignedVar) || asg.remains() {
@@ -282,80 +297,90 @@ fn search(
                     state.search_mode_ratio.2.update(1.0);
                 }
             }
-            processing_pressure += 1;
         } else {
             debug_assert_ne!(lbd, 0);
             reduction_pressure += 1;
-            if lbd <= 6 {
-                processing_pressure += 1;
-                if lbd <= 2 && cdb[cid].len() == 2 {
-                    biclause_at = asg.num_conflict;
-                }
-            }
-            vas_switch_pressure += 1;
+            // if cdb[cid].len() <= 3 {
+            //     extention_pressure = true;
+            // }
             cdb.lbd.update(lbd as f64);
+            lbd_ema.update(lbd as f64);
         }
-        lbd_ema.update(lbd as f64);
+        processing_pressure += (lbd <= 5) as usize;
         if reduction_pressure >= reduction_interval {
-            cdb.reduce(asg, state.span_manager.envelop_index());
+            cdb.reduce(asg, current_envelop_height);
             reduction_pressure = 0;
             state.search_mode_ratio.0.update(0.0);
             state.search_mode_ratio.1.update(0.0);
             state.search_mode_ratio.2.update(0.0);
         }
-        let _cia = asg.conflict_interval_average.0.trend();
-        let _cil = asg.conflict_interval_average.1.trend();
-        if state.span_manager.span_ended(span_len.saturating_sub(10)) {
-            span_len = 0;
-            let new_span = state.span_manager.prepare_new_span(span_len);
-            dump_stage(asg, cdb, state, new_span);
-            match asg.activity_scheme {
-                VarActivityScheme::LRB if asg.num_conflict - biclause_at <= 3 => {
+        let sp = if asg.activity_scheme == VarActivityScheme::VMTF {
+            span_len
+        } else {
+            span_len / luby_scale
+        };
+        phase_rotation_pressure += 1;
+        if cfg!(feature = "rephase") && phase_rotation_pressure >= current_phase.1 {
+            let last_phase = current_phase.0;
+            current_phase = &PR_TBL[current_phase.2];
+            asg.phase_mode = current_phase.0;
+            phase_rotation_pressure = 0;
+            match (last_phase, current_phase.0) {
+                (PhaseRotation::Best, PhaseRotation::Best) => {
+                    panic!();
+                }
+                (_, PhaseRotation::Best) => {
                     asg.activity_scheme = VarActivityScheme::VMTF;
-                    vas_switch_pressure = 0;
                     asg.set_learning_rate(0.0); // Don't change this
                     asg.rebuild_order();
-                    // state.flush("");
-                    // state.flush("to VMTF");
                 }
-                VarActivityScheme::VMTF if vas_switch_pressure >= vas_switch_interval => {
+                (PhaseRotation::Best, _) => {
                     asg.activity_scheme = VarActivityScheme::LRB;
                     asg.set_learning_rate(state.config.vrw_learning_rate);
                     asg.rebuild_order();
-                    // state.flush("");
-                    // state.flush("to LRB");
                 }
-                VarActivityScheme::VMTF => {}
-                VarActivityScheme::LRB if lbd_ema.trend() > 0.98 => {
+                _ => {}
+            }
+            state.flush(current_phase.0.as_mnemonic());
+        }
+        if state.span_manager.span_ended(sp) {
+            span_len = 0;
+            let new_segment = state.span_manager.prepare_new_span(span_len);
+            dump_stage(asg, cdb, state, new_segment);
+            match asg.activity_scheme {
+                VarActivityScheme::LRB => {
+                    RESTART!(asg, cdb, state);
+                    asg.clear_asserted_literals(cdb)?;
+                }
+                // VarActivityScheme::VMTF if extention_pressure => {
+                //     phase_rotation_pressure = 0;
+                // }
+                VarActivityScheme::VMTF if lbd_ema.get() > 8.0 => {
                     RESTART!(asg, cdb, state);
                     asg.clear_asserted_literals(cdb)?;
                 }
                 _ => (),
             }
-            if cfg!(feature = "rephase") && new_span.is_some() {
-                phase_rotation_pressure += 1;
-                if phase_rotation_pressure >= current_phase.1 {
-                    current_phase = &PR_TBL[current_phase.2];
-                    asg.phase_mode = current_phase.0;
-                    phase_rotation_pressure = 0;
-                    if current_phase.0 == PhaseRotation::default() {
-                        state.flush(".");
-                    }
+            // extention_pressure = false;
+            if asg.decision_level() == asg.root_level && processing_pressure >= processing_interval
+            {
+                if cfg!(feature = "clause_vivification") {
+                    cdb.vivify(asg, state)?;
                 }
+                if cfg!(feature = "clause_elimination") {
+                    let mut elim = Eliminator::instantiate(&state.config, &state.cnf);
+                    state.flush("clause subsumption, ");
+                    elim.simplify(asg, cdb, state, false)?;
+                    asg.eliminated.append(elim.eliminated_lits());
+                }
+                processing_pressure = 0;
             }
-            if asg.decision_level() == asg.root_level {
-                if processing_pressure >= processing_interval {
-                    if cfg!(feature = "clause_vivification") {
-                        cdb.vivify(asg, state)?;
-                    }
-                    if cfg!(feature = "clause_elimination") {
-                        let mut elim = Eliminator::instantiate(&state.config, &state.cnf);
-                        // state.flush("clause subsumption, ");
-                        elim.simplify(asg, cdb, state, false)?;
-                        asg.eliminated.append(elim.eliminated_lits());
-                    }
-                    processing_pressure = 0;
-                }
+            if new_segment == Some(true) {
+                current_envelop_height = state.span_manager.envelop_index();
+                state.config.vrw_learning_rate *= 1.0 - state.config.vrw_learning_rate;
+                luby_scale =
+                    32 * (state.c_lvl.get_slow().log2() + state.b_lvl.get_slow().log2()) as usize;
+                assert!(luby_scale < 10_000);
             }
         }
         if progress_pressure >= progress_interval {

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -315,8 +315,10 @@ fn search(
                 _ => (),
             }
             if asg.decision_level() == asg.root_level {
-                #[cfg(feature = "rephase")]
-                if !focusing && state.span_manager.current_span() == 1 {
+                if cfg!(feature = "rephase")
+                    && asg.activity_scheme == VarActivityScheme::LRB
+                    && state.span_manager.current_span() == 1
+                {
                     asg.select_rephasing_target();
                 }
                 if processing_pressure >= processing_interval {

--- a/src/solver/stage.rs
+++ b/src/solver/stage.rs
@@ -71,9 +71,11 @@ impl StageManager {
     pub fn current_span(&self) -> usize {
         self.luby_iter.luby() as usize
     }
+    /// returns the index for the current segment
     pub fn current_segment(&self) -> usize {
         self.luby_iter.seg_index as usize
     }
+    /// returns the index of the current envelop, equals to the height of "tree".
     pub fn envelop_index(&self) -> usize {
         self.envelope_hight
     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -463,7 +463,7 @@ impl StateIF for State {
         let asg_num_propagation = asg.derefer(assign::property::Tusize::NumPropagation);
         // let asg_cwss: f64 = asg.derefer(assign::property::Tf64::CurrentWorkingSetSize);
         let asg_dpc_ema = asg.refer(assign::property::TEma::DecisionPerConflict);
-        // let asg_ppc_ema = asg.refer(assign::property::TEma::PropagationPerConflict);
+        let asg_ppc_ema = asg.refer(assign::property::TEma::PropagationPerConflict);
         let asg_cpr_ema = asg.refer(assign::property::TEma::ConflictPerRestart);
 
         let cdb_num_clause = cdb.derefer(cdb::property::Tusize::NumClause);
@@ -578,17 +578,10 @@ impl StateIF for State {
         );
 
         println!(
-            "\x1B[2K {}({})|  CR:{},  LRB:{}, VMTF:{}, core:{}",
+            "\x1B[2K {}({})| LRB:{}, VMTF:{}, core:{}, /ppc:{}",
             // "\x1B[2K {}|VMTF:{},   CR:{}, core:{}, /ppc:{}",
             {
                 match asg.activity_scheme() {
-                    // VarActivityScheme::CR => {
-                    //     if self.span_manager.current_span() >= 16384 {
-                    //         " Long CR"
-                    //     } else {
-                    //         "      CR"
-                    //     }
-                    // }
                     VarActivityScheme::LRB => {
                         if self.span_manager.current_span() >= 16384 {
                             "Long LRB"
@@ -644,13 +637,13 @@ impl StateIF for State {
                 100.0 * self.search_mode_ratio.1.get_slow(),
                 1.0
             ),
-            fm!(
-                "{:>9.2}",
-                self,
-                LogF64Id::ConflictDistanceAverage2,
-                100.0 * self.search_mode_ratio.2.get_slow(),
-                1.0
-            ),
+            // fm!(
+            //     "{:>9.2}",
+            //     self,
+            //     LogF64Id::ConflictDistanceAverage2,
+            //     100.0 * self.search_mode_ratio.2.get_slow(),
+            //     1.0
+            // ),
             // fm!(
             //     "{:>9.4}",
             //     self,
@@ -669,13 +662,13 @@ impl StateIF for State {
                     asg_num_unreachables
                 }
             ),
-            // fm!(
-            //     "{:>9.2}",
-            //     self,
-            //     LogF64Id::PropagationPerConflict,
-            //     asg_ppc_ema.get(),
-            //     0.01
-            // ),
+            fm!(
+                "{:>9.2}",
+                self,
+                LogF64Id::PropagationPerConflict,
+                asg_ppc_ema.get(),
+                0.01
+            ),
         );
         self[LogUsizeId::LubySpan] = self.span_manager.current_segment();
         self[LogUsizeId::StageCycle] = self.span_manager.envelop_index();

--- a/src/state.rs
+++ b/src/state.rs
@@ -3,6 +3,7 @@
 use instant::{Duration, Instant};
 #[cfg(not(feature = "platform_wasm"))]
 use std::time::{Duration, Instant};
+
 use {
     crate::{
         assign::{self, AssignIF, VarActivityScheme},
@@ -577,33 +578,34 @@ impl StateIF for State {
         );
 
         println!(
-            "\x1B[2K {}|  CR:{},  LRB:{}, VMTF:{}, core:{}",
+            "\x1B[2K {}({})|  CR:{},  LRB:{}, VMTF:{}, core:{}",
             // "\x1B[2K {}|VMTF:{},   CR:{}, core:{}, /ppc:{}",
             {
                 match asg.activity_scheme() {
                     // VarActivityScheme::CR => {
                     //     if self.span_manager.current_span() >= 16384 {
-                    //         "    Long CR"
+                    //         " Long CR"
                     //     } else {
-                    //         "         CR"
+                    //         "      CR"
                     //     }
                     // }
                     VarActivityScheme::LRB => {
                         if self.span_manager.current_span() >= 16384 {
-                            "   Long LRB"
+                            "Long LRB"
                         } else {
-                            "        LRB"
+                            "     LRB"
                         }
                     }
                     VarActivityScheme::VMTF => {
                         if self.span_manager.current_span() >= 16384 {
-                            "  Long VMTF"
+                            "LongVMTF"
                         } else {
-                            "       VMTF"
+                            "    VMTF"
                         }
                     }
                 }
             },
+            asg.phase_mode().as_mnemonic(),
             // {
             //     let s0 = self.search_mode_ratio.0.get();
             //     let s1 = self.search_mode_ratio.1.get();

--- a/src/state.rs
+++ b/src/state.rs
@@ -112,7 +112,7 @@ pub struct State {
     //## MISC
     //
     /// search mode (focus, pursue, explore) ratio
-    pub search_mode_ratio: (Ema2, Ema2, Ema2),
+    pub search_mode_ratio: (Ema2, Ema2),
     /// EMA of backjump levels
     pub b_lvl: Ema2,
     /// EMA of conflicting levels
@@ -155,9 +155,8 @@ impl Default for State {
             reflection_interval: 10_000,
 
             search_mode_ratio: (
-                Ema2::default().with_value(0.33),
-                Ema2::default().with_value(0.33),
-                Ema2::default().with_value(0.33),
+                Ema2::default().with_value(0.5),
+                Ema2::default().with_value(0.5),
             ),
             b_lvl: Ema2::default_extended(),
             c_lvl: Ema2::default_extended(),
@@ -553,8 +552,20 @@ impl StateIF for State {
                 cdb_lb_ent,
                 0.01
             ),
-            fm!("{:>9.2}", self, LogF64Id::CLevel, self.c_lvl.get(), 0.01),
-            fm!("{:>9.2}", self, LogF64Id::BLevel, self.b_lvl.get(), 0.01),
+            fm!(
+                "{:>9.2}",
+                self,
+                LogF64Id::CLevel,
+                self.c_lvl.get_slow(),
+                0.01
+            ),
+            fm!(
+                "{:>9.2}",
+                self,
+                LogF64Id::BLevel,
+                self.b_lvl.get_slow(),
+                0.01
+            ),
             fm!(
                 "{:>9.2}",
                 self,


### PR DESCRIPTION
# Branch summary (forked from `dev-0.19.0`)

<img width="600" alt="Screenshot 2026-05-01 at 22 27 11" src="https://github.com/user-attachments/assets/2b09fb20-5bf5-42e3-8fd2-90e289edf493" />

## Motivation

Simplify the search strategy by replacing heavy EMA-based heuristics with
lightweight, principled policies for restarts, rephasing, and variable
activity scheme switching.

## Changes

### 1. Luby restarts (final commit)

Replaced the complex adaptive restart logic (which relied on multiple EMA
trends such as LBD, conflict-per-restart, and span manager signals) with a
plain **Luby sequence** restart policy. This removes a large class of
parameters and makes restart timing deterministic and reproducible.

### 2. Kissat-like rephasing

Implemented a **phase-rotation / rephasing** mechanism inspired by Kissat:

- Added rephase methods to `assign/select.rs` (`set_rephasing_target`, etc.).
- The solver cycles through rephasing targets at the root level based on
  structural progress (stage boundaries), biasing variable phases toward
  previously successful assignments rather than resetting them randomly.

### 3. Phase rotation combined with variable activity schemes

Integrated rephasing with the existing **LRB / VMTF switching** mechanism:

- When a biclause is learned recently, the solver switches from LRB to VMTF.
- VMTF switches back to LRB after `switch_interval` conflicts or when the
  LBD trend is rising.
- Rephasing is triggered when the solver is at the root level and the span
  manager marks a new segment, replacing the earlier ad-hoc `#[cfg(rephase)]`
  block with an always-on cycling policy.

### 4. Simplification of `select.rs` and `search.rs`

- Removed dead or redundant code paths in `assign/select.rs` and
  `assign/propagate.rs` that were no longer needed after rephasing took over
  phase management.
- Cleaned up the main `search` loop in `solver/search.rs`: removed nested
  conditionals, trimmed the EMA zoo, and clarified the span/stage boundary
  handling.
- `cdb/db.rs` pruned of clause-reduction knobs superseded by the new policy.

## Net effect

The solver now uses a small, coherent set of mechanisms:
- **Luby restarts** for restart timing.
- **Kissat-style phase rotation** for phase management.
- **LRB ↔ VMTF** switching triggered by structural events (biclauses, LBD trend).
