### PR TITLE
Reconsider LBD at The last day of The Late Show with Stephan Colbert

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,8 +9,6 @@
   - trigger for restarts, clause elimination, and clause vivification
   - clause DB size after clause reduction
 - `ClauseDBIF::reduce` can run at any decision level, and runs every 40,000 conflicts
-- Change the definition of 'unreachable core' to the number of unsatisfied given clauses
-  from the number of unassigned variables
 - Remove feature 'assign_rate'
 - Remove feature 'bi_clause_completion'
 - Remove feature 'boundary_check'

--- a/src/assign/mod.rs
+++ b/src/assign/mod.rs
@@ -73,8 +73,10 @@ pub trait AssignIF:
     fn extend_model(&mut self, c: &mut impl ClauseDBIF) -> Vec<Option<bool>>;
     /// return `true` if the set of literals is satisfiable under the current assignment.
     fn satisfies(&self, c: &[Lit]) -> bool;
-    /// compute Literal Block Distance (LBD) of a slice of literals under the current assignment.
+    /// compute Literal Block Distance (LBD) of a slice of literals under the best assignment.
     fn literal_block_distance(&mut self, lits: &[Lit]) -> DecisionLevel;
+    /// compute Literal Block Distance (LBD) of a slice of literals under the current assignment.
+    fn literal_block_distance_current(&mut self, lits: &[Lit]) -> DecisionLevel;
     /// compute Literal Block Distance (LBD) of a slice of literals under the current immutable assignment.
     fn literal_block_distance_(&self, lits: &[Lit]) -> usize;
     /// compute reward sum

