### PR TITLE
Fix certification error by 918d9e7c

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ default = [
     "unsafe_access",
     # "chrono_BT",
     "trail_saving",
-    # "BT_deepen",
 
     ### Heuristics
     "reason_side_rewarding",
@@ -38,7 +37,6 @@ default = [
     # "platform_wasm"
 ]
 
-BT_deepen = []                   # backtrack drift
 chrono_BT = []                  # NOT WORK
 clause_elimination = []         # pre(in)-processor setting
 clause_vivification = []        # pre(in)-processor setting

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,7 @@
 - Remove feature 'suppress_reason_chain'
 - Remove feature 'trace_equivalency'
 - Remove feature 'two_mode_reduction'
+- Remove feature 'BT_deepen' (replaced by instant reduction)
 - rename feature 'debug_propagation' to 'trace_propagation'
 - Remove src/solver/restart.rs
 

--- a/src/assign/propagate.rs
+++ b/src/assign/propagate.rs
@@ -267,9 +267,9 @@ impl PropagateIF for AssignStack {
 
             unset_assign!(self, vi);
             if let AssignReason::Implication(cid) = self.var[vi].reason {
+                cdb[cid].turn_off(FlagClause::ASSIGN_REASON);
                 let num_learnt: usize = cdb.num_learnt_clauses();
                 let lbd = cdb[cid].lbd;
-                cdb[cid].turn_off(FlagClause::ASSIGN_REASON);
                 if cdb[cid].is(FlagClause::LEARNT)
                     && cdb[cid].referred <= 1
                     && (num_learnt >= 800_000 && lbd > 10

--- a/src/config.rs
+++ b/src/config.rs
@@ -260,8 +260,6 @@ impl Config {
                 "stage-based re-phasing",
                 #[cfg(feature = "trail_saving")]
                 "trail saving",
-                #[cfg(feature = "BT_deepen")]
-                "backtrack-to-deeper-level",
                 #[cfg(feature = "unsafe_access")]
                 "unsafe access",
             ];

--- a/src/solver/conflict.rs
+++ b/src/solver/conflict.rs
@@ -150,6 +150,18 @@ pub fn handle_conflict(
         }
     }
 
+    // Certify the new learnt clause *before* backjumping: `cancel_until` may
+    // instantly drop reason clauses that are no longer locked (see
+    // `PropagateIF::cancel_until`), which are exactly the clauses that
+    // `conflict_analyze` just resolved through to build `new_learnt`. If those
+    // clauses were deleted (and their DRAT `d` line emitted) before this new
+    // clause is added, the RUP/RAT justification for the new clause can lose
+    // its natural witness and become unverifiable. Registering the clause
+    // first (and thus writing its `a` line first) preserves the standard
+    // "certify before you garbage-collect what justified it" invariant.
+    // `new_clause` itself has no dependency on assignment/trail state, so
+    // this reordering doesn't change its behavior.
+    let ref_clause = cdb.new_clause(new_learnt, true);
     asg.cancel_until(cdb, assign_level);
     // debug_assert_eq!(asg.assigned(l0), None);
     // debug_assert_eq!(
@@ -157,7 +169,7 @@ pub fn handle_conflict(
     //     Some(assign_level)
     // );
     let ret: (ClauseId, DecisionLevel);
-    match cdb.new_clause(new_learnt, true) {
+    match ref_clause {
         RefClause::Clause(cid) if learnt_len == 2 => {
             debug_assert_eq!(l0, cdb[cid].lit0());
             debug_assert_eq!(l1, cdb[cid].lit1());

--- a/src/solver/conflict.rs
+++ b/src/solver/conflict.rs
@@ -1,16 +1,12 @@
 //! Conflict Analysis
 
-#[cfg(feature = "trail_saving")]
-use crate::assign::TrailSavingIF;
-
 use {
     super::State,
     crate::{
-        assign::{AssignIF, AssignStack, PropagateIF, VarActivityScheme, VarManipulateIF},
+        assign::{AssignIF, AssignStack, PropagateIF, VarManipulateIF},
         cdb::{ClauseDB, ClauseDBIF},
         types::*,
     },
-    std::collections::HashSet,
 };
 
 /// returns:
@@ -154,51 +150,7 @@ pub fn handle_conflict(
         }
     }
 
-    // learnt clause quality based backtrack strategy switching
-    // Idea: If the learned clause is low quality, don’t trust it to justify a large backjump; use CBT/limited-backjump instead.
-    let bt_drift: Option<bool> = if cfg!(feature = "chrono_BT")
-        && assign_level > 0
-        && asg
-            .len_upto(conflicting_level)
-            .saturating_sub(asg.len_upto(assign_level))
-            >= 40
-    {
-        Some(true)
-    } else if cfg!(feature = "BT_deepen")
-        && asg.activity_scheme != VarActivityScheme::VMTF
-        && assign_level > 0
-        && new_learnt.len() > 2
-        && new_learnt
-            .iter()
-            .map(|l| asg.level(l.vi()))
-            .collect::<HashSet<_>>()
-            .len() as f64
-            >= 2.5 * cdb.lbd.get().max(3.0)
-    {
-        Some(false)
-    } else {
-        None
-    };
-    if let Some(b) = bt_drift {
-        if b {
-            asg.cancel_until(cdb, conflicting_level - 1);
-            state.bt_drift_average.update(1.0);
-        } else {
-            asg.cancel_until(cdb, assign_level - 1);
-            state.bt_drift_average.update(-1.0);
-        }
-        #[cfg(feature = "trail_saving")]
-        {
-            asg.clear_saved_trail();
-        }
-        #[cfg(feature = "chrono_BT")]
-        {
-            state.num_chrono_bt += 1;
-        }
-    } else {
-        asg.cancel_until(cdb, assign_level);
-        state.bt_drift_average.update(0.0);
-    }
+    asg.cancel_until(cdb, assign_level);
     // debug_assert_eq!(asg.assigned(l0), None);
     // debug_assert_eq!(
     //     new_learnt.iter().skip(1).map(|l| asg.level(l.vi())).max(),
@@ -210,19 +162,14 @@ pub fn handle_conflict(
             debug_assert_eq!(l0, cdb[cid].lit0());
             debug_assert_eq!(l1, cdb[cid].lit1());
             debug_assert_eq!(asg.assigned(l0), None);
-            debug_assert!(bt_drift.is_some() || asg.assigned(l1) == Some(false));
 
-            if bt_drift.is_none() {
-                asg.assign_by_implication(l0, AssignReason::BinaryLink(!l1), assign_level);
-            }
+            asg.assign_by_implication(l0, AssignReason::BinaryLink(!l1), assign_level);
             ret = (cid, 1);
         }
         RefClause::Clause(cid) => {
             debug_assert_eq!(cdb[cid].lit0(), l0);
-            if bt_drift.is_none_or(|up1| up1 && cdb[cid].is_unit_under(&*asg)) {
-                asg.assign_by_implication(l0, AssignReason::Implication(cid), assign_level);
-                cdb[cid].turn_on(FlagClause::ASSIGN_REASON);
-            }
+            asg.assign_by_implication(l0, AssignReason::Implication(cid), assign_level);
+            cdb[cid].turn_on(FlagClause::ASSIGN_REASON);
             // lbd should be calculated at conflict level, where all literals are assigned.
             // But since vars hold the last level even after unassignment,
             // we can have postponed the calculation.
@@ -236,7 +183,6 @@ pub fn handle_conflict(
                     || (l0 == cdb[cid].lit1() && l1 == cdb[cid].lit0())
             );
             debug_assert_eq!(asg.assigned(l0), None);
-            debug_assert!(bt_drift.is_some() || asg.assigned(l1) == Some(false));
             // if bt_drift.is_none() && asg.assigned(l1) != Some(false) {
             //     dbg!(cc);
             //     dbg!(asg.decision_level());
@@ -247,9 +193,7 @@ pub fn handle_conflict(
             //     panic!("here we are!");
             // }
             ret = (cid, asg.literal_block_distance_current(&cdb[cid].lits));
-            if bt_drift.is_none_or(|up1| up1 && cdb[cid].is_unit_under(&*asg)) {
-                asg.assign_by_implication(l0, AssignReason::BinaryLink(!l1), assign_level);
-            }
+            asg.assign_by_implication(l0, AssignReason::BinaryLink(!l1), assign_level);
         }
         RefClause::Dead => unreachable!("handle_conflict::RefClause::Dead"),
         RefClause::EmptyClause => unreachable!("handle_conflict::RefClause::EmptyClause"),

--- a/src/state.rs
+++ b/src/state.rs
@@ -117,8 +117,6 @@ pub struct State {
     pub b_lvl: Ema2,
     /// EMA of conflicting levels
     pub c_lvl: Ema2,
-    /// EMA of backtrack level drift caused by chrono_BT or BT_deepen
-    pub bt_drift_average: Ema,
     /// The unreachable core size
     pub core_size: usize,
     /// the last restart in conflicts
@@ -166,7 +164,6 @@ impl Default for State {
             ),
             b_lvl: Ema2::default_extended(),
             c_lvl: Ema2::default_extended(),
-            bt_drift_average: Ema::default().with_span(1000),
             core_size: 0,
             last_restart: 0,
             last_assertion: 0,


### PR DESCRIPTION
```
drat-trim SC2025/918d9e7c2e197312517736421d728958-SCPC-500-1.cnf proof.drat
c parsing input formula with 500 variables and 15462 clauses
c finished parsing
c detected empty clause; start verification via backward checking
c WARNING: RAT check on proof pivot failed : [1371131] 364 280 64 4 65 462 131 148 217 221 250 106 118 299 325 326 437 357 355 388 424 275 45 0
c RAT check failed on all possible pivots
c failed at proof line 1194762 (modulo deletion errors)

s NOT VERIFIED
c verification time: 18.374 seconds
```

----

So for every conflict, the order of events is:

1. `conflict_analyze` resolves the new learnt clause using the reason clauses of vars on the trail above `assign_level` (this includes reading `cdb[cid]` for those exact clauses that are about to be unlocked).
2. `cancel_until` backjumps, unassigning those vars — and *this* is where `00a7b5`'s new code can call `cdb.remove_clause(cid)` on one of those very reason clauses, emitting its `d` line **now**.
3. Only afterwards is the newly learnt clause registered via `cdb.new_clause(...)`, which is when its `a` line is finally written.

That means the proof can contain `d <reason clause D>` *before* `a <new learnt clause C>`, even though `C` was derived by resolving through `D`. `drat-trim` verifies backward, but its RUP/RAT check for `C` only considers the CNF plus whatever hasn't yet been deleted by `C`'s position in the file. If `D` was actually load-bearing for a unit-propagation-based justification of `C` (or of something derived from `C` later), deleting it before `C` is even added removes exactly the clause the checker needs, and the RAT/RUP check can fail — matching "RAT check failed on all possible pivots."

