### PR TITLE
Clause::reference_rate 20260611

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,50 +22,52 @@ Though Splr comes with **ABSOLUTELY NO WARRANTY**, I'd like to show some results
 
 #### Version 0.19.0
 
-| # | target CNF solved by splr                            |time (s)|ret|
-|--:|:-----------------------------------------------------|-------:|:-:|
-|  1|`04648cef5bed430ab6429991fa9e107d-ramsey_3_6_19.norma`|        |124|
-|  2|`0c0430a68f147be18ab3fded07f30fdb-oddball_53_5_tto_zp`|   98.47| 10|
-|  3|`0ccb0f855352783a972be45188bf3164-SCPC-500-12.cnf`    |   81.87| 20|
-|  4|`0e1d562093d5f4fc9013cf4a14a03f70-Break_12_50.xml.cnf`|   39.33| 10|
-|  5|`110f8eb8b9b80204fe955ea0973bbb00-clqcl_30_7_6.normal`|        |124|
-|  6|`24bde22f729a988fb2394b644cb60d39-SC25_Timetable_C_48`|    7.12| 10|
-|  7|`2d0c041c0fe72dc32527bfbf34f63e61-170223547.cnf`      |  441.85| 10|
-|  8|`35b9091b90bd28a492c9556d6fc4348d-bp4_TCO_CSO_ZR.norm`|        |124|
-|  9|`35ec95b9b2398fb522db178855016ae0-MVRoundRobin_n14_d1`|        |124|
-| 10|`46a8727e27d848faafd83a990c2e01a7-case8.normalised.cn`|        |124|
-| 11|`482295be38dc1d63a16f3cf649ef7ef6-myciel6-cn.used-as.`| 2663.28| 20|
-| 12|`53c21f3e78f060883026b5a12ba691d8-maximum_constrained`|   17.23| 10|
-| 13|`57b478982ee9aba245ba792452b18fe3-VanDerWaerden_pd_2-`| 1243.21| 10|
-| 14|`6147e666b75f603a4c4490d21ab654cd-hid-uns-enc-6-1-0-0`|  187.16| 20|
-| 15|`65f7145996bbec02b90bd0fa64a20502-test_v7_r12_vr10_c1`|        |124|
-| 16|`68e33d998466bbdd4bfb7249a5790e4f-arles_thres10_p10_r`|    0.13| 20|
-| 17|`83aa254f7d17e1df7bee19322ac4752b-1.normalised.cnf`   | 2613.04| 10|
-| 18|`8e62c5d47920ffe36052f86177403e70-SC25_Timetable_C_39`|    7.60| 10|
-| 19|`908433870bee8ba2c86f266d0b002fdb-MVRoundRobin_n20_d1`|        |124|
-| 20|`918d9e7c2e197312517736421d728958-SCPC-500-1.cnf`     |  118.09| 20|
-| 21|`91c429adc2dc8430461b6d87a9aef335-16_16_booth_wallace`|        |124|
-| 22|`967b58fea99a99b8da592d3e2fe7139b-dubois50.cnf.mis-99`|        |124|
-| 23|`98a9352230efc411c092f1dcdcdedcfc-bp4_BC012_IXA_LPI_F`|        |124|
-| 24|`9b5f767eb5c14eb888d51acf70e045c8-uniqinv40prop.cnf`  |        |124|
-| 25|`a0bcdaffb0ea36b678899fd86bdc7f18-arles_thres10_p10_r`|    0.07| 20|
-| 26|`a1fdd60d2570f47fb14956ac9e96951f-oddball_22_5_ttf.no`|   19.89| 20|
-| 27|`a70883771fd1c210d94a916d52510a3a-gm28sparrc.cnf`     |    0.38| 20|
-| 28|`b3d3680b3287a989ce61a6db1054efd2-case20.normalised.c`|  217.28| 10|
-| 29|`b9ed6fd14f4fc969ec966a4b54c36872-n320p5q2_n.apx_16.c`|   51.19| 10|
-| 30|`c21096fa2f550785c33dc862d83bc941-case17.normalised.c`|   39.49| 10|
-| 31|`cb950b9accfb53eb98f77b0f995ac0ae-rphp5_050_shuffled.`|        |124|
-| 32|`d5928883c1e1f70764a31a83aa419eaf-oski15a01b42s_opt.c`| 3089.61| 20|
-| 33|`d8666a18cf3a32af0a606099f0070b4b-7.normalised.cnf`   |        |124|
-| 34|`ddf9620410e6a4351f64c745670ef5d4-oddball_57_5_tto_zp`|  733.57| 10|
-| 35|`e23edb67db2d1dfdbfe2f4c02d09c6c7-14.normalised.cnf`  | 1203.91| 10|
-| 36|`e430acf720b63044e5c825a00a76b0eb-rphp_p25_r25.cnf`   |        |124|
-| 37|`e442248e155eb81a811edd1deca8a2cd-sudoku-N30-23.cnf`  |        |124|
-| 38|`f17dfbed8c18716a41b231702e127524-SC25_Timetable_C_40`|    8.39| 10|
-| 39|`f25a1df88f89c6bcbe2602fa7f6e816b-1-TC-256-K-63.sanit`|  701.32| 10|
-| 40|`f33a6163305d6559043b7438a692dea9-simon-r17-1.sanitiz`|        |124|
+- (0.19.0-rc7) @ 2026-06-16T17:15:17
 
-"splr"    , med:     90.17, max:   3089.61,total except 16 timeouts:13583.49
+| # | target CNF solved by splr                            |time (s)|ret|val|
+|--:|:-----------------------------------------------------|-------:|:-:|---|
+|  1|`04648cef5bed430ab6429991fa9e107d-ramsey_3_6_19.norma`|        |124|   |
+|  2|`0c0430a68f147be18ab3fded07f30fdb-oddball_53_5_tto_zp`|   36.19| 10|   |
+|  3|`0ccb0f855352783a972be45188bf3164-SCPC-500-12.cnf`    |  117.39| 20|   |
+|  4|`0e1d562093d5f4fc9013cf4a14a03f70-Break_12_50.xml.cnf`|    6.58| 10|   |
+|  5|`110f8eb8b9b80204fe955ea0973bbb00-clqcl_30_7_6.normal`|        |124|   |
+|  6|`24bde22f729a988fb2394b644cb60d39-SC25_Timetable_C_48`|   28.10| 10|   |
+|  7|`2d0c041c0fe72dc32527bfbf34f63e61-170223547.cnf`      |        |124|   |
+|  8|`35b9091b90bd28a492c9556d6fc4348d-bp4_TCO_CSO_ZR.norm`|        |124|   |
+|  9|`35ec95b9b2398fb522db178855016ae0-MVRoundRobin_n14_d1`|        |124|   |
+| 10|`46a8727e27d848faafd83a990c2e01a7-case8.normalised.cn`|        |124|   |
+| 11|`482295be38dc1d63a16f3cf649ef7ef6-myciel6-cn.used-as.`|        |124|   |
+| 12|`53c21f3e78f060883026b5a12ba691d8-maximum_constrained`|   14.32| 10|   |
+| 13|`57b478982ee9aba245ba792452b18fe3-VanDerWaerden_pd_2-`| 1559.81| 10|   |
+| 14|`6147e666b75f603a4c4490d21ab654cd-hid-uns-enc-6-1-0-0`|  432.30| 20|   |
+| 15|`65f7145996bbec02b90bd0fa64a20502-test_v7_r12_vr10_c1`|        |124|   |
+| 16|`68e33d998466bbdd4bfb7249a5790e4f-arles_thres10_p10_r`|    0.68| 20|   |
+| 17|`83aa254f7d17e1df7bee19322ac4752b-1.normalised.cnf`   |        |124|   |
+| 18|`8e62c5d47920ffe36052f86177403e70-SC25_Timetable_C_39`|   13.60| 10|   |
+| 19|`908433870bee8ba2c86f266d0b002fdb-MVRoundRobin_n20_d1`|        |124|   |
+| 20|`918d9e7c2e197312517736421d728958-SCPC-500-1.cnf`     |  235.12| 20|   |
+| 21|`91c429adc2dc8430461b6d87a9aef335-16_16_booth_wallace`|        |124|   |
+| 22|`967b58fea99a99b8da592d3e2fe7139b-dubois50.cnf.mis-99`|        |124|   |
+| 23|`98a9352230efc411c092f1dcdcdedcfc-bp4_BC012_IXA_LPI_F`|        |124|   |
+| 24|`9b5f767eb5c14eb888d51acf70e045c8-uniqinv40prop.cnf`  |        |124|   |
+| 25|`a0bcdaffb0ea36b678899fd86bdc7f18-arles_thres10_p10_r`|    0.68| 20|   |
+| 26|`a1fdd60d2570f47fb14956ac9e96951f-oddball_22_5_ttf.no`|   32.42| 20|   |
+| 27|`a70883771fd1c210d94a916d52510a3a-gm28sparrc.cnf`     |   17.62| 20|   |
+| 28|`b3d3680b3287a989ce61a6db1054efd2-case20.normalised.c`|    5.46| 10|   |
+| 29|`b9ed6fd14f4fc969ec966a4b54c36872-n320p5q2_n.apx_16.c`|   19.50| 10|   |
+| 30|`c21096fa2f550785c33dc862d83bc941-case17.normalised.c`|   52.47| 10|   |
+| 31|`cb950b9accfb53eb98f77b0f995ac0ae-rphp5_050_shuffled.`|        |124|   |
+| 32|`d5928883c1e1f70764a31a83aa419eaf-oski15a01b42s_opt.c`| 1824.52| 20|   |
+| 33|`d8666a18cf3a32af0a606099f0070b4b-7.normalised.cnf`   |        |124|   |
+| 34|`ddf9620410e6a4351f64c745670ef5d4-oddball_57_5_tto_zp`|   62.92| 10|   |
+| 35|`e23edb67db2d1dfdbfe2f4c02d09c6c7-14.normalised.cnf`  |  495.46| 10|   |
+| 36|`e430acf720b63044e5c825a00a76b0eb-rphp_p25_r25.cnf`   |        |124|   |
+| 37|`e442248e155eb81a811edd1deca8a2cd-sudoku-N30-23.cnf`  |        |124|   |
+| 38|`f17dfbed8c18716a41b231702e127524-SC25_Timetable_C_40`|   12.37| 10|   |
+| 39|`f25a1df88f89c6bcbe2602fa7f6e816b-1-TC-256-K-63.sanit`| 2607.61| 10|   |
+| 40|`f33a6163305d6559043b7438a692dea9-simon-r17-1.sanitiz`|        |124|   |
+
+"splr"    , med:     32.42, max:   2607.61,total except 19 timeouts: 7575.10
 
 #### Version 0.17.0
 

--- a/src/cdb/db.rs
+++ b/src/cdb/db.rs
@@ -5,10 +5,7 @@ use {
         property,
         watch_cache::*,
     },