--- a/src/assign/propagate.rs
+++ b/src/assign/propagate.rs
@@ -244,10 +244,7 @@ impl PropagateIF for AssignStack {
                             PhaseRotation::False => false,
                             PhaseRotation::True => true,
                             PhaseRotation::Best => {
-                                self.best_phases
-                                    .get(&vi)
-                                    .unwrap_or(&(v.assign.unwrap(), AssignReason::None))
-                                    .0
+                                self.best_phases[vi].0.unwrap_or(v.assign.unwrap())
                             }
                             PhaseRotation::Random => ((v.last_conflict as f64 + 1.0 / v.reward)
                                 as usize)

--- a/src/assign/propagate.rs
+++ b/src/assign/propagate.rs
@@ -49,7 +49,7 @@ macro_rules! var_assign {
 #[cfg(not(feature = "unsafe_access"))]
 macro_rules! var_assign {
     ($asg: expr, $var: expr) => {
-        $asg.assign[$var]
+        $asg.var[$var].assign
     };
 }
 
@@ -68,7 +68,7 @@ macro_rules! lit_assign {
 macro_rules! lit_assign {
     ($asg: expr, $lit: expr) => {
         match $lit {
-            l => match $asg.assign[l.vi()] {
+            l => match $asg.var[l.vi()].assign {
                 Some(x) if !bool::from(l) => Some(!x),
                 x => x,
             },
@@ -93,7 +93,7 @@ macro_rules! set_assign {
         match $lit {
             l => {
                 let vi = l.vi();
-                $asg.assign[vi] = Some(bool::from(l));
+                $asg.var[vi].assign = Some(bool::from(l));
             }
         }
     };

--- a/src/assign/select.rs
+++ b/src/assign/select.rs
@@ -42,7 +42,7 @@ macro_rules! var_assign {
 #[cfg(not(feature = "unsafe_access"))]
 macro_rules! var_assign {
     ($asg: expr, $var: expr) => {
-        $asg.assign[$var]
+        $asg.var[$var].assign
     };
 }
 

--- a/src/assign/select.rs
+++ b/src/assign/select.rs
@@ -90,6 +90,9 @@ impl VarSelectIF for AssignStack {
             let vi = l.vi();
             if let Some(b) = self.var[vi].assign {
                 self.best_phases.insert(vi, (b, self.var[vi].reason));
+                self.var[vi].best_level = self.var[vi].level;
+            } else {
+                self.var[vi].best_level = u32::MAX;
             }
         }
         // self.build_best_at = self.num_propagation;

--- a/src/assign/select.rs
+++ b/src/assign/select.rs
@@ -1,7 +1,7 @@
 //! Decision var selection
 
 use {
-    super::{AssignIF, heap::VarHeapIF, stack::AssignStack},
+    super::{heap::VarHeapIF, stack::AssignStack},
     crate::types::*,
 };
 
@@ -48,25 +48,44 @@ macro_rules! var_assign {
 
 /// API for var selection, depending on an internal heap.
 pub trait VarSelectIF {
-    fn check_consistency_of_best_phases(&mut self);
+    /// return `None` if current assignment is not compatible with the values.
+    /// Othewise return `Some(the core size)`.
+    fn check_best_phases(&mut self) -> Option<usize>;
     /// select a new decision variable.
     fn select_decision_literal(&mut self) -> Lit;
     /// update the internal heap on var order.
     fn update_order(&mut self, v: VarId);
     /// rebuild the internal var_order
     fn rebuild_order(&mut self);
-    /// save the current assignments as the best phases
-    fn save_best_phases(&mut self);
+    /// save the current assignments as the best phases.
+    /// return the core size.
+    fn save_best_phases(&mut self) -> usize;
 }
 
 impl VarSelectIF for AssignStack {
-    fn check_consistency_of_best_phases(&mut self) {
-        if self
-            .best_phases
-            .iter()
-            .any(|(vi, b)| self.var[*vi].assign == Some(!b.0))
-        {
-            self.best_phases.clear();
+    fn check_best_phases(&mut self) -> Option<usize> {
+        let mut alives = 0;
+        let mut inconsistent: bool = false;
+        for (vi, b) in self.best_phases.iter_mut().enumerate().skip(1) {
+            match (b.0, self.var[vi].assign) {
+                (Some(_), None) => {
+                    alives += 1;
+                }
+                (Some(bp), Some(a)) if bp == a => {
+                    *b = (None, DecisionLevel::MAX);
+                }
+                (Some(_), Some(_)) => {
+                    inconsistent = true;
+                    break;
+                }
+                _ => (),
+            }
+        }
+        if inconsistent {
+            self.best_phases.fill((None, DecisionLevel::default()));
+            None
+        } else {
+            Some(self.num_vars - alives - self.num_asserted_vars - self.num_eliminated_vars)
         }
     }
     fn select_decision_literal(&mut self) -> Lit {
@@ -84,18 +103,19 @@ impl VarSelectIF for AssignStack {
             }
         }
     }
-    fn save_best_phases(&mut self) {
-        self.best_phases.clear();
-        for l in self.trail.iter().skip(self.len_upto(self.root_level)) {
-            let vi = l.vi();
-            if let Some(b) = self.var[vi].assign {
-                self.best_phases.insert(vi, (b, self.var[vi].reason));
-                self.var[vi].best_level = self.var[vi].level;
+    fn save_best_phases(&mut self) -> usize {
+        let mut alives: usize = 0;
+        for (vi, v) in self.var.iter_mut().enumerate().skip(1) {
+            if let Some(b) = v.assign
+                && v.level > self.root_level
+            {
+                self.best_phases[vi] = (Some(b), v.level);
+                alives += 1;
             } else {
-                self.var[vi].best_level = u32::MAX;
+                self.best_phases[vi] = (None, DecisionLevel::MAX);
             }
         }
-        // self.build_best_at = self.num_propagation;
+        self.num_vars - alives - self.num_asserted_vars - self.num_eliminated_vars
     }
 }
 

--- a/src/assign/stack.rs
+++ b/src/assign/stack.rs
@@ -289,21 +289,23 @@ impl AssignIF for AssignStack {
         false
     }
     fn literal_block_distance(&mut self, lits: &[Lit]) -> DecisionLevel {
-        // if 8192 <= lits.len() {
-        //     return u16::MAX as DecisionLevel;
-        // }
         let key: usize = self.lbd_temp[0] + 1;
         self.lbd_temp[0] = key;
         let mut cnt: DecisionLevel = 0;
         for l in lits {
-            let lv = self.level(l.vi());
+            let lv = self.best_level(l.vi());
             if lv == 0 {
                 continue;
             }
-            let p = &mut self.lbd_temp[lv as usize];
-            if *p != key {
-                *p = key;
-                cnt = cnt.saturating_add(1);
+            if lv == u32::MAX {
+                // Every unassign var has a unique level.
+                cnt += 1;
+            } else {
+                let p = &mut self.lbd_temp[lv as usize];
+                if *p != key {
+                    *p = key;
+                    cnt = cnt.saturating_add(1);
+                }
             }
         }
         cnt
@@ -375,6 +377,8 @@ pub trait VarManipulateIF {
     fn assigned(&self, l: Lit) -> Option<bool>;
     /// return the assign level of var.
     fn level(&self, vi: VarId) -> DecisionLevel;
+    /// return the assign level of var at the best assignment context
+    fn best_level(&self, vi: VarId) -> DecisionLevel;
     /// return the reason of assignment.
     fn reason(&self, vi: VarId) -> AssignReason;
     /// return the var.
@@ -415,6 +419,15 @@ impl VarManipulateIF for AssignStack {
         }
         #[cfg(not(feature = "unsafe_access"))]
         self.var[vi].level
+    }
+    #[inline]
+    fn best_level(&self, vi: VarId) -> DecisionLevel {
+        #[cfg(feature = "unsafe_access")]
+        unsafe {
+            self.var.get_unchecked(vi).best_level
+        }
+        #[cfg(not(feature = "unsafe_access"))]
+        self.var[vi].best_level
     }
     #[inline]
     fn reason(&self, vi: VarId) -> AssignReason {

--- a/src/assign/stack.rs
+++ b/src/assign/stack.rs
@@ -6,7 +6,6 @@ use {
     },
     crate::{assign::learning_rate::VarActivityScheme, cdb::ClauseDBIF, types::*},
     std::{
-        collections::HashMap,
         fmt,
         ops::Range,
         slice::{Iter, IterMut},
@@ -40,7 +39,7 @@ pub struct AssignStack {
     //## Phase handling
     //
     pub(crate) phase_mode: PhaseRotation,
-    pub(super) best_phases: HashMap<VarId, (bool, AssignReason)>,
+    pub(super) best_phases: Vec<(Option<bool>, DecisionLevel)>,
 
     //## Elimanated vars
     //
@@ -109,7 +108,7 @@ impl Default for AssignStack {
             conflict_interval_average: (Ema2::default(), Ema2::default_extended()),
 
             phase_mode: PhaseRotation::default(),
-            best_phases: HashMap::new(),
+            best_phases: Vec::new(),
 
             eliminated: Vec::new(),
 
@@ -165,6 +164,7 @@ impl Instantiate for AssignStack {
             num_vars: cnf.num_of_variables,
 
             var: Var::new_vars(nv),
+            best_phases: vec![(None, DecisionLevel::MAX); nv + 1],
 
             lbd_temp: vec![0; nv + 1],
 
@@ -293,11 +293,11 @@ impl AssignIF for AssignStack {
         self.lbd_temp[0] = key;
         let mut cnt: DecisionLevel = 0;
         for l in lits {
-            let lv = self.best_level(l.vi());
+            let lv: DecisionLevel = self.best_level(l.vi());
             if lv == 0 {
                 continue;
             }
-            if lv == u32::MAX {
+            if lv == DecisionLevel::MAX {
                 // Every unassign var has a unique level.
                 cnt += 1;
             } else {
@@ -424,10 +424,10 @@ impl VarManipulateIF for AssignStack {
     fn best_level(&self, vi: VarId) -> DecisionLevel {
         #[cfg(feature = "unsafe_access")]
         unsafe {
-            self.var.get_unchecked(vi).best_level
+            self.best_phases.get_unchecked(vi).1
         }
         #[cfg(not(feature = "unsafe_access"))]
-        self.var[vi].best_level
+        self.best_phases[vi].1
     }
     #[inline]
     fn reason(&self, vi: VarId) -> AssignReason {
@@ -466,8 +466,6 @@ impl VarManipulateIF for AssignStack {
         self.var[vi].reason = AssignReason::Decision(0);
         self.set_activity(vi, 0.0);
         self.remove_from_heap(vi);
-
-        self.check_best_phase(vi);
     }
     fn make_var_eliminated(&mut self, vi: VarId) {
         if !self.var[vi].is(FlagVar::ELIMINATED) {
@@ -499,23 +497,6 @@ impl VarManipulateIF for AssignStack {
                 );
             }
         }
-    }
-}
-
-impl AssignStack {
-    /// check usability of the saved best phase.
-    /// return `true` if the current best phase got invalid.
-    fn check_best_phase(&mut self, vi: VarId) -> bool {
-        if let Some((b, _)) = self.best_phases.get(&vi) {
-            debug_assert!(self.var[vi].assign.is_some());
-            if self.var[vi].assign != Some(*b) {
-                if self.root_level == self.var[vi].level {
-                    self.best_phases.clear();
-                }
-                return true;
-            }
-        }
-        false
     }
 }
 

--- a/src/assign/stack.rs
+++ b/src/assign/stack.rs
@@ -310,6 +310,28 @@ impl AssignIF for AssignStack {
         }
         cnt
     }
+    fn literal_block_distance_current(&mut self, lits: &[Lit]) -> DecisionLevel {
+        let key: usize = self.lbd_temp[0] + 1;
+        self.lbd_temp[0] = key;
+        let mut cnt: DecisionLevel = 0;
+        for l in lits {
+            let lv: DecisionLevel = self.level(l.vi());
+            if lv == 0 {
+                continue;
+            }
+            if lv == DecisionLevel::MAX {
+                // Every unassign var has a unique level.
+                cnt += 1;
+            } else {
+                let p = &mut self.lbd_temp[lv as usize];
+                if *p != key {
+                    *p = key;
+                    cnt = cnt.saturating_add(1);
+                }
+            }
+        }
+        cnt
+    }
     fn literal_block_distance_(&self, lits: &[Lit]) -> usize {
         lits.iter()
             .map(|l| self.var[l.vi()].level)

--- a/src/bin/splr.rs
+++ b/src/bin/splr.rs
@@ -273,29 +273,29 @@ fn report(s: &Solver, out: &mut dyn Write) -> std::io::Result<()> {
     )?;
     out.write_all(
         format!(
-            "c     Conflict|????:{:>9.4}, cLvl:{:>9.4}, bLvl:{:>9.4}, /cpr:{:>9.2},\n",
-            state[LogF64Id::End],
+            "c     Conflict|cLvl:{:>9.4}, bLvl:{:>9.4}, #RST:{:>9}, /cpr:{:>9.2},\n",
             state[LogF64Id::CLevel],
             state[LogF64Id::BLevel],
+            state[LogUsizeId::RemainingVar],
             state[LogF64Id::ConflictPerRestart],
         )
         .as_bytes(),
     )?;
     out.write_all(
         format!(
-            "c      Learing|avrg:{:>9.4}, ???:{:>9.4}, #RST:{:>9}, /dpc:{:>9.2},\n",
+            "c      Learing| LBD:{:>9.4}, ti1%:{:>9.4}, ti2%:{:>9.2}, /dpc:{:>9.2},\n",
             state[LogF64Id::EmaLBD],
-            state[LogF64Id::End],
-            state[LogUsizeId::Restart],
+            state[LogF64Id::Tier1ClauseRatio],
+            state[LogF64Id::Tier2ClauseRatio],
             state[LogF64Id::DecisionPerConflict],
         )
         .as_bytes(),
     )?;
     out.write_all(
         format!(
-            "c         misc|vivC:{:>9}, subC:{:>9}, core:{:>9}, /ppc:{:>9.2},\n",
-            state[LogUsizeId::VivifiedClause],
-            state[LogUsizeId::SubsumedClause],
+            "c         misc| LRB:{:>9.2}, VMTF:{:>9.2}, core:{:>9}, /ppc:{:>9.2},\n",
+            state[LogF64Id::ConflictDistanceAverage0],
+            state[LogF64Id::ConflictDistanceAverage1],
             state[LogUsizeId::UnreachableCore],
             state[LogF64Id::PropagationPerConflict],
         )

--- a/src/cdb/db.rs
+++ b/src/cdb/db.rs
@@ -342,6 +342,7 @@ impl ClauseDBIF for ClauseDB {
             }
         }
         c.turn_on(FlagClause::YOUNG);
+        c.lbd = c.lits.len() as DecisionLevel;
         let l0 = c.lits[0];
         let l1 = c.lits[1];
         if len2 {
@@ -816,11 +817,6 @@ impl ClauseDBIF for ClauseDB {
 
         // maintain_watch_literal \\ assert!(watch_cache[!c.lits[0]].iter().any(|wc| wc.0 == cid && wc.1 == c.lits[1]));
         // maintain_watch_literal \\ assert!(watch_cache[!c.lits[1]].iter().any(|wc| wc.0 == cid && wc.1 == c.lits[0]));
-    }
-    fn check_lbd(&mut self, cid: ClauseId, lbd: DecisionLevel) {
-        if lbd <= 2 && self[cid].is(FlagClause::LEARNT) {
-            self.num_lbd2 += 1;
-        }
     }
     fn update_at_analysis(&mut self, cid: ClauseId) -> bool {
         let c = &mut self.clause[NonZeroU32::get(cid.ordinal) as usize];

--- a/src/cdb/db.rs
+++ b/src/cdb/db.rs
@@ -877,6 +877,9 @@ impl ClauseDBIF for ClauseDB {
                 tier2.push(SortKey::new(ClauseId::from(i), lbd as f64));
                 continue;
             }
+            if asg.literal_block_distance_current(&c.lits) <= 2 {
+                continue;
+            }
             tier3.push(ClauseId::from(i));
         }
         for cid in tier3.into_iter() {

--- a/src/cdb/db.rs
+++ b/src/cdb/db.rs
@@ -856,9 +856,6 @@ impl ClauseDBIF for ClauseDB {
             nlearnts += 1;
             let act = c.activated;
             c.activated = 0;
-            if c.is(FlagClause::ASSIGN_REASON) {
-                continue;
-            }
             let len = c.len();
             if len <= 4 || lbd <= 3 {
                 // the ultimate and permanent criteria of good clauses
@@ -870,6 +867,9 @@ impl ClauseDBIF for ClauseDB {
                 // tier 2 group: pretty small or frequently used clauses
                 ntier2 += 1;
                 picks += len;
+                continue;
+            }
+            if c.is(FlagClause::ASSIGN_REASON) {
                 continue;
             }
             if len <= 8 && act > 1 {

--- a/src/cdb/db.rs
+++ b/src/cdb/db.rs
@@ -829,8 +829,10 @@ impl ClauseDBIF for ClauseDB {
         let ClauseDB {
             clause,
             num_reduction,
+            num_lbd2,
             ..
         } = self;
+        *num_lbd2 = 0;
         *num_reduction += 1;
 
         let mut nlearnts: usize = 0;
@@ -838,6 +840,7 @@ impl ClauseDBIF for ClauseDB {
         let mut ntier2: usize = 0;
         let mut tier2: Vec<SortKey<ClauseId>> = Vec::new();
         let mut tier3: Vec<ClauseId> = Vec::new();
+        // let mut tier3: Vec<SortKey<ClauseId>> = Vec::new();
         let mut picks: usize = 0;
         for (i, c) in clause
             .iter_mut()
@@ -845,28 +848,35 @@ impl ClauseDBIF for ClauseDB {
             .skip(1)
             .filter(|(_, c)| !c.is_dead())
         {
+            if c.lbd <= 2 {
+                *num_lbd2 += 1;
+            }
             if !c.is(FlagClause::LEARNT) {
                 continue;
             }
             nlearnts += 1;
-            if c.is(FlagClause::YOUNG) {
-                c.turn_off(FlagClause::YOUNG);
-                ntier2 += 1;
-                continue;
-            }
             let act = c.activated;
             c.activated = 0;
+
+            if c.is(FlagClause::YOUNG) {
+                c.turn_off(FlagClause::YOUNG);
+                if c.lbd <= 2 {
+                    ntier2 += 1;
+                    continue;
+                }
+            }
             if c.is(FlagClause::ASSIGN_REASON) {
                 ntier1 += 1;
                 continue;
             }
-            let lbd = asg.literal_block_distance(&c.lits) as usize;
             let aas = asg.activity_sum(&c.lits) / c.len() as f64;
-            if lbd <= 4 || lbd <= act {
+            if c.lbd <= 2 && act > 0 {
                 ntier1 += 1;
+            } else if c.lbd as usize <= act {
+                ntier2 += 1;
                 picks += act;
             } else if act >= 1 && aas > 0.15 {
-                tier2.push(SortKey::new(ClauseId::from(i), lbd as f64));
+                tier2.push(SortKey::new(ClauseId::from(i), c.lbd as f64));
             } else {
                 tier3.push(ClauseId::from(i));
             }
@@ -882,7 +892,7 @@ impl ClauseDBIF for ClauseDB {
         }
         self.tier1_clauses.update(ntier1 as f64 / nlearnts as f64);
         self.tier2_clauses
-            .update((picks + ntier2) as f64 / nlearnts as f64);
+            .update((ntier2 + picks) as f64 / nlearnts as f64);
     }
     fn certificate_add_assertion(&mut self, lit: Lit) {
         self.certification_store.add_clause(&[lit]);

--- a/src/cdb/db.rs
+++ b/src/cdb/db.rs
@@ -342,7 +342,6 @@ impl ClauseDBIF for ClauseDB {
             }
         }
         c.turn_on(FlagClause::YOUNG);
-        c.lbd = c.lits.len() as DecisionLevel;
         let l0 = c.lits[0];
         let l1 = c.lits[1];
         if len2 {
@@ -848,38 +847,71 @@ impl ClauseDBIF for ClauseDB {
             .skip(1)
             .filter(|(_, c)| !c.is_dead())
         {
-            if c.lbd <= 2 {
+            let lbd = asg.literal_block_distance(&c.lits) as usize;
+            if lbd <= 2 {
                 *num_lbd2 += 1;
             }
             if !c.is(FlagClause::LEARNT) {
                 continue;
             }
             nlearnts += 1;
-            let act = c.activated;
-            c.activated = 0;
+            let act = c.activated + c.is(FlagClause::YOUNG) as usize;
+            // c.activated /= 2;
+            if c.activated <= 1 {
+                c.activated = 0;
+            } else {
+                c.activated = c.activated.ilog2() as usize;
+            }
+            // c.activated = 0;
 
             if c.is(FlagClause::YOUNG) {
                 c.turn_off(FlagClause::YOUNG);
-                if c.lbd <= 2 {
-                    ntier2 += 1;
-                    continue;
-                }
             }
             if c.is(FlagClause::ASSIGN_REASON) {
-                ntier1 += 1;
                 continue;
             }
-            let aas = asg.activity_sum(&c.lits) / c.len() as f64;
-            if c.lbd <= 2 && act > 0 {
+            // let _aas = asg.activity_sum(&c.lits) as f64;
+            // the ultimate and permanent criteria of good clauses
+            if c.len() <= 3 || lbd <= 2 {
                 ntier1 += 1;
-            } else if c.lbd as usize <= act {
+                picks += 4;
+                continue;
+            }
+            // The other clauses should removed if they aren't used.
+            if act == 0 {
+                tier3.push(ClauseId::from(i));
+                continue;
+            }
+
+            // tier 2 group: pretty small or frequently used clauses
+            // if c.lbd.get() <= 2.0 || act >= 16 {
+            // if c.lbd.get() <= act as f64 {
+            if c.len() <= act {
                 ntier2 += 1;
-                picks += act;
-            } else if act >= 1 && aas > 0.15 {
+                picks += 1;
+                continue;
+            }
+            // The others will be srceened
+            tier2.push(SortKey::new(ClauseId::from(i), lbd as f64));
+            //
+            /*
+            if c.len() <= 4 {
+                ntier1 += 1;
+                picks += 1;
+            } else if act >= 8 {
+                ntier2 += 1;
+                picks += 1;
+            } else if act > 0 {
                 tier2.push(SortKey::new(ClauseId::from(i), c.lbd as f64));
             } else {
                 tier3.push(ClauseId::from(i));
             }
+            */
+            // } else if c.lbd < act as u32 {
+            //     tier2.push(SortKey::new(ClauseId::from(i), c.lbd as f64));
+            // } else {
+            //     tier3.push(ClauseId::from(i));
+            // }
         }
         for cid in tier3.into_iter() {
             self.remove_clause(cid);
@@ -891,8 +923,7 @@ impl ClauseDBIF for ClauseDB {
             }
         }
         self.tier1_clauses.update(ntier1 as f64 / nlearnts as f64);
-        self.tier2_clauses
-            .update((ntier2 + picks) as f64 / nlearnts as f64);
+        self.tier2_clauses.update((ntier2) as f64 / nlearnts as f64);
     }
     fn certificate_add_assertion(&mut self, lit: Lit) {
         self.certification_store.add_clause(&[lit]);

--- a/src/cdb/db.rs
+++ b/src/cdb/db.rs
@@ -341,7 +341,6 @@ impl ClauseDBIF for ClauseDB {
                 *num_learnt += 1;
             }
         }
-        c.turn_on(FlagClause::YOUNG);
         let l0 = c.lits[0];
         let l1 = c.lits[1];
         if len2 {
@@ -855,18 +854,8 @@ impl ClauseDBIF for ClauseDB {
                 *num_lbd2 += 1;
             }
             nlearnts += 1;
-            let act = c.activated + c.is(FlagClause::YOUNG) as usize;
+            let act = c.activated;
             c.activated = 0;
-            // // c.activated /= 2;
-            // if c.activated <= 1 {
-            //     c.activated = 0;
-            // } else {
-            //     c.activated = c.activated.ilog2() as usize;
-            // }
-
-            if c.is(FlagClause::YOUNG) {
-                c.turn_off(FlagClause::YOUNG);
-            }
             if c.is(FlagClause::ASSIGN_REASON) {
                 continue;
             }
@@ -877,19 +866,14 @@ impl ClauseDBIF for ClauseDB {
                 picks += len;
                 continue;
             }
-            // if act == 0 {
-            //     // The other clauses should removed if they aren't used.
-            //     tier3.push(ClauseId::from(i));
-            //     continue;
-            // }
             if len <= act {
                 // tier 2 group: pretty small or frequently used clauses
                 ntier2 += 1;
                 picks += len;
                 continue;
             }
-            // The others will be srceened
             if len <= 8 && act > 1 {
+                // potentially good clauses in any circumstance
                 tier2.push(SortKey::new(ClauseId::from(i), lbd as f64));
                 continue;
             }

--- a/src/cdb/db.rs
+++ b/src/cdb/db.rs
@@ -847,22 +847,22 @@ impl ClauseDBIF for ClauseDB {
             .skip(1)
             .filter(|(_, c)| !c.is_dead())
         {
+            if !c.is(FlagClause::LEARNT) {
+                continue;
+            }
             let lbd = asg.literal_block_distance(&c.lits) as usize;
             if lbd <= 2 {
                 *num_lbd2 += 1;
             }
-            if !c.is(FlagClause::LEARNT) {
-                continue;
-            }
             nlearnts += 1;
             let act = c.activated + c.is(FlagClause::YOUNG) as usize;
-            // c.activated /= 2;
-            if c.activated <= 1 {
-                c.activated = 0;
-            } else {
-                c.activated = c.activated.ilog2() as usize;
-            }
-            // c.activated = 0;
+            c.activated = 0;
+            // // c.activated /= 2;
+            // if c.activated <= 1 {
+            //     c.activated = 0;
+            // } else {
+            //     c.activated = c.activated.ilog2() as usize;
+            // }
 
             if c.is(FlagClause::YOUNG) {
                 c.turn_off(FlagClause::YOUNG);
@@ -870,48 +870,30 @@ impl ClauseDBIF for ClauseDB {
             if c.is(FlagClause::ASSIGN_REASON) {
                 continue;
             }
-            // let _aas = asg.activity_sum(&c.lits) as f64;
-            // the ultimate and permanent criteria of good clauses
-            if c.len() <= 3 || lbd <= 2 {
+            let len = c.len();
+            if len <= 4 || lbd <= 3 {
+                // the ultimate and permanent criteria of good clauses
                 ntier1 += 1;
-                picks += 4;
+                picks += len;
                 continue;
             }
-            // The other clauses should removed if they aren't used.
-            if act == 0 {
-                tier3.push(ClauseId::from(i));
-                continue;
-            }
-
-            // tier 2 group: pretty small or frequently used clauses
-            // if c.lbd.get() <= 2.0 || act >= 16 {
-            // if c.lbd.get() <= act as f64 {
-            if c.len() <= act {
+            // if act == 0 {
+            //     // The other clauses should removed if they aren't used.
+            //     tier3.push(ClauseId::from(i));
+            //     continue;
+            // }
+            if len < act {
+                // tier 2 group: pretty small or frequently used clauses
                 ntier2 += 1;
-                picks += 1;
+                picks += len;
                 continue;
             }
             // The others will be srceened
-            tier2.push(SortKey::new(ClauseId::from(i), lbd as f64));
-            //
-            /*
-            if c.len() <= 4 {
-                ntier1 += 1;
-                picks += 1;
-            } else if act >= 8 {
-                ntier2 += 1;
-                picks += 1;
-            } else if act > 0 {
-                tier2.push(SortKey::new(ClauseId::from(i), c.lbd as f64));
-            } else {
-                tier3.push(ClauseId::from(i));
+            if len <= 8 && act > 1 {
+                tier2.push(SortKey::new(ClauseId::from(i), lbd as f64));
+                continue;
             }
-            */
-            // } else if c.lbd < act as u32 {
-            //     tier2.push(SortKey::new(ClauseId::from(i), c.lbd as f64));
-            // } else {
-            //     tier3.push(ClauseId::from(i));
-            // }
+            tier3.push(ClauseId::from(i));
         }
         for cid in tier3.into_iter() {
             self.remove_clause(cid);

--- a/src/cdb/db.rs
+++ b/src/cdb/db.rs
@@ -882,7 +882,7 @@ impl ClauseDBIF for ClauseDB {
             //     tier3.push(ClauseId::from(i));
             //     continue;
             // }
-            if len < act {
+            if len <= act {
                 // tier 2 group: pretty small or frequently used clauses
                 ntier2 += 1;
                 picks += len;

--- a/src/cdb/mod.rs
+++ b/src/cdb/mod.rs
@@ -107,8 +107,6 @@ pub trait ClauseDBIF:
     /// update flags.
     /// return `true` if it's learnt.
     fn update_at_analysis(&mut self, cid: ClauseId) -> bool;
-    /// increment `num_lbd2` if the clause is a non-binary learnt clause with LBD ≤ 2.
-    fn check_lbd(&mut self, cid: ClauseId, lbd: DecisionLevel);
     /// record an asserted literal to unsat certification.
     fn certificate_add_assertion(&mut self, lit: Lit);
     /// save the certification record to a file.

--- a/src/cdb/vivify.rs
+++ b/src/cdb/vivify.rs
@@ -53,7 +53,6 @@ impl VivifyIF for ClauseDB {
             if c.is_dead() {
                 continue;
             }
-            let is_learnt = c.is(FlagClause::LEARNT);
             c.vivified();
             let clits = c.iter().copied().collect::<Vec<Lit>>();
             if to_display <= num_check {
@@ -78,7 +77,7 @@ impl VivifyIF for ClauseDB {
                         asg.assign_by_decision(!lit);
                         //## Rule 3
                         if let Err(cc) = asg.propagate_sandbox(self) {
-                            let mut vec: Vec<Lit>;
+                            let vec: Vec<Lit>;
                             match cc.1 {
                                 AssignReason::BinaryLink(l) => {
                                     let cnfl_lits = vec![cc.0, !l];
@@ -131,11 +130,6 @@ impl VivifyIF for ClauseDB {
                                     num_assert += 1;
                                 }
                                 _ => {
-                                    let new_ci = self.new_clause(&mut vec, is_learnt).is_new();
-                                    if is_learnt && let Some(ci) = new_ci {
-                                        let lbd = asg.literal_block_distance(&self[ci].lits);
-                                        self.check_lbd(ci, lbd);
-                                    }
                                     self.remove_clause(cid);
                                     num_shrink += 1;
                                 }

--- a/src/processor/eliminate.rs
+++ b/src/processor/eliminate.rs
@@ -94,8 +94,6 @@ pub fn eliminate_var(
                         RefClause::Clause(ci) => {
                             // the merged clause might be a duplicated clause.
                             elim.add_cid_occur(asg, ci, &mut cdb[ci], true);
-                            let lbd = asg.literal_block_distance(&cdb[ci].lits);
-                            cdb.check_lbd(ci, lbd);
 
                             #[cfg(feature = "trace_elimination")]
                             println!(

--- a/src/solver/conflict.rs
+++ b/src/solver/conflict.rs
@@ -217,8 +217,11 @@ pub fn handle_conflict(
                 cdb[cid].turn_on(FlagClause::ASSIGN_REASON);
                 // cdb[cid].activated = cdb[cid].activated.max(1);
             }
+            // lbd should be calculated at conflict level, where all literals are assigned.
+            // But since vars hold the last level even after unassignment,
+            // we can have postponed the calculation.
             let d = asg.literal_block_distance(&cdb[cid].lits);
-            cdb.check_lbd(cid, d);
+            cdb[cid].lbd = d;
             ret = (cid, d);
         }
         RefClause::RegisteredClause(cid) => {
@@ -238,7 +241,7 @@ pub fn handle_conflict(
             //     }
             //     panic!("here we are!");
             // }
-            ret = (cid, asg.literal_block_distance(&cdb[cid].lits));
+            ret = (cid, cdb[cid].lbd);
             if bt_drift.is_none_or(|up1| up1 && cdb[cid].is_unit_under(&*asg)) {
                 asg.assign_by_implication(l0, AssignReason::BinaryLink(!l1), assign_level);
             }
@@ -421,6 +424,7 @@ fn conflict_analyze(
                     }
                 }
                 cdb[cid].activated = cdb[cid].activated.saturating_add(1);
+                cdb[cid].lbd = cdb[cid].lbd.min(asg.literal_block_distance(&cdb[cid].lits));
             }
             AssignReason::Decision(_) | AssignReason::None => {}
         }

--- a/src/solver/conflict.rs
+++ b/src/solver/conflict.rs
@@ -221,7 +221,6 @@ pub fn handle_conflict(
             // But since vars hold the last level even after unassignment,
             // we can have postponed the calculation.
             let d = asg.literal_block_distance(&cdb[cid].lits);
-            cdb[cid].lbd = d;
             ret = (cid, d);
         }
         RefClause::RegisteredClause(cid) => {
@@ -241,7 +240,7 @@ pub fn handle_conflict(
             //     }
             //     panic!("here we are!");
             // }
-            ret = (cid, cdb[cid].lbd);
+            ret = (cid, asg.literal_block_distance(&cdb[cid].lits));
             if bt_drift.is_none_or(|up1| up1 && cdb[cid].is_unit_under(&*asg)) {
                 asg.assign_by_implication(l0, AssignReason::BinaryLink(!l1), assign_level);
             }
@@ -424,7 +423,6 @@ fn conflict_analyze(
                     }
                 }
                 cdb[cid].activated = cdb[cid].activated.saturating_add(1);
-                cdb[cid].lbd = cdb[cid].lbd.min(asg.literal_block_distance(&cdb[cid].lits));
             }
             AssignReason::Decision(_) | AssignReason::None => {}
         }

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -334,7 +334,8 @@ fn search(
         }
 
         // track the largest set of clauses that does not emit conflicts
-        if assign_peak <= asg.stack_len() {
+        // not use '<=' to avoid an oscilation
+        if assign_peak < asg.stack_len() {
             assign_peak = asg.stack_len();
             state.core_size = asg.save_best_phases();
         }

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -220,21 +220,6 @@ impl SolveIF for Solver {
     }
 }
 
-const _PR_TBL: [(PhaseRotation, usize, usize); 12] = [
-    (PhaseRotation::Best, 40_000, 1),
-    (PhaseRotation::Walk, 60_000, 2),
-    (PhaseRotation::False, 20_000, 3),
-    (PhaseRotation::Best, 40_000, 4),
-    (PhaseRotation::Walk, 60_000, 5),
-    (PhaseRotation::True, 20_000, 6),
-    (PhaseRotation::Best, 40_000, 7),
-    (PhaseRotation::Walk, 60_000, 8),
-    (PhaseRotation::Random, 20_000, 9),
-    (PhaseRotation::Best, 40_000, 10),
-    (PhaseRotation::Walk, 60_000, 11),
-    (PhaseRotation::Inverted, 20_000, 0),
-];
-
 const PR_TBL: [(PhaseRotation, usize, usize); 6] = [
     (PhaseRotation::Best, 100_000, 1),
     (PhaseRotation::False, 100_000, 2),
@@ -351,14 +336,11 @@ fn search(
         } else {
             cdb.lbd.update(lbd as f64);
         }
-
-        // track the largest set of clauses that does not emit conflicts
         // not use '<=' to avoid an oscilation
         if assign_peak < asg.stack_len() {
             assign_peak = asg.stack_len();
             state.core_size = asg.save_best_phases();
         }
-
         reduction_pressure += (lbd > 4) as usize;
         processing_pressure += (lbd <= 5) as usize;
         progress_pressure += 1;

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -335,26 +335,6 @@ fn search(
             assign_peak = asg.stack_len();
             asg.save_best_phases();
             state.core_size = asg.derefer(assign::property::Tusize::NumUnassignedVar);
-            // let mut np: usize = 0;
-            // let mut ns: usize = 0;
-            // for c in cdb.iter().skip(1) {
-            //     if c.is_dead() || c.is(FlagClause::LEARNT) {
-            //         continue;
-            //     }
-            //     np += 1;
-            //     if c.is_satisfied_under(asg) {
-            //         ns += 1;
-            //     }
-            // }
-            // state.core_size = np - ns;
-            // asg.save_best_phases();
-            // to_vmtf!();
-            // state.flush("");
-            // state.flush(format!(
-            //     "unreachable core: {} ({:>.3}%)",
-            //     state.core_size,
-            //     100.0 * ns as f64 / np as f64,
-            // ));
         }
 
         reduction_pressure += (lbd > 4) as usize;

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -272,7 +272,6 @@ fn search(
         () => {
             if asg.activity_scheme != VarActivityScheme::VMTF {
                 asg.activity_scheme = VarActivityScheme::VMTF;
-                // ??? No: we need to stay in the current rephase ???
                 asg.phase_mode = PhaseRotation::Walk;
                 asg.set_learning_rate(0.0); // Don't change this
                 asg.rebuild_order();
@@ -297,6 +296,18 @@ fn search(
             reduction_pressure = 0;
             state.search_mode_ratio.0.update(0.0);
             state.search_mode_ratio.1.update(0.0);
+        };
+    }
+
+    macro_rules! update_core {
+        ($n: expr) => {
+            if let Some(core) = asg.check_best_phases() {
+                assign_peak = assign_peak.saturating_sub(2 * $n);
+                state.core_size = core;
+            } else {
+                assign_peak = 0;
+                state.core_size = asg.derefer(assign::property::Tusize::NumUnassertedVar);
+            }
         };
     }
 
@@ -327,8 +338,7 @@ fn search(
                 }
             }
             // assert_eq!(asg.decision_level(), asg.root_level);
-            state.core_size = asg.check_best_phases().unwrap_or_default();
-            assign_peak = assign_peak.saturating_sub(2);
+            update_core!(1);
         } else {
             cdb.lbd.update(lbd as f64);
         }
@@ -372,8 +382,7 @@ fn search(
                 }
                 let unasserted_now = asg.derefer(assign::property::Tusize::NumUnassertedVar);
                 if unasserted_now != unasserted_pre {
-                    assign_peak = assign_peak.saturating_sub(2 * (unasserted_pre - unasserted_now));
-                    state.core_size = asg.check_best_phases().unwrap_or_default();
+                    update_core!(unasserted_pre - unasserted_now);
                 }
             }
             if cfg!(feature = "rephase") {

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -220,19 +220,28 @@ impl SolveIF for Solver {
     }
 }
 
-const PR_TBL: [(PhaseRotation, usize, usize); 12] = [
+const _PR_TBL: [(PhaseRotation, usize, usize); 12] = [
     (PhaseRotation::Best, 40_000, 1),
-    (PhaseRotation::Walk, 40_000, 2),
-    (PhaseRotation::False, 40_000, 3),
+    (PhaseRotation::Walk, 60_000, 2),
+    (PhaseRotation::False, 20_000, 3),
     (PhaseRotation::Best, 40_000, 4),
-    (PhaseRotation::Walk, 40_000, 5),
-    (PhaseRotation::True, 40_000, 6),
+    (PhaseRotation::Walk, 60_000, 5),
+    (PhaseRotation::True, 20_000, 6),
     (PhaseRotation::Best, 40_000, 7),
-    (PhaseRotation::Walk, 40_000, 8),
-    (PhaseRotation::Random, 40_000, 9),
+    (PhaseRotation::Walk, 60_000, 8),
+    (PhaseRotation::Random, 20_000, 9),
     (PhaseRotation::Best, 40_000, 10),
-    (PhaseRotation::Walk, 40_000, 11),
-    (PhaseRotation::Inverted, 40_000, 0),
+    (PhaseRotation::Walk, 60_000, 11),
+    (PhaseRotation::Inverted, 20_000, 0),
+];
+
+const PR_TBL: [(PhaseRotation, usize, usize); 6] = [
+    (PhaseRotation::Best, 100_000, 1),
+    (PhaseRotation::False, 100_000, 2),
+    (PhaseRotation::True, 100_000, 3),
+    (PhaseRotation::Random, 100_000, 4),
+    (PhaseRotation::Inverted, 100_000, 5),
+    (PhaseRotation::Walk, 100_000, 0),
 ];
 
 /// main loop; returns `Ok(true)` for SAT, `Ok(false)` for UNSAT.

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -325,8 +325,7 @@ fn search(
                     state.search_mode_ratio.1.update(1.0);
                 }
             }
-            // assign_peak = assign_peak.saturating_sub(1);
-            assign_peak /= 2;
+            assign_peak = assign_peak.saturating_sub(1);
         } else {
             cdb.lbd.update(lbd as f64);
         }
@@ -334,25 +333,28 @@ fn search(
         // track the largest set of clauses that does not emit conflicts
         if assign_peak <= asg.stack_len() {
             assign_peak = asg.stack_len();
-            let mut np: usize = 0;
-            let mut ns: usize = 0;
-            for c in cdb.iter().skip(1) {
-                if c.is_dead() || c.is(FlagClause::LEARNT) {
-                    continue;
-                }
-                np += 1;
-                if c.is_satisfied_under(asg) {
-                    ns += 1;
-                }
-            }
-            state.core_size = np - ns;
             asg.save_best_phases();
-            state.flush("");
-            state.flush(format!(
-                "unreachable core: {} ({:>.3}%)",
-                state.core_size,
-                100.0 * ns as f64 / np as f64,
-            ));
+            state.core_size = asg.derefer(assign::property::Tusize::NumUnassignedVar);
+            // let mut np: usize = 0;
+            // let mut ns: usize = 0;
+            // for c in cdb.iter().skip(1) {
+            //     if c.is_dead() || c.is(FlagClause::LEARNT) {
+            //         continue;
+            //     }
+            //     np += 1;
+            //     if c.is_satisfied_under(asg) {
+            //         ns += 1;
+            //     }
+            // }
+            // state.core_size = np - ns;
+            // asg.save_best_phases();
+            // to_vmtf!();
+            // state.flush("");
+            // state.flush(format!(
+            //     "unreachable core: {} ({:>.3}%)",
+            //     state.core_size,
+            //     100.0 * ns as f64 / np as f64,
+            // ));
         }
 
         reduction_pressure += (lbd > 4) as usize;
@@ -383,7 +385,7 @@ fn search(
                     asg.eliminated.append(elim.eliminated_lits());
                 }
                 let now = asg.derefer(assign::property::Tusize::NumUnassertedVar);
-                if now < pre {
+                if now != pre {
                     // assign_peak = assign_peak.saturating_sub(diff);
                     assign_peak /= 2;
                 }

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -328,7 +328,7 @@ fn search(
             }
             // assert_eq!(asg.decision_level(), asg.root_level);
             state.core_size = asg.check_best_phases().unwrap_or_default();
-            assign_peak = assign_peak.saturating_sub(2)
+            assign_peak = assign_peak.saturating_sub(2);
         } else {
             cdb.lbd.update(lbd as f64);
         }
@@ -355,24 +355,26 @@ fn search(
             if reduction_pressure >= reduction_interval {
                 reduce!();
             }
-            RESTART!(asg, cdb, state)?;
-            if processing_pressure >= processing_interval {
-                let pre = asg.derefer(assign::property::Tusize::NumUnassertedVar);
-                if cfg!(feature = "clause_vivification") {
-                    cdb.vivify(asg, state)?;
+            {
+                let unasserted_pre = asg.derefer(assign::property::Tusize::NumUnassertedVar);
+                RESTART!(asg, cdb, state)?;
+                if processing_pressure >= processing_interval {
+                    if cfg!(feature = "clause_vivification") {
+                        cdb.vivify(asg, state)?;
+                    }
+                    if cfg!(feature = "clause_elimination") {
+                        let mut elim = Eliminator::instantiate(&state.config, &state.cnf);
+                        state.flush("clause subsumption, ");
+                        elim.simplify(asg, cdb, state, false)?;
+                        asg.eliminated.append(elim.eliminated_lits());
+                    }
+                    processing_pressure = 0;
                 }
-                if cfg!(feature = "clause_elimination") {
-                    let mut elim = Eliminator::instantiate(&state.config, &state.cnf);
-                    state.flush("clause subsumption, ");
-                    elim.simplify(asg, cdb, state, false)?;
-                    asg.eliminated.append(elim.eliminated_lits());
-                }
-                let now = asg.derefer(assign::property::Tusize::NumUnassertedVar);
-                if now != pre {
-                    assign_peak = assign_peak.saturating_sub(2 * (pre - now));
+                let unasserted_now = asg.derefer(assign::property::Tusize::NumUnassertedVar);
+                if unasserted_now != unasserted_pre {
+                    assign_peak = assign_peak.saturating_sub(2 * (unasserted_pre - unasserted_now));
                     state.core_size = asg.check_best_phases().unwrap_or_default();
                 }
-                processing_pressure = 0;
             }
             if cfg!(feature = "rephase") {
                 match asg.activity_scheme {

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -251,6 +251,7 @@ fn search(
     let mut rephase_span: usize = 0;
     let mut current_phase: &(PhaseRotation, usize, usize) = &PR_TBL[0];
     let vmtf_interval: usize = 40_000;
+    // a simple value checker
     let mut assign_peak: usize = 0;
     let luby_scale: usize = 8;
     let mut span_scale: usize = luby_scale;
@@ -325,7 +326,9 @@ fn search(
                     state.search_mode_ratio.1.update(1.0);
                 }
             }
-            assign_peak = assign_peak.saturating_sub(2);
+            // assert_eq!(asg.decision_level(), asg.root_level);
+            state.core_size = asg.check_best_phases().unwrap_or_default();
+            assign_peak = assign_peak.saturating_sub(2)
         } else {
             cdb.lbd.update(lbd as f64);
         }
@@ -333,8 +336,7 @@ fn search(
         // track the largest set of clauses that does not emit conflicts
         if assign_peak <= asg.stack_len() {
             assign_peak = asg.stack_len();
-            asg.save_best_phases();
-            state.core_size = asg.derefer(assign::property::Tusize::NumUnassignedVar);
+            state.core_size = asg.save_best_phases();
         }
 
         reduction_pressure += (lbd > 4) as usize;
@@ -366,8 +368,8 @@ fn search(
                 }
                 let now = asg.derefer(assign::property::Tusize::NumUnassertedVar);
                 if now != pre {
-                    assign_peak = assign_peak.saturating_sub(1 + pre - now);
-                    // assign_peak /= 2;
+                    assign_peak = assign_peak.saturating_sub(2 * (pre - now));
+                    state.core_size = asg.check_best_phases().unwrap_or_default();
                 }
                 processing_pressure = 0;
             }

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -325,7 +325,7 @@ fn search(
                     state.search_mode_ratio.1.update(1.0);
                 }
             }
-            assign_peak = assign_peak.saturating_sub(1);
+            assign_peak = assign_peak.saturating_sub(2);
         } else {
             cdb.lbd.update(lbd as f64);
         }
@@ -366,8 +366,8 @@ fn search(
                 }
                 let now = asg.derefer(assign::property::Tusize::NumUnassertedVar);
                 if now != pre {
-                    // assign_peak = assign_peak.saturating_sub(diff);
-                    assign_peak /= 2;
+                    assign_peak = assign_peak.saturating_sub(1 + pre - now);
+                    // assign_peak /= 2;
                 }
                 processing_pressure = 0;
             }

--- a/src/types/clause.rs
+++ b/src/types/clause.rs
@@ -19,6 +19,8 @@ pub struct Clause {
     pub search_from: u16,
     /// Sum of activated (used as propagated) duration
     pub(crate) activated: usize,
+    /// lbd
+    pub(crate) lbd: DecisionLevel,
 }
 
 /// API for Clause, providing literal accessors.
@@ -50,6 +52,7 @@ impl Default for Clause {
             flags: FlagClause::empty(),
             search_from: 2,
             activated: 0,
+            lbd: 0,
         }
     }
 }

--- a/src/types/clause.rs
+++ b/src/types/clause.rs
@@ -19,8 +19,6 @@ pub struct Clause {
     pub search_from: u16,
     /// Sum of activated (used as propagated) duration
     pub(crate) activated: usize,
-    /// lbd
-    pub(crate) lbd: DecisionLevel,
 }
 
 /// API for Clause, providing literal accessors.
@@ -52,7 +50,6 @@ impl Default for Clause {
             flags: FlagClause::empty(),
             search_from: 2,
             activated: 0,
-            lbd: 0,
         }
     }
 }

--- a/src/types/flags.rs
+++ b/src/types/flags.rs
@@ -25,8 +25,6 @@ bitflags! {
         const OCCUR_LINKED  = 0b0000_0100;
         /// a clause is registered in vars' assing list.
         const ASSIGN_REASON = 0b0000_1000;
-        /// a clause born after last reduction.
-        const YOUNG         = 0b0001_0000;
     }
 }
 

--- a/src/types/var.rs
+++ b/src/types/var.rs
@@ -1,11 +1,10 @@
 //! Var struct and Database management API
 use {
-    // super::{heap::VarHeapIF, stack::AssignStack, AssignIF},
     crate::types::{
         AssignReason, DecisionLevel,
         flags::{FlagIF, FlagVar},
     },
-    std::{fmt, u32},
+    std::fmt,
 };
 
 /// Object representing a variable.

--- a/src/types/var.rs
+++ b/src/types/var.rs
@@ -1,8 +1,11 @@
 //! Var struct and Database management API
 use {
     // super::{heap::VarHeapIF, stack::AssignStack, AssignIF},
-    crate::types::{AssignReason, DecisionLevel, flags::FlagIF, flags::FlagVar},
-    std::fmt,
+    crate::types::{
+        AssignReason, DecisionLevel,
+        flags::{FlagIF, FlagVar},
+    },
+    std::{fmt, u32},
 };
 
 /// Object representing a variable.
@@ -12,6 +15,8 @@ pub struct Var {
     pub(crate) assign: Option<bool>,
     /// decision level
     pub(crate) level: DecisionLevel,
+    /// decision level in the best assignment
+    pub(crate) best_level: DecisionLevel,
     /// assign Reason
     pub(crate) reason: AssignReason,
     /// last reason for assignment.
@@ -30,6 +35,7 @@ impl Default for Var {
         Var {
             assign: None,
             level: 0,
+            best_level: u32::MAX,
             reason: AssignReason::None,
             #[cfg(feature = "trail_saving")]
             reason_saved: AssignReason::None,

--- a/src/types/var.rs
+++ b/src/types/var.rs
@@ -15,8 +15,6 @@ pub struct Var {
     pub(crate) assign: Option<bool>,
     /// decision level
     pub(crate) level: DecisionLevel,
-    /// decision level in the best assignment
-    pub(crate) best_level: DecisionLevel,
     /// assign Reason
     pub(crate) reason: AssignReason,
     /// last reason for assignment.
@@ -35,7 +33,6 @@ impl Default for Var {
         Var {
             assign: None,
             level: 0,
-            best_level: u32::MAX,
             reason: AssignReason::None,
             #[cfg(feature = "trail_saving")]
             reason_saved: AssignReason::None,


### PR DESCRIPTION
Though LBDs are varied under rephasing rotation, it's a great criteria of the potential (or optimistic) structural importance of clauses. Therefore we should keep the minimal value of it like Kissat. And we should use another criterion for the current importance of clauses at the same time; the recency counted by the number of references in conflict analysis.

So,
- A clause's length has less information on the importance of clause.
- We need `lbd` field in `Clause` to hold the minimum value.
- Its value should be updated at every conflict analysis.
- The first value of LBD is not important. We had better to track the number of the current LBD2 clauses.

### Meanwhile

> Which is better value for LBD you think, the minimul value so far or the value at the best assignment so sar?

Affirmative response I got.

## An Honest Comparison

| | Minimum LBD | Best-assignment LBD |
|---|---|---|
| **Discriminating power** | Low — biased toward short-trail contexts | High — measured when many levels available |
| **Update frequency** | Every conflict involvement | Only when clause is active near best trail |
| **Staleness risk** | Low — always takes new minimums | Higher — may not be observed at best trail |
| **What it captures** | "This clause was once tight somewhere" | "This clause is tight when the solver is doing well" |
| **Consistency with solver design** | Standalone | Aligned with best-phase saving philosophy |

---

## My Assessment

Best-assignment LBD asks a better question. "How does this clause behave when the solver is at its most productive?" is more meaningful than "what's the luckiest reading this clause ever got?" The short-trail bias in minimum LBD is a real defect — it systematically over-values clauses that were tight in trivial contexts and under-values clauses that are tight in demanding ones.

The practical sampling concern is real but manageable. A reasonable implementation: on every LBD recomputation, if the current trail height exceeds some fraction of the best-ever trail (say 80%), update the stored LBD. This broadens the observation window while still biasing toward productive contexts.

Between the two as a single stored value, I'd choose best-assignment LBD — it asks the right question about the right context, at the cost of sparser observations.