-    crate::{
-        assign::{self, AssignIF},
-        types::*,
-    },
+    crate::{assign::AssignIF, types::*},
     std::{
         collections::HashMap,
         num::NonZeroU32,
@@ -40,8 +37,6 @@ pub struct ClauseDB {
     certification_store: CertificationStore,
     /// a number of clauses to emit out-of-memory exception
     soft_limit: usize,
-    /// last clause reduction
-    last_reduction: usize,
 
     //
     //## LBD
@@ -82,7 +77,6 @@ impl Default for ClauseDB {
             freelist: Vec::new(),
             certification_store: CertificationStore::default(),
             soft_limit: 0, // 248_000_000
-            last_reduction: 0,
             lbd_temp: Vec::new(),
             lbd: Ema2::default_extended(),
             num_clause: 0,
@@ -316,6 +310,9 @@ impl ClauseDBIF for ClauseDB {
             debug_assert!(c.lits.is_empty()); // c.lits.clear();
             std::mem::swap(&mut c.lits, vec);
             c.search_from = 2;
+            c.refered_at = 0;
+            c.vivify_age = 0;
+            c.lbd = DecisionLevel::MAX;
         } else {
             cid = ClauseId::from(self.clause.len());
             let mut c = Clause {
@@ -832,7 +829,6 @@ impl ClauseDBIF for ClauseDB {
     fn reduce(&mut self, asg: &mut impl AssignIF, in_span: bool) {
         let ClauseDB {
             clause,
-            last_reduction,
             num_reduction,
             num_lbd2,
             ..
@@ -840,15 +836,18 @@ impl ClauseDBIF for ClauseDB {
         *num_lbd2 = 0;
         *num_reduction += 1;
 
-        let mut nlearnts: usize = 0;
+        let mut num_alives: usize = 0;
         // tier 1 group: the small clauses under the best assignment
         let mut ntier1: usize = 0;
         // tier 2 group: the small clauses under the best assignment
         let mut ntier2: usize = 0;
-        let mut tier3: Vec<(ClauseId, usize)> = Vec::new();
-        let mut tier4: Vec<ClauseId> = Vec::new();
-        let mut newst_target: DecisionLevel = DecisionLevel::MAX;
-        let mut slope_beg: usize = if in_span { 0 } else { usize::MAX };
+        let mut tier3: Vec<(ClauseId, usize, DecisionLevel)> = Vec::new();
+        let mut tier4: Vec<(ClauseId, DecisionLevel)> = Vec::new();
+        let mut peak_at: usize = 0;
+        let mut peak_level: DecisionLevel = 0;
+        // let mut max_required: DecisionLevel = 0;
+        let mut has_progress: bool = false;
+        let mut young_best: DecisionLevel = DecisionLevel::MAX;
 
         for (i, c) in clause
             .iter_mut()
@@ -856,69 +855,104 @@ impl ClauseDBIF for ClauseDB {
             .skip(1)
             .filter(|(_, c)| !c.is_dead())
         {
-            let lbd_g = asg.literal_block_distance(&c.lits);
-            let lbd_l = asg.literal_block_distance_current(&c.lits);
-            if in_span && lbd_l <= newst_target {
-                newst_target = lbd_l;
-                if c.refered_at > slope_beg {
-                    slope_beg = c.refered_at;
-                }
-            }
-            if lbd_g <= 2 {
+            let len = c.len();
+            // let lbd_g = asg.literal_block_distance(&c.lits);
+            let new_lbd = asg.literal_block_distance_current(&c.lits);
+            let lbd_l = new_lbd; // c.lbd.min(new_lbd);
+            c.lbd = new_lbd;
+            if lbd_l <= 2 {
                 *num_lbd2 += 1;
             }
-            if !c.is(FlagClause::LEARNT) {
+            let young = c.is(FlagClause::YOUNG);
+            if young {
+                c.turn_off(FlagClause::YOUNG);
+                young_best = young_best.min(lbd_l);
+            }
+            if lbd_l >= peak_level {
+                peak_at = peak_at.max(c.refered_at);
+                peak_level = lbd_l;
+            }
+            // if !in_span {
+            //     if len <= 4 || lbd_l <= 3 {
+            //         continue;
+            //     } else {
+            //         tier4.push(ClauseId::from(i));
+            //     }
+            //     continue;
+            // }
+            num_alives += 1;
+            if len <= 5 {
+                ntier1 += 1;
+                has_progress |= young;
                 continue;
             }
-            nlearnts += 1;
-            match (lbd_g <= 2, lbd_l <= 5) {
-                (false, false) => (),
-                (false, true) => {
-                    ntier2 += 1;
-                    continue;
+            if lbd_l <= 4 {
+                ntier2 += 1;
+                has_progress |= young;
+                continue;
+            }
+            // if !in_span {
+            //     tier4.push((ClauseId::from(i), lbd_l));
+            //     continue;
+            // }
+            if !c.is(FlagClause::LEARNT)
+                || c.is(FlagClause::ASSIGN_REASON)
+                || (c.is(FlagClause::BEST_PROPAGATOR)/* && lbd_l <= 5 */)
+            {
+                continue;
+            }
+            if young && lbd_l < 8 {
+                tier4.push((ClauseId::from(i), lbd_l));
+                continue;
+            }
+            tier3.push((ClauseId::from(i), c.refered_at, lbd_l as DecisionLevel));
+        }
+        if has_progress {
+            // if we got progress, we don't need to care much; just trim old ones.
+            let threshold = peak_at.saturating_sub(1000);
+            for (c, t, l) in tier3.into_iter().rev() {
+                if t < threshold && l >= 5 {
+                    self.remove_clause(c);
                 }
-                (true, false) => {
-                    ntier1 += 1;
-                    continue;
-                }
-                (true, true) => {
-                    ntier1 += 1;
-                    ntier2 += 1;
-                    if c.refered_at < *last_reduction {
-                        c.turn_on(FlagClause::TO_VIVIFY);
-                    }
-                    continue;
+            }
+        } else {
+            // Otherwise, help movements to new directions
+            let threshold = peak_level;
+            for (c, _, l) in tier3.into_iter().rev() {
+                if l > threshold {
+                    self.remove_clause(c);
                 }
             }
-            c.turn_on(FlagClause::TO_VIVIFY);
-            if !in_span && lbd_g <= 5 {
-                continue;
-            }
-            if c.is(FlagClause::ASSIGN_REASON) {
-                continue;
-            }
-            if lbd_l >= 12 {
-                tier4.push(ClauseId::from(i));
-                continue;
-            }
-            tier3.push((ClauseId::from(i), c.refered_at));
         }
-        if in_span {
-            let now = asg.derefer(assign::property::Tusize::NumConflict);
-            slope_beg = slope_beg.saturating_sub(1 * (now - slope_beg));
-        }
-        for c in tier4.into_iter() {
-            self.remove_clause(c);
-        }
-        for (c, t) in tier3.into_iter() {
-            if t >= slope_beg {
-                continue;
+        if !in_span && false {
+            for (c, _) in tier4.into_iter() {
+                self.remove_clause(c);
             }
-            self.remove_clause(c);
+        } else {
+            let threshold = if has_progress { 6 } else { 8 };
+            for (c, l) in tier4.into_iter() {
+                if l >= threshold {
+                    self.remove_clause(c);
+                }
+            }
         }
-        if nlearnts > 0 {
-            self.tier1_clauses.update(ntier1 as f64 / nlearnts as f64);
-            self.tier2_clauses.update((ntier2) as f64 / nlearnts as f64);
+        debug_assert!(num_alives > 0);
+        self.tier1_clauses.update(ntier1 as f64 / num_alives as f64);
+        self.tier2_clauses.update(ntier2 as f64 / num_alives as f64);
+    }
+    fn save_best_assign_reasons(&mut self, asg: &impl AssignIF, clear: bool) {
+        if clear {
+            for c in self.clause.iter_mut().skip(1) {
+                c.turn_off(FlagClause::BEST_PROPAGATOR);
+            }
+        }
+        for l in asg.stack_iter() {
+            match asg.reason(l.vi()) {
+                AssignReason::Implication(cid) => {
+                    self[cid].turn_on(FlagClause::BEST_PROPAGATOR);
+                }
+                _ => {}
+            }
         }
     }
     fn certificate_add_assertion(&mut self, lit: Lit) {

--- a/src/cdb/db.rs
+++ b/src/cdb/db.rs
@@ -826,12 +826,11 @@ impl ClauseDBIF for ClauseDB {
         c.is(FlagClause::LEARNT)
     }
     /// reduce the number of 'learnt' or *removable* clauses.
-    fn reduce(&mut self, asg: &mut impl AssignIF, _last_restart: usize, _retain_depth: f64) {
+    fn reduce(&mut self, asg: &mut impl AssignIF) {
         let ClauseDB {
             clause,
             num_reduction,
             num_lbd2,
-
             certification_store,
             binary_link,
             watch_cache,
@@ -843,55 +842,20 @@ impl ClauseDBIF for ClauseDB {
         } = self;
         *num_lbd2 = 0;
         *num_reduction += 1;
-
         let mut num_alives: usize = 0;
         // tier 1 group: the small clauses under the best assignment
         let mut ntier1: usize = 0;
         // tier 2 group: the small clauses under the best assignment
         let mut ntier2: usize = 0;
         let now = asg.derefer(crate::assign::property::Tusize::NumConflict);
-
         for (i, c) in clause
             .iter_mut()
             .enumerate()
             .skip(1)
             .filter(|(_, c)| !c.is_dead())
         {
-            // if retain_depth > 0.0 && c.refered_at < last_restart {
-            //     c.reference_distance *= 0.8;
-            //     c.reference_distance += 0.2 * (now - c.refered_at) as f64;
-            //     c.refered_at = now;
-            // }
             num_alives += 1;
-            let lbd = asg.literal_block_distance_current(&c.lits) as usize;
-            // if i.is_multiple_of(2000) && lbd <= 10 {
-            //     println!(
-            //         "{i:>9}: lbd:{:>3}, rate:{:>4.2}, age: {:>3}",
-            //         lbd, c.reference_rate, c.vivify_age,
-            //     );
-            // }
-            // if lbd <= 2 {
-            //     *num_lbd2 += 1;
-            //     ntier1 += 1;
-            //     continue;
-            // }
-            // let young = c.is(FlagClause::YOUNG);
-            // if young {
-            //     c.turn_off(FlagClause::YOUNG);
-            // }
-            // if lbd == 3 && c.len() <= 8 {
-            //     ntier2 += 1;
-            //     continue;
-            // }
-            // if c.len() <= 5 {
-            //     ntier2 += 1;
-            //     continue;
-            // }
-            // if lbd <= 8 && c.reference_distance <= 4.0 * retain_depth {
-            //     ntier2 += 1;
-            //     continue;
-            // }
-            match lbd {
+            match asg.literal_block_distance_current(&c.lits) {
                 0 | 1 | 2 => {
                     *num_lbd2 += 1;
                     ntier1 += 1;
@@ -915,12 +879,10 @@ impl ClauseDBIF for ClauseDB {
                 }
                 _ => {}
             }
-            if !c.is(FlagClause::LEARNT) || c.is(FlagClause::ASSIGN_REASON)
-            // || c.is(FlagClause::BEST_PROPAGATOR)
-            {
+            if !c.is(FlagClause::LEARNT) || c.is(FlagClause::ASSIGN_REASON) {
                 continue;
             }
-            if c.reference_rate >= 2.0 || c.len() <= 5 || c.referred_at + 2 >= now {
+            if c.reference_rate >= 2.0 || c.len() <= 5 || c.referred_at + 4 >= now {
                 continue;
             }
             remove_clause_fn(

--- a/src/cdb/db.rs
+++ b/src/cdb/db.rs
@@ -310,8 +310,8 @@ impl ClauseDBIF for ClauseDB {
             debug_assert!(c.lits.is_empty()); // c.lits.clear();
             std::mem::swap(&mut c.lits, vec);
             c.search_from = 2;
-            c.refered_at = 0;
-            c.reference_distance = 0.0;
+            c.referred_at = 0;
+            c.reference_rate = 1.0;
             c.vivify_age = 0;
         } else {
             cid = ClauseId::from(self.clause.len());
@@ -826,7 +826,7 @@ impl ClauseDBIF for ClauseDB {
         c.is(FlagClause::LEARNT)
     }
     /// reduce the number of 'learnt' or *removable* clauses.
-    fn reduce(&mut self, asg: &mut impl AssignIF, last_restart: usize, retain_depth: f64) {
+    fn reduce(&mut self, asg: &mut impl AssignIF, _last_restart: usize, _retain_depth: f64) {
         let ClauseDB {
             clause,
             num_reduction,
@@ -849,8 +849,7 @@ impl ClauseDBIF for ClauseDB {
         let mut ntier1: usize = 0;
         // tier 2 group: the small clauses under the best assignment
         let mut ntier2: usize = 0;
-        // let mut has_progress: bool = false;
-        // let threshold = (*num_reduction as f64).log2();
+        // let now = asg.derefer(assign::property::Tusize::NumConflict);
 
         for (i, c) in clause
             .iter_mut()
@@ -858,49 +857,83 @@ impl ClauseDBIF for ClauseDB {
             .skip(1)
             .filter(|(_, c)| !c.is_dead())
         {
-            if let Some(diff) = last_restart.checked_sub(c.refered_at) {
-                c.reference_distance *= 0.8;
-                c.reference_distance += 0.2 * diff as f64;
-            }
-            let len = c.len();
-            let lbd = asg.literal_block_distance_current(&c.lits);
-            // c.lbd = lbd;
-            if lbd <= 2 {
-                *num_lbd2 += 1;
-            }
-            let young = c.is(FlagClause::YOUNG);
-            if young {
-                c.turn_off(FlagClause::YOUNG);
-            }
+            // if retain_depth > 0.0 && c.refered_at < last_restart {
+            //     c.reference_distance *= 0.8;
+            //     c.reference_distance += 0.2 * (now - c.refered_at) as f64;
+            //     c.refered_at = now;
+            // }
             num_alives += 1;
-            if len <= 4 {
-                ntier1 += 1;
-                continue;
-            }
-            if lbd <= 3 {
-                ntier2 += 1;
-                continue;
+            let lbd = asg.literal_block_distance_current(&c.lits) as usize;
+            // if i.is_multiple_of(2000) && lbd <= 10 {
+            //     println!(
+            //         "{i:>9}: lbd:{:>3}, rate:{:>4.2}, age: {:>3}",
+            //         lbd, c.reference_rate, c.vivify_age,
+            //     );
+            // }
+            // if lbd <= 2 {
+            //     *num_lbd2 += 1;
+            //     ntier1 += 1;
+            //     continue;
+            // }
+            // let young = c.is(FlagClause::YOUNG);
+            // if young {
+            //     c.turn_off(FlagClause::YOUNG);
+            // }
+            // if lbd == 3 && c.len() <= 8 {
+            //     ntier2 += 1;
+            //     continue;
+            // }
+            // if c.len() <= 5 {
+            //     ntier2 += 1;
+            //     continue;
+            // }
+            // if lbd <= 8 && c.reference_distance <= 4.0 * retain_depth {
+            //     ntier2 += 1;
+            //     continue;
+            // }
+            match lbd {
+                0 | 1 | 2 => {
+                    *num_lbd2 += 1;
+                    ntier1 += 1;
+                    continue;
+                }
+                3 => {
+                    ntier1 += 1;
+                    continue;
+                }
+                4 if c.reference_rate > 0.3 => {
+                    ntier2 += 1;
+                    continue;
+                }
+                5 if c.reference_rate > 0.5 => {
+                    ntier2 += 1;
+                    continue;
+                }
+                6 if c.reference_rate > 0.7 => {
+                    ntier2 += 1;
+                    continue;
+                }
+                _ => {}
             }
             if !c.is(FlagClause::LEARNT) || c.is(FlagClause::ASSIGN_REASON)
-            // || (c.is(FlagClause::BEST_PROPAGATOR)/* && lbd_l <= 5 */)
+            // || c.is(FlagClause::BEST_PROPAGATOR)
             {
                 continue;
             }
-            if c.reference_distance > retain_depth
-            /* threshold */
-            {
-                remove_clause_fn(
-                    certification_store,
-                    binary_link,
-                    watch_cache,
-                    num_bi_clause,
-                    num_clause,
-                    num_learnt,
-                    ClauseId::from(i),
-                    c,
-                );
-                freelist.push(ClauseId::from(i));
+            if lbd <= 10 && c.reference_rate >= 1.0 {
+                continue;
             }
+            remove_clause_fn(
+                certification_store,
+                binary_link,
+                watch_cache,
+                num_bi_clause,
+                num_clause,
+                num_learnt,
+                ClauseId::from(i),
+                c,
+            );
+            freelist.push(ClauseId::from(i));
         }
         self.tier1_clauses.update(ntier1 as f64 / num_alives as f64);
         self.tier2_clauses.update(ntier2 as f64 / num_alives as f64);

--- a/src/cdb/db.rs
+++ b/src/cdb/db.rs
@@ -826,7 +826,7 @@ impl ClauseDBIF for ClauseDB {
         c.is(FlagClause::LEARNT)
     }
     /// reduce the number of 'learnt' or *removable* clauses.
-    fn reduce(&mut self, asg: &mut impl AssignIF) {
+    fn reduce(&mut self, asg: &mut impl AssignIF, last_restart: usize) {
         self.num_reduction += 1;
         let ClauseDB {
             clause,
@@ -846,7 +846,7 @@ impl ClauseDBIF for ClauseDB {
         let mut ntier1: usize = 0;
         // tier 2 group: the small clauses under the best assignment
         let mut ntier2: usize = 0;
-        let now = asg.derefer(crate::assign::property::Tusize::NumConflict);
+        let _now = asg.derefer(crate::assign::property::Tusize::NumConflict);
         for (i, c) in clause
             .iter_mut()
             .enumerate()
@@ -854,10 +854,10 @@ impl ClauseDBIF for ClauseDB {
             .filter(|(_, c)| !c.is_dead())
         {
             num_alives += 1;
-            match asg
-                .literal_block_distance_current(&c.lits)
-                .min(c.len() as DecisionLevel - 1)
-            {
+            // match asg
+            //     .literal_block_distance_current(&c.lits)
+            //     .min((c.len() as DecisionLevel).saturating_sub(2))
+            match asg.literal_block_distance_current(&c.lits) {
                 0 | 1 | 2 => {
                     *num_lbd2 += 1;
                     continue;
@@ -884,10 +884,14 @@ impl ClauseDBIF for ClauseDB {
                 }
                 _ => {}
             }
+            if c.len() <= 3 {
+                ntier1 += 1;
+                continue;
+            }
             if !c.is(FlagClause::LEARNT) || c.is(FlagClause::ASSIGN_REASON) {
                 continue;
             }
-            if c.reference_rate >= 16.0 || c.referred_at + 4 >= now {
+            if c.reference_rate >= 16.0 || c.referred_at >= last_restart {
                 continue;
             }
             remove_clause_fn(

--- a/src/cdb/db.rs
+++ b/src/cdb/db.rs
@@ -849,7 +849,7 @@ impl ClauseDBIF for ClauseDB {
         let mut ntier1: usize = 0;
         // tier 2 group: the small clauses under the best assignment
         let mut ntier2: usize = 0;
-        // let now = asg.derefer(assign::property::Tusize::NumConflict);
+        let now = asg.derefer(crate::assign::property::Tusize::NumConflict);
 
         for (i, c) in clause
             .iter_mut()
@@ -901,15 +901,15 @@ impl ClauseDBIF for ClauseDB {
                     ntier1 += 1;
                     continue;
                 }
-                4 if c.reference_rate > 0.3 => {
+                4 if c.reference_rate >= 0.1 => {
                     ntier2 += 1;
                     continue;
                 }
-                5 if c.reference_rate > 0.5 => {
+                5 if c.reference_rate >= 0.5 => {
                     ntier2 += 1;
                     continue;
                 }
-                6 if c.reference_rate > 0.7 => {
+                6 if c.reference_rate >= 0.8 => {
                     ntier2 += 1;
                     continue;
                 }
@@ -920,7 +920,7 @@ impl ClauseDBIF for ClauseDB {
             {
                 continue;
             }
-            if lbd <= 10 && c.reference_rate >= 1.0 {
+            if c.reference_rate >= 2.0 || c.len() <= 5 || c.referred_at + 2 >= now {
                 continue;
             }
             remove_clause_fn(

--- a/src/cdb/db.rs
+++ b/src/cdb/db.rs
@@ -832,6 +832,14 @@ impl ClauseDBIF for ClauseDB {
             clause,
             num_reduction,
             num_lbd2,
+
+            certification_store,
+            binary_link,
+            watch_cache,
+            num_bi_clause,
+            num_clause,
+            num_learnt,
+            freelist,
             ..
         } = self;
         *num_lbd2 = 0;
@@ -842,9 +850,10 @@ impl ClauseDBIF for ClauseDB {
         let mut ntier1: usize = 0;
         // tier 2 group: the small clauses under the best assignment
         let mut ntier2: usize = 0;
-        let mut tier3: Vec<(ClauseId, f64, DecisionLevel)> = Vec::new();
+        // let mut tier3: Vec<(ClauseId, f64, DecisionLevel)> = Vec::new();
         // let mut tier4: Vec<(ClauseId, DecisionLevel)> = Vec::new();
         // let mut has_progress: bool = false;
+        let threshold = (*num_reduction as f64 + 1.0).log2();
 
         for (i, c) in clause
             .iter_mut()
@@ -881,14 +890,37 @@ impl ClauseDBIF for ClauseDB {
             {
                 continue;
             }
-            tier3.push((ClauseId::from(i), c.reference_distance, lbd));
-        }
-        let threshold = (*num_reduction as f64 + 1.0).log2();
-        for (c, t, _) in tier3.into_iter() {
-            if t >= threshold {
-                self.remove_clause(c);
+            // tier3.push((ClauseId::from(i), c.reference_distance, lbd));
+            if c.reference_distance >= threshold {
+                remove_clause_fn(
+                    certification_store,
+                    binary_link,
+                    watch_cache,
+                    num_bi_clause,
+                    num_clause,
+                    num_learnt,
+                    ClauseId::from(i),
+                    c,
+                );
+                freelist.push(ClauseId::from(i));
             }
         }
+        // for (cid, t, _) in tier3.into_iter() {
+        //     if t >= threshold {
+        //         // self.remove_clause(cid);
+        //         remove_clause_fn(
+        //             certification_store,
+        //             binary_link,
+        //             watch_cache,
+        //             num_bi_clause,
+        //             num_clause,
+        //             num_learnt,
+        //             cid,
+        //             &mut clause[cid.ordinal.get() as usize],
+        //         );
+        //         freelist.push(cid);
+        //     }
+        // }
         self.tier1_clauses.update(ntier1 as f64 / num_alives as f64);
         self.tier2_clauses.update(ntier2 as f64 / num_alives as f64);
     }

--- a/src/cdb/db.rs
+++ b/src/cdb/db.rs
@@ -846,7 +846,6 @@ impl ClauseDBIF for ClauseDB {
         let mut ntier1: usize = 0;
         // tier 2 group: the small clauses under the best assignment
         let mut ntier2: usize = 0;
-        let _now = asg.derefer(crate::assign::property::Tusize::NumConflict);
         for (i, c) in clause
             .iter_mut()
             .enumerate()
@@ -854,9 +853,6 @@ impl ClauseDBIF for ClauseDB {
             .filter(|(_, c)| !c.is_dead())
         {
             num_alives += 1;
-            // match asg
-            //     .literal_block_distance_current(&c.lits)
-            //     .min((c.len() as DecisionLevel).saturating_sub(2))
             match asg.literal_block_distance_current(&c.lits) {
                 0..=2 => {
                     *num_lbd2 += 1;

--- a/src/cdb/db.rs
+++ b/src/cdb/db.rs
@@ -827,7 +827,7 @@ impl ClauseDBIF for ClauseDB {
         c.is(FlagClause::LEARNT)
     }
     /// reduce the number of 'learnt' or *removable* clauses.
-    fn reduce(&mut self, asg: &mut impl AssignIF, last_restart: usize) {
+    fn reduce(&mut self, asg: &mut impl AssignIF, last_restart: usize, retain_depth: f64) {
         let ClauseDB {
             clause,
             num_reduction,
@@ -850,10 +850,8 @@ impl ClauseDBIF for ClauseDB {
         let mut ntier1: usize = 0;
         // tier 2 group: the small clauses under the best assignment
         let mut ntier2: usize = 0;
-        // let mut tier3: Vec<(ClauseId, f64, DecisionLevel)> = Vec::new();
-        // let mut tier4: Vec<(ClauseId, DecisionLevel)> = Vec::new();
         // let mut has_progress: bool = false;
-        let threshold = (*num_reduction as f64 + 1.0).log2();
+        // let threshold = (*num_reduction as f64).log2();
 
         for (i, c) in clause
             .iter_mut()
@@ -866,7 +864,6 @@ impl ClauseDBIF for ClauseDB {
                 c.reference_distance += 0.2 * diff as f64;
             }
             let len = c.len();
-            // let lbd_g = asg.literal_block_distance(&c.lits);
             let lbd = asg.literal_block_distance_current(&c.lits);
             // c.lbd = lbd;
             if lbd <= 2 {
@@ -877,11 +874,11 @@ impl ClauseDBIF for ClauseDB {
                 c.turn_off(FlagClause::YOUNG);
             }
             num_alives += 1;
-            if len <= 5 {
+            if len <= 4 {
                 ntier1 += 1;
                 continue;
             }
-            if lbd <= 4 {
+            if lbd <= 3 {
                 ntier2 += 1;
                 continue;
             }
@@ -890,8 +887,9 @@ impl ClauseDBIF for ClauseDB {
             {
                 continue;
             }
-            // tier3.push((ClauseId::from(i), c.reference_distance, lbd));
-            if c.reference_distance >= threshold {
+            if c.reference_distance > retain_depth
+            /* threshold */
+            {
                 remove_clause_fn(
                     certification_store,
                     binary_link,
@@ -905,22 +903,6 @@ impl ClauseDBIF for ClauseDB {
                 freelist.push(ClauseId::from(i));
             }
         }
-        // for (cid, t, _) in tier3.into_iter() {
-        //     if t >= threshold {
-        //         // self.remove_clause(cid);
-        //         remove_clause_fn(
-        //             certification_store,
-        //             binary_link,
-        //             watch_cache,
-        //             num_bi_clause,
-        //             num_clause,
-        //             num_learnt,
-        //             cid,
-        //             &mut clause[cid.ordinal.get() as usize],
-        //         );
-        //         freelist.push(cid);
-        //     }
-        // }
         self.tier1_clauses.update(ntier1 as f64 / num_alives as f64);
         self.tier2_clauses.update(ntier2 as f64 / num_alives as f64);
     }

--- a/src/cdb/db.rs
+++ b/src/cdb/db.rs
@@ -313,7 +313,6 @@ impl ClauseDBIF for ClauseDB {
             c.refered_at = 0;
             c.reference_distance = 0.0;
             c.vivify_age = 0;
-            c.lbd = DecisionLevel::MAX;
         } else {
             cid = ClauseId::from(self.clause.len());
             let mut c = Clause {
@@ -913,11 +912,8 @@ impl ClauseDBIF for ClauseDB {
             }
         }
         for l in asg.stack_iter() {
-            match asg.reason(l.vi()) {
-                AssignReason::Implication(cid) => {
-                    self[cid].turn_on(FlagClause::BEST_PROPAGATOR);
-                }
-                _ => {}
+            if let AssignReason::Implication(cid) = asg.reason(l.vi()) {
+                self[cid].turn_on(FlagClause::BEST_PROPAGATOR);
             }
         }
     }

--- a/src/cdb/db.rs
+++ b/src/cdb/db.rs
@@ -311,6 +311,7 @@ impl ClauseDBIF for ClauseDB {
             std::mem::swap(&mut c.lits, vec);
             c.search_from = 2;
             c.refered_at = 0;
+            c.reference_distance = 0.0;
             c.vivify_age = 0;
             c.lbd = DecisionLevel::MAX;
         } else {
@@ -826,7 +827,7 @@ impl ClauseDBIF for ClauseDB {
         c.is(FlagClause::LEARNT)
     }
     /// reduce the number of 'learnt' or *removable* clauses.
-    fn reduce(&mut self, asg: &mut impl AssignIF, in_span: bool) {
+    fn reduce(&mut self, asg: &mut impl AssignIF, last_restart: usize) {
         let ClauseDB {
             clause,
             num_reduction,
@@ -841,12 +842,12 @@ impl ClauseDBIF for ClauseDB {
         let mut ntier1: usize = 0;
         // tier 2 group: the small clauses under the best assignment
         let mut ntier2: usize = 0;
-        let mut tier3: Vec<(ClauseId, usize, DecisionLevel)> = Vec::new();
-        let mut tier4: Vec<(ClauseId, DecisionLevel)> = Vec::new();
-        let mut peak_at: usize = 0;
-        let mut peak_level: DecisionLevel = 0;
+        let mut tier3: Vec<(ClauseId, f64, DecisionLevel)> = Vec::new();
+        // let mut tier4: Vec<(ClauseId, DecisionLevel)> = Vec::new();
+        // let mut peak_at: usize = 0;
+        // let mut peak_level: DecisionLevel = 0;
         // let mut max_required: DecisionLevel = 0;
-        let mut has_progress: bool = false;
+        // let mut has_progress: bool = false;
         let mut young_best: DecisionLevel = DecisionLevel::MAX;
 
         for (i, c) in clause
@@ -855,6 +856,10 @@ impl ClauseDBIF for ClauseDB {
             .skip(1)
             .filter(|(_, c)| !c.is_dead())
         {
+            if let Some(diff) = last_restart.checked_sub(c.refered_at) {
+                c.reference_distance *= 0.8;
+                c.reference_distance += 0.2 * diff as f64;
+            }
             let len = c.len();
             // let lbd_g = asg.literal_block_distance(&c.lits);
             let new_lbd = asg.literal_block_distance_current(&c.lits);
@@ -868,74 +873,61 @@ impl ClauseDBIF for ClauseDB {
                 c.turn_off(FlagClause::YOUNG);
                 young_best = young_best.min(lbd_l);
             }
-            if lbd_l >= peak_level {
-                peak_at = peak_at.max(c.refered_at);
-                peak_level = lbd_l;
-            }
-            // if !in_span {
-            //     if len <= 4 || lbd_l <= 3 {
-            //         continue;
-            //     } else {
-            //         tier4.push(ClauseId::from(i));
-            //     }
-            //     continue;
-            // }
             num_alives += 1;
             if len <= 5 {
                 ntier1 += 1;
-                has_progress |= young;
                 continue;
             }
             if lbd_l <= 4 {
                 ntier2 += 1;
-                has_progress |= young;
                 continue;
             }
-            // if !in_span {
-            //     tier4.push((ClauseId::from(i), lbd_l));
-            //     continue;
-            // }
-            if !c.is(FlagClause::LEARNT)
-                || c.is(FlagClause::ASSIGN_REASON)
-                || (c.is(FlagClause::BEST_PROPAGATOR)/* && lbd_l <= 5 */)
+            if !c.is(FlagClause::LEARNT) || c.is(FlagClause::ASSIGN_REASON)
+            // || (c.is(FlagClause::BEST_PROPAGATOR)/* && lbd_l <= 5 */)
             {
                 continue;
             }
-            if young && lbd_l < 8 {
-                tier4.push((ClauseId::from(i), lbd_l));
-                continue;
-            }
-            tier3.push((ClauseId::from(i), c.refered_at, lbd_l as DecisionLevel));
+            tier3.push((
+                ClauseId::from(i),
+                c.reference_distance,
+                lbd_l as DecisionLevel,
+            ));
         }
-        if has_progress {
-            // if we got progress, we don't need to care much; just trim old ones.
-            let threshold = peak_at.saturating_sub(1000);
-            for (c, t, l) in tier3.into_iter().rev() {
-                if t < threshold && l >= 5 {
-                    self.remove_clause(c);
-                }
-            }
-        } else {
-            // Otherwise, help movements to new directions
-            let threshold = peak_level;
-            for (c, _, l) in tier3.into_iter().rev() {
-                if l > threshold {
-                    self.remove_clause(c);
-                }
-            }
-        }
-        if !in_span && false {
-            for (c, _) in tier4.into_iter() {
+        let threshold = (*num_reduction as f64 + 1.0).log2();
+        for (c, t, _) in tier3.into_iter().rev() {
+            if t >= threshold {
                 self.remove_clause(c);
             }
-        } else {
-            let threshold = if has_progress { 6 } else { 8 };
-            for (c, l) in tier4.into_iter() {
-                if l >= threshold {
-                    self.remove_clause(c);
-                }
-            }
         }
+        // if has_progress {
+        //     // if we got progress, we don't need to care much; just trim old ones.
+        //     let threshold = peak_at.saturating_sub(1000);
+        //     for (c, t, l) in tier3.into_iter().rev() {
+        //         if t < threshold && l >= 5 {
+        //             self.remove_clause(c);
+        //         }
+        //     }
+        // } else {
+        //     // Otherwise, help movements to new directions
+        //     let threshold = peak_level;
+        //     for (c, _, l) in tier3.into_iter().rev() {
+        //         if l > threshold {
+        //             self.remove_clause(c);
+        //         }
+        //     }
+        // }
+        // if !in_span && false {
+        //     for (c, _) in tier4.into_iter() {
+        //         self.remove_clause(c);
+        //     }
+        // } else {
+        //     let threshold = if has_progress { 6 } else { 8 };
+        //     for (c, l) in tier4.into_iter() {
+        //         if l >= threshold {
+        //             self.remove_clause(c);
+        //         }
+        //     }
+        // }
         debug_assert!(num_alives > 0);
         self.tier1_clauses.update(ntier1 as f64 / num_alives as f64);
         self.tier2_clauses.update(ntier2 as f64 / num_alives as f64);

--- a/src/cdb/db.rs
+++ b/src/cdb/db.rs
@@ -827,9 +827,9 @@ impl ClauseDBIF for ClauseDB {
     }
     /// reduce the number of 'learnt' or *removable* clauses.
     fn reduce(&mut self, asg: &mut impl AssignIF) {
+        self.num_reduction += 1;
         let ClauseDB {
             clause,
-            num_reduction,
             num_lbd2,
             certification_store,
             binary_link,
@@ -841,7 +841,6 @@ impl ClauseDBIF for ClauseDB {
             ..
         } = self;
         *num_lbd2 = 0;
-        *num_reduction += 1;
         let mut num_alives: usize = 0;
         // tier 1 group: the small clauses under the best assignment
         let mut ntier1: usize = 0;
@@ -855,25 +854,31 @@ impl ClauseDBIF for ClauseDB {
             .filter(|(_, c)| !c.is_dead())
         {
             num_alives += 1;
-            match asg.literal_block_distance_current(&c.lits) {
+            match asg
+                .literal_block_distance_current(&c.lits)
+                .min(c.len() as DecisionLevel - 1)
+            {
                 0 | 1 | 2 => {
                     *num_lbd2 += 1;
-                    ntier1 += 1;
                     continue;
                 }
-                3 => {
+                3 if c.reference_rate >= 0.01 => {
                     ntier1 += 1;
                     continue;
                 }
                 4 if c.reference_rate >= 0.1 => {
+                    ntier1 += 1;
+                    continue;
+                }
+                5 if c.reference_rate >= 2.0 => {
                     ntier2 += 1;
                     continue;
                 }
-                5 if c.reference_rate >= 0.5 => {
+                6 if c.reference_rate >= 4.0 => {
                     ntier2 += 1;
                     continue;
                 }
-                6 if c.reference_rate >= 0.8 => {
+                7 if c.reference_rate >= 8.0 => {
                     ntier2 += 1;
                     continue;
                 }
@@ -882,7 +887,7 @@ impl ClauseDBIF for ClauseDB {
             if !c.is(FlagClause::LEARNT) || c.is(FlagClause::ASSIGN_REASON) {
                 continue;
             }
-            if c.reference_rate >= 2.0 || c.len() <= 5 || c.referred_at + 4 >= now {
+            if c.reference_rate >= 16.0 || c.referred_at + 4 >= now {
                 continue;
             }
             remove_clause_fn(

--- a/src/cdb/db.rs
+++ b/src/cdb/db.rs
@@ -858,7 +858,7 @@ impl ClauseDBIF for ClauseDB {
             //     .literal_block_distance_current(&c.lits)
             //     .min((c.len() as DecisionLevel).saturating_sub(2))
             match asg.literal_block_distance_current(&c.lits) {
-                0 | 1 | 2 => {
+                0..=2 => {
                     *num_lbd2 += 1;
                     continue;
                 }

--- a/src/cdb/db.rs
+++ b/src/cdb/db.rs
@@ -844,11 +844,7 @@ impl ClauseDBIF for ClauseDB {
         let mut ntier2: usize = 0;
         let mut tier3: Vec<(ClauseId, f64, DecisionLevel)> = Vec::new();
         // let mut tier4: Vec<(ClauseId, DecisionLevel)> = Vec::new();
-        // let mut peak_at: usize = 0;
-        // let mut peak_level: DecisionLevel = 0;
-        // let mut max_required: DecisionLevel = 0;
         // let mut has_progress: bool = false;
-        let mut young_best: DecisionLevel = DecisionLevel::MAX;
 
         for (i, c) in clause
             .iter_mut()
@@ -862,23 +858,21 @@ impl ClauseDBIF for ClauseDB {
             }
             let len = c.len();
             // let lbd_g = asg.literal_block_distance(&c.lits);
-            let new_lbd = asg.literal_block_distance_current(&c.lits);
-            let lbd_l = new_lbd; // c.lbd.min(new_lbd);
-            c.lbd = new_lbd;
-            if lbd_l <= 2 {
+            let lbd = asg.literal_block_distance_current(&c.lits);
+            // c.lbd = lbd;
+            if lbd <= 2 {
                 *num_lbd2 += 1;
             }
             let young = c.is(FlagClause::YOUNG);
             if young {
                 c.turn_off(FlagClause::YOUNG);
-                young_best = young_best.min(lbd_l);
             }
             num_alives += 1;
             if len <= 5 {
                 ntier1 += 1;
                 continue;
             }
-            if lbd_l <= 4 {
+            if lbd <= 4 {
                 ntier2 += 1;
                 continue;
             }
@@ -887,48 +881,14 @@ impl ClauseDBIF for ClauseDB {
             {
                 continue;
             }
-            tier3.push((
-                ClauseId::from(i),
-                c.reference_distance,
-                lbd_l as DecisionLevel,
-            ));
+            tier3.push((ClauseId::from(i), c.reference_distance, lbd));
         }
         let threshold = (*num_reduction as f64 + 1.0).log2();
-        for (c, t, _) in tier3.into_iter().rev() {
+        for (c, t, _) in tier3.into_iter() {
             if t >= threshold {
                 self.remove_clause(c);
             }
         }
-        // if has_progress {
-        //     // if we got progress, we don't need to care much; just trim old ones.
-        //     let threshold = peak_at.saturating_sub(1000);
-        //     for (c, t, l) in tier3.into_iter().rev() {
-        //         if t < threshold && l >= 5 {
-        //             self.remove_clause(c);
-        //         }
-        //     }
-        // } else {
-        //     // Otherwise, help movements to new directions
-        //     let threshold = peak_level;
-        //     for (c, _, l) in tier3.into_iter().rev() {
-        //         if l > threshold {
-        //             self.remove_clause(c);
-        //         }
-        //     }
-        // }
-        // if !in_span && false {
-        //     for (c, _) in tier4.into_iter() {
-        //         self.remove_clause(c);
-        //     }
-        // } else {
-        //     let threshold = if has_progress { 6 } else { 8 };
-        //     for (c, l) in tier4.into_iter() {
-        //         if l >= threshold {
-        //             self.remove_clause(c);
-        //         }
-        //     }
-        // }
-        debug_assert!(num_alives > 0);
         self.tier1_clauses.update(ntier1 as f64 / num_alives as f64);
         self.tier2_clauses.update(ntier2 as f64 / num_alives as f64);
     }

--- a/src/cdb/mod.rs
+++ b/src/cdb/mod.rs
@@ -103,7 +103,7 @@ pub trait ClauseDBIF:
     /// reduce learnt clauses
     /// # CAVEAT
     /// *precondition*: decision level == 0.
-    fn reduce(&mut self, asg: &mut impl AssignIF, last_restart: usize);
+    fn reduce(&mut self, asg: &mut impl AssignIF, last_restart: usize, retain_depth: f64);
     /// turn `FlagClause::BEST_PROPAGATOR` of 'used clauses' on
     fn save_best_assign_reasons(&mut self, asg: &impl AssignIF, clear: bool);
     /// update flags.

--- a/src/cdb/mod.rs
+++ b/src/cdb/mod.rs
@@ -103,7 +103,7 @@ pub trait ClauseDBIF:
     /// reduce learnt clauses
     /// # CAVEAT
     /// *precondition*: decision level == 0.
-    fn reduce(&mut self, asg: &mut impl AssignIF);
+    fn reduce(&mut self, asg: &mut impl AssignIF, last_restart: usize);
     /// turn `FlagClause::BEST_PROPAGATOR` of 'used clauses' on
     fn save_best_assign_reasons(&mut self, asg: &impl AssignIF, clear: bool);
     /// update flags.

--- a/src/cdb/mod.rs
+++ b/src/cdb/mod.rs
@@ -103,7 +103,7 @@ pub trait ClauseDBIF:
     /// reduce learnt clauses
     /// # CAVEAT
     /// *precondition*: decision level == 0.
-    fn reduce(&mut self, asg: &mut impl AssignIF, is_span: bool);
+    fn reduce(&mut self, asg: &mut impl AssignIF, last_restart: usize);
     /// turn `FlagClause::BEST_PROPAGATOR` of 'used clauses' on
     fn save_best_assign_reasons(&mut self, asg: &impl AssignIF, clear: bool);
     /// update flags.

--- a/src/cdb/mod.rs
+++ b/src/cdb/mod.rs
@@ -104,6 +104,8 @@ pub trait ClauseDBIF:
     /// # CAVEAT
     /// *precondition*: decision level == 0.
     fn reduce(&mut self, asg: &mut impl AssignIF, is_span: bool);
+    /// turn `FlagClause::BEST_PROPAGATOR` of 'used clauses' on
+    fn save_best_assign_reasons(&mut self, asg: &impl AssignIF, clear: bool);
     /// update flags.
     /// return `true` if it's learnt.
     fn update_at_analysis(&mut self, cid: ClauseId) -> bool;

--- a/src/cdb/mod.rs
+++ b/src/cdb/mod.rs
@@ -103,7 +103,7 @@ pub trait ClauseDBIF:
     /// reduce learnt clauses
     /// # CAVEAT
     /// *precondition*: decision level == 0.
-    fn reduce(&mut self, asg: &mut impl AssignIF, last_restart: usize, retain_depth: f64);
+    fn reduce(&mut self, asg: &mut impl AssignIF);
     /// turn `FlagClause::BEST_PROPAGATOR` of 'used clauses' on
     fn save_best_assign_reasons(&mut self, asg: &impl AssignIF, clear: bool);
     /// update flags.

--- a/src/cdb/vivify.rs
+++ b/src/cdb/vivify.rs
@@ -7,7 +7,7 @@ use crate::{
     types::*,
 };
 
-const VIVIFY_LIMIT: usize = 40_000;
+const VIVIFY_LIMIT: usize = 400_000;
 
 pub trait VivifyIF {
     fn vivify(&mut self, asg: &mut AssignStack, state: &mut State) -> MaybeInconsistent;
@@ -16,15 +16,13 @@ pub trait VivifyIF {
 impl VivifyIF for ClauseDB {
     /// vivify clauses under `asg`
     fn vivify(&mut self, asg: &mut AssignStack, state: &mut State) -> MaybeInconsistent {
-        const NUM_TARGETS: Option<usize> = Some(VIVIFY_LIMIT);
         if asg.remains() {
             asg.propagate_sandbox(self).map_err(|cc| {
                 state.log(None, "By vivifier");
                 SolverError::RootLevelConflict(cc)
             })?;
         }
-        let mut clauses: Vec<SortKey<ClauseId>> =
-            select_targets(self, asg.num_conflict, NUM_TARGETS);
+        let mut clauses: Vec<SortKey<ClauseId>> = select_targets(self, asg.num_conflict, None);
         state[Stat::Vivification] += 1;
         if clauses.is_empty() {
             return Ok(());
@@ -64,7 +62,9 @@ impl VivifyIF for ClauseDB {
                 to_display = num_check + display_step;
             }
             num_check += 1;
-            // debug_assert!(clits.iter().all(|l| !clits.contains(&!*l)));
+            if VIVIFY_LIMIT < num_check {
+                continue;
+            } // debug_assert!(clits.iter().all(|l| !clits.contains(&!*l)));
             let mut decisions: Vec<Lit> = Vec::new();
             for lit in clits.iter().copied() {
                 // assert!(!asg.var(lit.vi()).is(FlagVar::ELIMINATED));
@@ -142,9 +142,6 @@ impl VivifyIF for ClauseDB {
                     }
                 }
             }
-            if VIVIFY_LIMIT < num_check {
-                break;
-            }
         }
         asg.backtrack_sandbox();
         if asg.remains() {
@@ -184,10 +181,10 @@ fn select_targets(
         .enumerate()
         .skip(1)
         .filter_map(|(i, c)| {
-            if c.refered_at + 100_000 * (1 + c.vivify_age) < older_than {
+            if c.referred_at + 20_000 * (1 + c.vivify_age) < older_than {
                 Some(SortKey::new_invert(
                     ClauseId::from(i),
-                    -(c.refered_at as f64),
+                    -(c.referred_at as f64),
                 ))
             } else {
                 None
@@ -327,5 +324,8 @@ impl Clause {
     fn vivified(&mut self) {
         self.turn_off(FlagClause::TO_VIVIFY);
         self.vivify_age += 1;
+        self.reference_rate *= 0.8;
+        self.reference_rate += 0.2 * self.referred as f64;
+        self.referred = 0;
     }
 }

--- a/src/cdb/vivify.rs
+++ b/src/cdb/vivify.rs
@@ -43,14 +43,15 @@ impl VivifyIF for ClauseDB {
                 continue;
             }
             let c = &mut self[cid];
-            let used = c.referred;
             c.vivified();
             // Skip clauses that are unlikely to be improved by vivification.
             // Empirically success concentrates on clauses
             // that are not too short and have a moderate LBD; outside this band
             // the success rate collapses, so skipping them saves work without
             // losing many improvable clauses.
-            if used == 0 || c.len() < 8 || 12 < asg.literal_block_distance_current(&c.lits) {
+            if c.len() < 9_usize.saturating_sub(c.vivify_age)
+                || 12 < asg.literal_block_distance_current(&c.lits)
+            {
                 continue;
             }
             let is_learnt = c.is(FlagClause::LEARNT);

--- a/src/cdb/vivify.rs
+++ b/src/cdb/vivify.rs
@@ -7,8 +7,6 @@ use crate::{
     types::*,
 };
 
-const VIVIFY_LIMIT: usize = 400_000;
-
 pub trait VivifyIF {
     fn vivify(&mut self, asg: &mut AssignStack, state: &mut State) -> MaybeInconsistent;
 }
@@ -22,12 +20,6 @@ impl VivifyIF for ClauseDB {
                 SolverError::RootLevelConflict(cc)
             })?;
         }
-        let mut clauses: Vec<SortKey<ClauseId>> = select_targets(self, asg.num_conflict, None);
-        state[Stat::Vivification] += 1;
-        if clauses.is_empty() {
-            return Ok(());
-        }
-        let num_target = clauses.len();
         // This is a reusable vector to reduce memory consumption,
         // the key is the number of invocation
         let mut seen: Vec<usize> = vec![0; asg.num_vars + 1];
@@ -36,35 +28,51 @@ impl VivifyIF for ClauseDB {
         let mut num_shrink = 0;
         let mut num_assert = 0;
         let mut to_display = 0;
-        'next_clause: while let Some(cp) = clauses.pop() {
+        state[Stat::Vivification] += 1;
+        // Inlined target selection (formerly `select_targets`).
+        // Pick clauses that haven't been vivified recently. We deliberately
+        // do NOT sort the candidates: the per-clause filter in the loop below
+        // decides which ones are actually worth processing.
+        'next_clause: for i in 1..self.clause.len() {
+            let cid = ClauseId::from(i);
+            let c = &mut self[cid];
+            if c.is_dead() {
+                continue;
+            }
+            if c.referred_at + 20_000 * (1 + c.vivify_age) > asg.num_conflict {
+                continue;
+            }
+            let c = &mut self[cid];
+            let used = c.referred;
+            c.vivified();
+            // Skip clauses that are unlikely to be improved by vivification.
+            // Empirically success concentrates on clauses
+            // that are not too short and have a moderate LBD; outside this band
+            // the success rate collapses, so skipping them saves work without
+            // losing many improvable clauses.
+            if used == 0 || c.len() < 8 || 12 < asg.literal_block_distance_current(&c.lits) {
+                continue;
+            }
+            let is_learnt = c.is(FlagClause::LEARNT);
+            let clits = c.iter().copied().collect::<Vec<Lit>>();
+            if to_display <= num_check {
+                state.flush("");
+                state.flush(format!(
+                    "clause vivifying(assert:{num_assert} shorten:{num_shrink}, check:{num_check})..."
+                ));
+                to_display = num_check + display_step;
+            }
+            num_check += 1;
+            // debug_assert!(clits.iter().all(|l| !clits.contains(&!*l)));
+            // Build a clean environment
+            // debug_assert!(asg.stack_is_empty() || !asg.remains());
+            // debug_assert_eq!(asg.root_level(), asg.decision_level());
             asg.backtrack_sandbox();
             debug_assert_eq!(asg.decision_level(), asg.root_level());
             if asg.remains() {
                 asg.propagate_sandbox(self)
                     .map_err(SolverError::RootLevelConflict)?;
             }
-
-            // debug_assert!(asg.stack_is_empty() || !asg.remains());
-            // debug_assert_eq!(asg.root_level(), asg.decision_level());
-            let cid = cp.to();
-            let c = &mut self[cid];
-            if c.is_dead() {
-                continue;
-            }
-            let is_learnt = c.is(FlagClause::LEARNT);
-            c.vivified();
-            let clits = c.iter().copied().collect::<Vec<Lit>>();
-            if to_display <= num_check {
-                state.flush("");
-                state.flush(format!(
-                    "clause vivifying(assert:{num_assert} shorten:{num_shrink}, check:{num_check}/{num_target})..."
-                ));
-                to_display = num_check + display_step;
-            }
-            num_check += 1;
-            if VIVIFY_LIMIT < num_check {
-                continue;
-            } // debug_assert!(clits.iter().all(|l| !clits.contains(&!*l)));
             let mut decisions: Vec<Lit> = Vec::new();
             for lit in clits.iter().copied() {
                 // assert!(!asg.var(lit.vi()).is(FlagVar::ELIMINATED));
@@ -168,47 +176,6 @@ impl VivifyIF for ClauseDB {
         state[Stat::VivifiedVar] += num_assert;
         Ok(())
     }
-}
-
-fn select_targets(
-    cdb: &mut ClauseDB,
-    older_than: usize,
-    len: Option<usize>,
-) -> Vec<SortKey<ClauseId>> {
-    // let mut skips = 0;
-    let mut clauses: Vec<SortKey<ClauseId>> = cdb
-        .iter()
-        .enumerate()
-        .skip(1)
-        .filter_map(|(i, c)| {
-            if c.referred_at + 20_000 * (1 + c.vivify_age) < older_than {
-                Some(SortKey::new_invert(
-                    ClauseId::from(i),
-                    -(c.referred_at as f64),
-                ))
-            } else {
-                None
-            }
-            // c.to_vivify().and_then(|r| {
-            //     if r == 0.0 {
-            //         skips += 1;
-            //         None
-            //     } else {
-            //         Some(SortKey::new_invert(ClauseId::from(i), r))
-            //     }
-            // })
-        })
-        .collect::<Vec<_>>();
-    // if skips < clauses.len() {
-    //     return vec![];
-    // }
-    if let Some(max_len) = len
-        && max_len < clauses.len()
-    {
-        clauses.sort();
-        clauses.truncate(max_len);
-    }
-    clauses
 }
 
 impl AssignStack {

--- a/src/cdb/vivify.rs
+++ b/src/cdb/vivify.rs
@@ -39,7 +39,7 @@ impl VivifyIF for ClauseDB {
             if c.is_dead() {
                 continue;
             }
-            if c.referred_at + 20_000 * (1 + c.vivify_age) > asg.num_conflict {
+            if c.referred_at + 20_000 * (1 + c.vivify_age) > asg.num_conflict || c.vivify_age >= 8 {
                 continue;
             }
             let c = &mut self[cid];

--- a/src/cdb/vivify.rs
+++ b/src/cdb/vivify.rs
@@ -49,12 +49,15 @@ impl VivifyIF for ClauseDB {
             // that are not too short and have a moderate LBD; outside this band
             // the success rate collapses, so skipping them saves work without
             // losing many improvable clauses.
-            if c.len() < 9_usize.saturating_sub(c.vivify_age)
+            if c.len() < 9_usize.saturating_sub(c.vivify_age).max(3)
                 || 12 < asg.literal_block_distance_current(&c.lits)
             {
                 continue;
             }
             let is_learnt = c.is(FlagClause::LEARNT);
+            let vivify_age = c.vivify_age;
+            let referred_at = c.referred_at;
+            let reference_rate = c.reference_rate;
             let clits = c.iter().copied().collect::<Vec<Lit>>();
             if to_display <= num_check {
                 state.flush("");
@@ -140,7 +143,12 @@ impl VivifyIF for ClauseDB {
                                     num_assert += 1;
                                 }
                                 _ => {
-                                    self.new_clause(&mut vec, is_learnt);
+                                    if let Some(cid) = self.new_clause(&mut vec, is_learnt).is_new()
+                                    {
+                                        self[cid].referred_at = referred_at;
+                                        self[cid].reference_rate = reference_rate;
+                                        self[cid].vivify_age = vivify_age;
+                                    }
                                     self.remove_clause(cid);
                                     num_shrink += 1;
                                 }

--- a/src/cdb/vivify.rs
+++ b/src/cdb/vivify.rs
@@ -291,14 +291,8 @@ impl AssignStack {
 }
 
 impl Clause {
-    /// return `Some(value)` if the clause should try vivification.
-    /// smaller value is better.
-    fn to_vivify(&self) -> Option<f64> {
-        (!self.is_dead() && self.is(FlagClause::TO_VIVIFY)).then(|| self.len() as f64)
-    }
     /// clear flags about vivification
     fn vivified(&mut self) {
-        self.turn_off(FlagClause::TO_VIVIFY);
         self.vivify_age += 1;
         self.reference_rate *= 0.8;
         self.reference_rate += 0.2 * self.referred as f64;

--- a/src/cdb/vivify.rs
+++ b/src/cdb/vivify.rs
@@ -23,7 +23,8 @@ impl VivifyIF for ClauseDB {
                 SolverError::RootLevelConflict(cc)
             })?;
         }
-        let mut clauses: Vec<SortKey<ClauseId>> = select_targets(self, NUM_TARGETS);
+        let mut clauses: Vec<SortKey<ClauseId>> =
+            select_targets(self, asg.num_conflict, NUM_TARGETS);
         state[Stat::Vivification] += 1;
         if clauses.is_empty() {
             return Ok(());
@@ -52,7 +53,6 @@ impl VivifyIF for ClauseDB {
             if c.is_dead() {
                 continue;
             }
-            c.turn_off(FlagClause::TO_VIVIFY);
             let is_learnt = c.is(FlagClause::LEARNT);
             c.vivified();
             let clits = c.iter().copied().collect::<Vec<Lit>>();
@@ -173,21 +173,33 @@ impl VivifyIF for ClauseDB {
     }
 }
 
-fn select_targets(cdb: &mut ClauseDB, len: Option<usize>) -> Vec<SortKey<ClauseId>> {
-    let mut skips = 0;
+fn select_targets(
+    cdb: &mut ClauseDB,
+    older_than: usize,
+    len: Option<usize>,
+) -> Vec<SortKey<ClauseId>> {
+    // let mut skips = 0;
     let mut clauses: Vec<SortKey<ClauseId>> = cdb
         .iter()
         .enumerate()
         .skip(1)
         .filter_map(|(i, c)| {
-            c.to_vivify().and_then(|r| {
-                if r == 0.0 {
-                    skips += 1;
-                    None
-                } else {
-                    Some(SortKey::new_invert(ClauseId::from(i), r))
-                }
-            })
+            if c.refered_at + 100_000 * (1 + c.vivify_age) < older_than {
+                Some(SortKey::new_invert(
+                    ClauseId::from(i),
+                    -(c.refered_at as f64),
+                ))
+            } else {
+                None
+            }
+            // c.to_vivify().and_then(|r| {
+            //     if r == 0.0 {
+            //         skips += 1;
+            //         None
+            //     } else {
+            //         Some(SortKey::new_invert(ClauseId::from(i), r))
+            //     }
+            // })
         })
         .collect::<Vec<_>>();
     // if skips < clauses.len() {
@@ -312,5 +324,8 @@ impl Clause {
         (!self.is_dead() && self.is(FlagClause::TO_VIVIFY)).then(|| self.len() as f64)
     }
     /// clear flags about vivification
-    fn vivified(&mut self) {}
+    fn vivified(&mut self) {
+        self.turn_off(FlagClause::TO_VIVIFY);
+        self.vivify_age += 1;
+    }
 }

--- a/src/solver/conflict.rs
+++ b/src/solver/conflict.rs
@@ -208,7 +208,6 @@ pub fn handle_conflict(
             if bt_drift.is_none() {
                 asg.assign_by_implication(l0, AssignReason::BinaryLink(!l1), assign_level);
             }
-            cdb[cid].turn_on(FlagClause::YOUNG);
             ret = (cid, 1);
         }
         RefClause::Clause(cid) => {
@@ -218,7 +217,6 @@ pub fn handle_conflict(
                 cdb[cid].turn_on(FlagClause::ASSIGN_REASON);
                 // cdb[cid].activated = cdb[cid].activated.max(1);
             }
-            cdb[cid].turn_on(FlagClause::YOUNG);
             cdb[cid].reference_rate = 1.0;
             // lbd should be calculated at conflict level, where all literals are assigned.
             // But since vars hold the last level even after unassignment,

--- a/src/solver/conflict.rs
+++ b/src/solver/conflict.rs
@@ -219,11 +219,11 @@ pub fn handle_conflict(
                 // cdb[cid].activated = cdb[cid].activated.max(1);
             }
             cdb[cid].turn_on(FlagClause::YOUNG);
-            cdb[cid].reference_distance = 0.0;
+            cdb[cid].reference_rate = 1.0;
             // lbd should be calculated at conflict level, where all literals are assigned.
             // But since vars hold the last level even after unassignment,
             // we can have postponed the calculation.
-            let d = asg.literal_block_distance(&cdb[cid].lits);
+            let d = asg.literal_block_distance_current(&cdb[cid].lits);
             ret = (cid, d);
         }
         RefClause::RegisteredClause(cid) => {
@@ -243,7 +243,7 @@ pub fn handle_conflict(
             //     }
             //     panic!("here we are!");
             // }
-            ret = (cid, asg.literal_block_distance(&cdb[cid].lits));
+            ret = (cid, asg.literal_block_distance_current(&cdb[cid].lits));
             if bt_drift.is_none_or(|up1| up1 && cdb[cid].is_unit_under(&*asg)) {
                 asg.assign_by_implication(l0, AssignReason::BinaryLink(!l1), assign_level);
             }
@@ -425,12 +425,8 @@ fn conflict_analyze(
                         trace!(q, " -- ignore flagged already");
                     }
                 }
-                if cdb[cid].refered_at < state.last_restart {
-                    cdb[cid].reference_distance *= 0.8;
-                    cdb[cid].reference_distance +=
-                        0.2 * (asg.num_conflict - state.last_restart) as f64;
-                }
-                cdb[cid].refered_at = asg.num_conflict;
+                cdb[cid].referred_at = asg.num_conflict;
+                cdb[cid].referred += 1;
             }
             AssignReason::Decision(_) | AssignReason::None => {}
         }

--- a/src/solver/conflict.rs
+++ b/src/solver/conflict.rs
@@ -215,7 +215,6 @@ pub fn handle_conflict(
             if bt_drift.is_none_or(|up1| up1 && cdb[cid].is_unit_under(&*asg)) {
                 asg.assign_by_implication(l0, AssignReason::Implication(cid), assign_level);
                 cdb[cid].turn_on(FlagClause::ASSIGN_REASON);
-                // cdb[cid].activated = cdb[cid].activated.max(1);
             }
             cdb[cid].reference_rate = 1.0;
             // lbd should be calculated at conflict level, where all literals are assigned.

--- a/src/solver/conflict.rs
+++ b/src/solver/conflict.rs
@@ -208,6 +208,7 @@ pub fn handle_conflict(
             if bt_drift.is_none() {
                 asg.assign_by_implication(l0, AssignReason::BinaryLink(!l1), assign_level);
             }
+            cdb[cid].turn_on(FlagClause::YOUNG);
             ret = (cid, 1);
         }
         RefClause::Clause(cid) => {
@@ -217,6 +218,7 @@ pub fn handle_conflict(
                 cdb[cid].turn_on(FlagClause::ASSIGN_REASON);
                 // cdb[cid].activated = cdb[cid].activated.max(1);
             }
+            cdb[cid].turn_on(FlagClause::YOUNG);
             // lbd should be calculated at conflict level, where all literals are assigned.
             // But since vars hold the last level even after unassignment,
             // we can have postponed the calculation.

--- a/src/solver/conflict.rs
+++ b/src/solver/conflict.rs
@@ -425,9 +425,12 @@ fn conflict_analyze(
                         trace!(q, " -- ignore flagged already");
                     }
                 }
+                if cdb[cid].refered_at < state.last_restart {
+                    cdb[cid].reference_distance *= 0.8;
+                    cdb[cid].reference_distance +=
+                        0.2 * (asg.num_conflict - state.last_restart) as f64;
+                }
                 cdb[cid].refered_at = asg.num_conflict;
-                cdb[cid].reference_distance *= 0.8;
-                cdb[cid].reference_distance += 0.2 * (asg.num_conflict - state.last_restart) as f64;
             }
             AssignReason::Decision(_) | AssignReason::None => {}
         }

--- a/src/solver/conflict.rs
+++ b/src/solver/conflict.rs
@@ -219,7 +219,7 @@ pub fn handle_conflict(
                 // cdb[cid].activated = cdb[cid].activated.max(1);
             }
             cdb[cid].turn_on(FlagClause::YOUNG);
-            cdb[cid].reference_distance = 8.0;
+            cdb[cid].reference_distance = 0.0;
             // lbd should be calculated at conflict level, where all literals are assigned.
             // But since vars hold the last level even after unassignment,
             // we can have postponed the calculation.

--- a/src/solver/conflict.rs
+++ b/src/solver/conflict.rs
@@ -219,6 +219,7 @@ pub fn handle_conflict(
                 // cdb[cid].activated = cdb[cid].activated.max(1);
             }
             cdb[cid].turn_on(FlagClause::YOUNG);
+            cdb[cid].reference_distance = 8.0;
             // lbd should be calculated at conflict level, where all literals are assigned.
             // But since vars hold the last level even after unassignment,
             // we can have postponed the calculation.
@@ -425,6 +426,8 @@ fn conflict_analyze(
                     }
                 }
                 cdb[cid].refered_at = asg.num_conflict;
+                cdb[cid].reference_distance *= 0.8;
+                cdb[cid].reference_distance += 0.2 * (asg.num_conflict - state.last_restart) as f64;
             }
             AssignReason::Decision(_) | AssignReason::None => {}
         }

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -258,15 +258,11 @@ fn search(
     let mut span_scale: usize = luby_scale;
 
     macro_rules! reduce {
-        ($in_span: expr) => {{
+        () => {{
             state.search_mode_ratio.0.update(0.0);
             state.search_mode_ratio.1.update(0.0);
             reduction_pressure = 0;
-            cdb.reduce(
-                asg,
-                state.last_restart,
-                state.span_manager.envelop_index() as f64 + 0.0,
-            )
+            cdb.reduce(asg)
         }};
     }
     macro_rules! to_lrb {
@@ -377,16 +373,13 @@ fn search(
         rephase_rotation_pressure += 1;
         span_len += 1;
         if reduction_pressure >= 8192 * state.span_manager.envelop_index() {
-            reduce!(false);
+            reduce!();
         }
         if state.span_manager.span_ended(span_len / span_scale) {
             span_len = 0;
             let new_segment = state.span_manager.prepare_new_span(span_len);
             dump_stage(asg, state, new_segment);
             let unasserted_pre = asg.derefer(assign::property::Tusize::NumUnassertedVar);
-            // if reduction_pressure >= 1024 * 16 {
-            //     reduce!(true);
-            // }
             RESTART!(asg, cdb, state)?;
             if vivificatioen_pressure >= vivificatioen_interval {
                 if cfg!(feature = "clause_vivification") {

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -259,7 +259,7 @@ fn search(
             state.search_mode_ratio.0.update(0.0);
             state.search_mode_ratio.1.update(0.0);
             reduction_pressure = 0;
-            cdb.reduce(asg)
+            cdb.reduce(asg, state.last_restart)
         }};
     }
     macro_rules! to_lrb {
@@ -369,7 +369,7 @@ fn search(
         // reduction_pressure += 1;
         rephase_rotation_pressure += 1;
         span_len += 1;
-        if reduction_pressure >= 4096 * state.span_manager.envelop_index() {
+        if reduction_pressure >= 80_000 {
             reduce!();
         }
         if state.span_manager.span_ended(span_len / span_scale) {
@@ -379,6 +379,7 @@ fn search(
             let unasserted_pre = asg.derefer(assign::property::Tusize::NumUnassertedVar);
             RESTART!(asg, cdb, state)?;
             if vivificatioen_pressure >= vivificatioen_interval {
+                reduce!();
                 if cfg!(feature = "clause_vivification") && current_phase.0 == RephaseTarget::Walk {
                     cdb.vivify(asg, state)?;
                 }

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -415,14 +415,11 @@ fn search(
             }
             if new_segment == Some(true) {
                 span_scale = luby_scale * state.span_manager.envelop_index();
-            }
-            // Adapt LRB learning rate to the upcoming Luby span length:
-            // shorter spans → higher α (fast learning before the next restart),
-            // longer spans  → lower  α (stable estimates over more conflicts).
-            if asg.activity_scheme == VarActivityScheme::LRB {
-                let span = (state.span_manager.current_span() * luby_scale) as f64;
-                let _adaptive_lr = (state.config.vrw_learning_rate / span.sqrt()).clamp(0.0, 1.0);
-                let adaptive_lr = 1.0 / (span_scale as f64);
+                // Adapt LRB learning rate to the upcoming Luby span length:
+                // shorter spans → higher α (fast learning before the next restart),
+                // longer spans  → lower  α (stable estimates over more conflicts).
+                let span = (state.span_manager.envelop_index() * luby_scale) as f64;
+                let adaptive_lr = (1.0 / span.sqrt()).clamp(0.0, 1.0);
                 asg.set_learning_rate(adaptive_lr);
             }
         }

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -35,6 +35,7 @@ macro_rules! RESTART {
         }
         $cdb.handle(SolverEvent::Restart);
         $state.handle(SolverEvent::Restart);
+        $state.last_restart = $asg.num_conflict;
         $asg.clear_asserted_literals($cdb)
     }};
     ($asg: expr, $cdb: expr, $state: expr, $_: expr) => {
@@ -45,6 +46,7 @@ macro_rules! RESTART {
         }
         $cdb.handle(SolverEvent::Restart);
         $state.handle(SolverEvent::Restart);
+        $state.last_restart = $asg.num_conflict;
     };
 }
 
@@ -223,14 +225,14 @@ impl SolveIF for Solver {
 
 /// table of (RephaseTarget, span length, next index)
 const REPHASE_ROTATION: [(RephaseTarget, usize, usize); 8] = [
-    (RephaseTarget::Best, 400, 1),
-    (RephaseTarget::Walk, 2000, 2),
-    (RephaseTarget::False, 400, 3),
-    (RephaseTarget::Walk, 2000, 4),
-    (RephaseTarget::True, 400, 5),
-    (RephaseTarget::Walk, 2000, 6),
-    (RephaseTarget::Inverted, 400, 7),
-    (RephaseTarget::Walk, 2000, 0),
+    (RephaseTarget::Best, 20, 1),
+    (RephaseTarget::Walk, 100, 2),
+    (RephaseTarget::False, 20, 3),
+    (RephaseTarget::Walk, 100, 4),
+    (RephaseTarget::True, 20, 5),
+    (RephaseTarget::Walk, 100, 6),
+    (RephaseTarget::Inverted, 20, 7),
+    (RephaseTarget::Walk, 100, 0),
     // (RephaseTarget::Random, 4, 0),
 ];
 
@@ -260,7 +262,7 @@ fn search(
             state.search_mode_ratio.0.update(0.0);
             state.search_mode_ratio.1.update(0.0);
             reduction_pressure = 0;
-            cdb.reduce(asg, $in_span)
+            cdb.reduce(asg, state.last_restart)
         }};
     }
     macro_rules! to_lrb {

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -13,6 +13,7 @@ use {
         state::{Stat, State, StateIF},
         types::*,
     },
+    std::cmp::Ordering,
 };
 
 /// API to [`solve`](`crate::solver::SolveIF::solve`) SAT problems.
@@ -221,12 +222,15 @@ impl SolveIF for Solver {
 }
 
 /// table of (RephaseTarget, span length, next index)
-const REPHASE_ROTATION: [(RephaseTarget, usize, usize); 5] = [
-    (RephaseTarget::Best, 500, 1),
-    (RephaseTarget::False, 400, 2),
-    (RephaseTarget::True, 400, 3),
-    (RephaseTarget::Walk, 500, 4),
-    (RephaseTarget::Inverted, 400, 0),
+const REPHASE_ROTATION: [(RephaseTarget, usize, usize); 8] = [
+    (RephaseTarget::Best, 400, 1),
+    (RephaseTarget::Walk, 2000, 2),
+    (RephaseTarget::False, 400, 3),
+    (RephaseTarget::Walk, 2000, 4),
+    (RephaseTarget::True, 400, 5),
+    (RephaseTarget::Walk, 2000, 6),
+    (RephaseTarget::Inverted, 400, 7),
+    (RephaseTarget::Walk, 2000, 0),
     // (RephaseTarget::Random, 4, 0),
 ];
 
@@ -237,8 +241,10 @@ fn search(
     state: &mut State,
 ) -> Result<bool, SolverError> {
     let mut span_len: usize = 1;
-    let mut processing_pressure: usize = 0;
-    let processing_interval: usize = 80_000;
+    let mut vivificatioen_pressure: usize = 0;
+    let vivificatioen_interval: usize = 8_000;
+    let mut elimination_pressure: usize = 0;
+    let elimination_interval: usize = 80_000;
     let mut progress_pressure: usize = 0;
     let progress_interval: usize = 10_000;
     let mut reduction_pressure: usize = 0;
@@ -303,7 +309,12 @@ fn search(
                 state.core_size = core;
             } else {
                 assign_peak = 0;
+                let pre = state.core_size;
                 state.core_size = asg.derefer(assign::property::Tusize::NumUnassertedVar);
+                cdb.save_best_assign_reasons(asg, true);
+                if pre < state.core_size {
+                    to_vmtf!();
+                }
             }
         };
     }
@@ -341,19 +352,28 @@ fn search(
             lbd_l = asg.literal_block_distance_current(&cdb[cid].lits);
             cdb.lbd.update(lbd_g as f64);
         }
-        // not use '<=' to avoid an oscilation
-        if assign_peak < asg.stack_len() {
-            assign_peak = asg.stack_len();
-            state.core_size = asg.save_best_phases();
-            state.flush("");
-            state.flush(format!("core: {}", state.core_size));
+        match asg.stack_len().cmp(&assign_peak) {
+            Ordering::Less => {}
+            Ordering::Equal => {
+                // Do not update best_phases here to avoid an oscilation
+                cdb.save_best_assign_reasons(asg, false);
+            }
+            Ordering::Greater => {
+                assign_peak = asg.stack_len();
+                state.core_size = asg.save_best_phases();
+                cdb.save_best_assign_reasons(asg, false);
+                state.flush("");
+                state.flush(format!("core: {}", state.core_size));
+            }
         }
-        processing_pressure += 1;
+        elimination_pressure += 1;
+        vivificatioen_pressure += 1;
         progress_pressure += 1;
-        reduction_pressure += (lbd_g <= lbd_l) as usize;
+        reduction_pressure += (4 < lbd_l) as usize;
+        // reduction_pressure += 1;
         rephase_rotation_pressure += 1;
         span_len += 1;
-        if reduction_pressure > span_scale * 8 {
+        if reduction_pressure >= span_scale * 256 {
             reduce!(true);
         }
         if state.span_manager.span_ended(span_len / span_scale) {
@@ -361,23 +381,29 @@ fn search(
             let new_segment = state.span_manager.prepare_new_span(span_len);
             dump_stage(asg, state, new_segment);
             let unasserted_pre = asg.derefer(assign::property::Tusize::NumUnassertedVar);
+            if reduction_pressure >= 1024 * 16 {
+                reduce!(true);
+            }
             RESTART!(asg, cdb, state)?;
-            if processing_pressure >= processing_interval {
+            if vivificatioen_pressure >= vivificatioen_interval {
                 if cfg!(feature = "clause_vivification") {
                     cdb.vivify(asg, state)?;
                 }
+                vivificatioen_pressure = 0;
+            }
+            if elimination_pressure >= elimination_interval {
                 if cfg!(feature = "clause_elimination") {
                     let mut elim = Eliminator::instantiate(&state.config, &state.cnf);
                     state.flush("clause subsumption, ");
                     elim.simplify(asg, cdb, state, false)?;
                     asg.eliminated.append(elim.eliminated_lits());
                 }
-                processing_pressure = 0;
+                elimination_pressure = 0;
             }
             let unasserted_now = asg.derefer(assign::property::Tusize::NumUnassertedVar);
             if unasserted_now != unasserted_pre {
                 update_core!(unasserted_pre - unasserted_now);
-                to_vmtf!();
+                // to_vmtf!();
             }
             if cfg!(feature = "rephase") {
                 match asg.activity_scheme {

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -339,8 +339,7 @@ fn search(
             return Err(SolverError::RootLevelConflict(cc));
         }
         asg.update_activity_tick();
-        let (cid, lbd_g) = handle_conflict(asg, cdb, state, &cc)?;
-        let lbd_l: DecisionLevel;
+        let (cid, lbd) = handle_conflict(asg, cdb, state, &cc)?;
         if cid == ClauseId::default() {
             match asg.activity_scheme {
                 VarActivityScheme::LRB => {
@@ -353,10 +352,8 @@ fn search(
                 }
             }
             update_core!(1);
-            lbd_l = 0;
         } else {
-            lbd_l = asg.literal_block_distance_current(&cdb[cid].lits);
-            cdb.lbd.update(lbd_g as f64);
+            cdb.lbd.update(lbd as f64);
         }
         match asg.stack_len().cmp(&assign_peak) {
             Ordering::Less => {}
@@ -375,21 +372,21 @@ fn search(
         elimination_pressure += 1;
         vivificatioen_pressure += 1;
         progress_pressure += 1;
-        reduction_pressure += (4 < lbd_l) as usize;
+        reduction_pressure += 1;
         // reduction_pressure += 1;
         rephase_rotation_pressure += 1;
         span_len += 1;
-        if reduction_pressure >= span_scale * 256 {
-            reduce!(true);
+        if reduction_pressure >= 8192 * state.span_manager.envelop_index() {
+            reduce!(false);
         }
         if state.span_manager.span_ended(span_len / span_scale) {
             span_len = 0;
             let new_segment = state.span_manager.prepare_new_span(span_len);
             dump_stage(asg, state, new_segment);
             let unasserted_pre = asg.derefer(assign::property::Tusize::NumUnassertedVar);
-            if reduction_pressure >= 1024 * 16 {
-                reduce!(true);
-            }
+            // if reduction_pressure >= 1024 * 16 {
+            //     reduce!(true);
+            // }
             RESTART!(asg, cdb, state)?;
             if vivificatioen_pressure >= vivificatioen_interval {
                 if cfg!(feature = "clause_vivification") {

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -262,7 +262,11 @@ fn search(
             state.search_mode_ratio.0.update(0.0);
             state.search_mode_ratio.1.update(0.0);
             reduction_pressure = 0;
-            cdb.reduce(asg, state.last_restart)
+            cdb.reduce(
+                asg,
+                state.last_restart,
+                state.span_manager.envelop_index() as f64 + 0.0,
+            )
         }};
     }
     macro_rules! to_lrb {

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -366,10 +366,9 @@ fn search(
         vivificatioen_pressure += 1;
         progress_pressure += 1;
         reduction_pressure += 1;
-        // reduction_pressure += 1;
         rephase_rotation_pressure += 1;
         span_len += 1;
-        if reduction_pressure >= 80_000 {
+        if reduction_pressure >= 40_000 {
             reduce!();
         }
         if state.span_manager.span_ended(span_len / span_scale) {
@@ -379,8 +378,8 @@ fn search(
             let unasserted_pre = asg.derefer(assign::property::Tusize::NumUnassertedVar);
             RESTART!(asg, cdb, state)?;
             if vivificatioen_pressure >= vivificatioen_interval {
-                reduce!();
                 if cfg!(feature = "clause_vivification") && current_phase.0 == RephaseTarget::Walk {
+                    reduce!();
                     cdb.vivify(asg, state)?;
                 }
                 vivificatioen_pressure = 0;

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -224,16 +224,13 @@ impl SolveIF for Solver {
 }
 
 /// table of (RephaseTarget, span length, next index)
-const REPHASE_ROTATION: [(RephaseTarget, usize, usize); 8] = [
-    (RephaseTarget::Best, 20, 1),
-    (RephaseTarget::Walk, 100, 2),
-    (RephaseTarget::False, 20, 3),
-    (RephaseTarget::Walk, 100, 4),
-    (RephaseTarget::True, 20, 5),
-    (RephaseTarget::Walk, 100, 6),
-    (RephaseTarget::Inverted, 20, 7),
-    (RephaseTarget::Walk, 100, 0),
-    // (RephaseTarget::Random, 4, 0),
+const REPHASE_ROTATION: [(RephaseTarget, usize, usize); 6] = [
+    (RephaseTarget::False, 20, 1),
+    (RephaseTarget::Walk, 60, 2),
+    (RephaseTarget::True, 20, 3),
+    (RephaseTarget::Best, 80, 4),
+    (RephaseTarget::Inverted, 20, 5),
+    (RephaseTarget::Walk, 60, 0),
 ];
 
 /// main loop; returns `Ok(true)` for SAT, `Ok(false)` for UNSAT.
@@ -372,7 +369,7 @@ fn search(
         // reduction_pressure += 1;
         rephase_rotation_pressure += 1;
         span_len += 1;
-        if reduction_pressure >= 8192 * state.span_manager.envelop_index() {
+        if reduction_pressure >= 4096 * state.span_manager.envelop_index() {
             reduce!();
         }
         if state.span_manager.span_ended(span_len / span_scale) {
@@ -382,7 +379,7 @@ fn search(
             let unasserted_pre = asg.derefer(assign::property::Tusize::NumUnassertedVar);
             RESTART!(asg, cdb, state)?;
             if vivificatioen_pressure >= vivificatioen_interval {
-                if cfg!(feature = "clause_vivification") {
+                if cfg!(feature = "clause_vivification") && current_phase.0 == RephaseTarget::Walk {
                     cdb.vivify(asg, state)?;
                 }
                 vivificatioen_pressure = 0;

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -415,11 +415,11 @@ fn search(
             }
             if new_segment == Some(true) {
                 span_scale = luby_scale * state.span_manager.envelop_index();
-                // Adapt LRB learning rate to the upcoming Luby span length:
+                // Adapt LRB learning rate to the upcoming Luby envelope height:
                 // shorter spans → higher α (fast learning before the next restart),
                 // longer spans  → lower  α (stable estimates over more conflicts).
-                let span = (state.span_manager.envelop_index() * luby_scale) as f64;
-                let adaptive_lr = (1.0 / span.sqrt()).clamp(0.0, 1.0);
+                let span: f64 = (state.span_manager.envelop_index() * luby_scale) as f64;
+                let adaptive_lr: f64 = 1.0 / span.sqrt();
                 asg.set_learning_rate(adaptive_lr);
             }
         }

--- a/src/solver/search.rs
+++ b/src/solver/search.rs
@@ -420,9 +420,9 @@ fn search(
             // shorter spans → higher α (fast learning before the next restart),
             // longer spans  → lower  α (stable estimates over more conflicts).
             if asg.activity_scheme == VarActivityScheme::LRB {
-                let span = state.span_manager.current_span() as f64;
-                let adaptive_lr = (state.config.vrw_learning_rate / span.sqrt())
-                    .clamp(1e-4, state.config.vrw_learning_rate);
+                let span = (state.span_manager.current_span() * luby_scale) as f64;
+                let _adaptive_lr = (state.config.vrw_learning_rate / span.sqrt()).clamp(0.0, 1.0);
+                let adaptive_lr = 1.0 / (span_scale as f64);
                 asg.set_learning_rate(adaptive_lr);
             }
         }

--- a/src/state.rs
+++ b/src/state.rs
@@ -121,6 +121,8 @@ pub struct State {
     pub bt_drift_average: Ema,
     /// The unreachable core size
     pub core_size: usize,
+    /// the last restart in conflicts
+    pub last_restart: usize,
 
     #[cfg(feature = "chrono_BT")]
     /// chronoBT threshold
@@ -164,6 +166,7 @@ impl Default for State {
             c_lvl: Ema2::default_extended(),
             bt_drift_average: Ema::default().with_span(1000),
             core_size: 0,
+            last_restart: 0,
 
             #[cfg(feature = "chrono_BT")]
             chrono_bt_threshold: 100,

--- a/src/types/clause.rs
+++ b/src/types/clause.rs
@@ -22,8 +22,6 @@ pub struct Clause {
     pub(crate) reference_distance: f64,
     /// last vivified time in conflicts
     pub(crate) vivify_age: usize,
-    ///
-    pub(crate) lbd: DecisionLevel,
 }
 
 /// API for Clause, providing literal accessors.
@@ -57,7 +55,6 @@ impl Default for Clause {
             refered_at: 0,
             reference_distance: 0.0,
             vivify_age: 0,
-            lbd: DecisionLevel::MAX,
         }
     }
 }

--- a/src/types/clause.rs
+++ b/src/types/clause.rs
@@ -18,10 +18,11 @@ pub struct Clause {
     /// Since it's just a hint, we don't need u32 or usize.
     pub search_from: u16,
     /// Sum of activated (used as propagated) duration
-    pub(crate) refered_at: usize,
-    pub(crate) reference_distance: f64,
+    pub(crate) referred_at: usize,
+    pub(crate) reference_rate: f64,
     /// last vivified time in conflicts
     pub(crate) vivify_age: usize,
+    pub(crate) referred: usize,
 }
 
 /// API for Clause, providing literal accessors.
@@ -52,9 +53,10 @@ impl Default for Clause {
             lits: vec![],
             flags: FlagClause::empty(),
             search_from: 2,
-            refered_at: 0,
-            reference_distance: 0.0,
+            referred_at: 0,
+            reference_rate: 1.0,
             vivify_age: 0,
+            referred: 0,
         }
     }
 }

--- a/src/types/clause.rs
+++ b/src/types/clause.rs
@@ -19,6 +19,10 @@ pub struct Clause {
     pub search_from: u16,
     /// Sum of activated (used as propagated) duration
     pub(crate) refered_at: usize,
+    /// last vivified time in conflicts
+    pub(crate) vivify_age: usize,
+    ///
+    pub(crate) lbd: DecisionLevel,
 }
 
 /// API for Clause, providing literal accessors.
@@ -50,6 +54,8 @@ impl Default for Clause {
             flags: FlagClause::empty(),
             search_from: 2,
             refered_at: 0,
+            vivify_age: 0,
+            lbd: DecisionLevel::MAX,
         }
     }
 }

--- a/src/types/clause.rs
+++ b/src/types/clause.rs
@@ -19,6 +19,7 @@ pub struct Clause {
     pub search_from: u16,
     /// Sum of activated (used as propagated) duration
     pub(crate) refered_at: usize,
+    pub(crate) reference_distance: f64,
     /// last vivified time in conflicts
     pub(crate) vivify_age: usize,
     ///
@@ -54,6 +55,7 @@ impl Default for Clause {
             flags: FlagClause::empty(),
             search_from: 2,
             refered_at: 0,
+            reference_distance: 0.0,
             vivify_age: 0,
             lbd: DecisionLevel::MAX,
         }

--- a/src/types/clause.rs
+++ b/src/types/clause.rs
@@ -19,9 +19,11 @@ pub struct Clause {
     pub search_from: u16,
     /// Sum of activated (used as propagated) duration
     pub(crate) referred_at: usize,
+    /// The average number of references in a vivification interval
     pub(crate) reference_rate: f64,
     /// last vivified time in conflicts
     pub(crate) vivify_age: usize,
+    /// The number of referrences in conflict analysis
     pub(crate) referred: usize,
 }
 

--- a/src/types/flags.rs
+++ b/src/types/flags.rs
@@ -25,12 +25,8 @@ bitflags! {
         const OCCUR_LINKED    = 0b0000_0100;
         /// a clause is registered in vars' assing list.
         const ASSIGN_REASON   = 0b0000_1000;
-        /// a clause is born after the last reduction
-        const TO_VIVIFY       = 0b0001_0000;
-        ///
+        /// used in the best assignments
         const BEST_PROPAGATOR = 0b0010_0000;
-        ///
-        const YOUNG           = 0b0100_0000;
     }
 }
 

--- a/src/types/flags.rs
+++ b/src/types/flags.rs
@@ -18,15 +18,19 @@ bitflags! {
     #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
     pub struct FlagClause: u8 {
         /// a clause is a generated clause by conflict analysis and is removable.
-        const LEARNT        = 0b0000_0001;
+        const LEARNT          = 0b0000_0001;
         /// a clause or var is enqueued for eliminator.
-        const ENQUEUED      = 0b0000_0010;
+        const ENQUEUED        = 0b0000_0010;
         /// a clause is registered in vars' occurrence list.
-        const OCCUR_LINKED  = 0b0000_0100;
+        const OCCUR_LINKED    = 0b0000_0100;
         /// a clause is registered in vars' assing list.
-        const ASSIGN_REASON = 0b0000_1000;
+        const ASSIGN_REASON   = 0b0000_1000;
         /// a clause is born after the last reduction
-        const TO_VIVIFY     = 0b0001_0000;
+        const TO_VIVIFY       = 0b0001_0000;
+        ///
+        const BEST_PROPAGATOR = 0b0010_0000;
+        ///
+        const YOUNG           = 0b0100_0000;
     }
 }
 


### PR DESCRIPTION
# Summary

This branch reworks how Splr judges, keeps, and refines learnt clauses, moving
away from the static LBD-tier model toward a usage-driven *reference rate*.

## Core idea: reference rate instead of birth-time tiers

- Each clause now tracks how often it is actually touched during conflict
  analysis. A smoothed *reference rate* accumulates these references and decays
  over time, giving an evolving estimate of a clause's ongoing usefulness rather
  than a one-shot LBD snapshot taken at creation.
- The `TO_VIVIFY` and `YOUNG` clause flags are gone, along with the slope/birth
  heuristics that drove the previous reduction logic.

## Clause reduction

- `reduce` is now a single pass that combines the clause's *current* LBD with its
  reference rate: very tight clauses are always kept, and progressively looser
  ones must show a correspondingly higher reference rate to survive.
- Recently referenced clauses (since the last restart) and assignment reasons are
  protected. Reduction cadence is driven by conflict count and restart tracking
  rather than the Luby span scale.

## Vivification

- Vivification becomes the central refinement driver. Instead of pre-selecting
  and sorting a target list, it sweeps all clauses and applies an inline filter
  based on clause age, how many times it has already been vivified, length, and
  current LBD — concentrating effort where success is likely.
- Vivification is scheduled together with reduction during the `Walk` rephase
  phase, and clauses derived from vivification inherit their parent's reference
  history so their accumulated value is not lost.

## Supporting changes

- A `BEST_PROPAGATOR` flag marks clauses that act as reasons in the best/peak
  assignment, captured via `save_best_assign_reasons`. But not in use for now.
- The rephase rotation is retuned (shorter spans, `Walk` revisited), and the LRB
  learning rate is now derived from the Luby envelope height per segment.
