### PR TITLE
Remove a redundant CNF holder to fix #298

### DIFF
--- a/src/bin/splr.rs
+++ b/src/bin/splr.rs
@@ -237,8 +237,8 @@ fn report(s: &Solver, out: &mut dyn Write) -> std::io::Result<()> {
                 .file_name()
                 .map_or(Cow::from("file with strange chars"), |f| f
                     .to_string_lossy()),
-            state.target.num_of_variables,
-            state.target.num_of_clauses,
+            state.cnf.num_of_variables,
+            state.cnf.num_of_clauses,
         )
         .as_bytes(),
     )?;

--- a/src/solver/build.rs
+++ b/src/solver/build.rs
@@ -316,7 +316,7 @@ impl Solver {
                 Err(e) => panic!("{}", e),
             }
         }
-        debug_assert_eq!(self.asg.num_vars, self.state.target.num_of_variables);
+        debug_assert_eq!(self.asg.num_vars, self.state.cnf.num_of_variables);
         // s.state[Stat::NumBin] = s.cdb.iter().skip(1).filter(|c| c.len() == 2).count();
         Ok(self)
     }
@@ -345,7 +345,7 @@ impl Solver {
                 return Err(SolverError::EmptyClause);
             }
         }
-        debug_assert_eq!(self.asg.num_vars, self.state.target.num_of_variables);
+        debug_assert_eq!(self.asg.num_vars, self.state.cnf.num_of_variables);
         // s.state[Stat::NumBin] = s.cdb.iter().skip(1).filter(|c| c.len() == 2).count();
         Ok(self)
     }

--- a/src/solver/mod.rs
+++ b/src/solver/mod.rs
@@ -10,12 +10,7 @@ mod stage;
 /// Module `validate` implements a model checker.
 mod validate;
 
-pub use self::{
-    build::SatSolverIF,
-    search::SolveIF,
-    stage::StageManager,
-    validate::ValidateIF,
-};
+pub use self::{build::SatSolverIF, search::SolveIF, stage::StageManager, validate::ValidateIF};
 
 use crate::{assign::AssignStack, cdb::ClauseDB, state::*, types::*};
 
@@ -232,5 +227,21 @@ mod tests {
             vec![-3i32],
         );
         sat!(vec![&v1, &v2, &v3, &v4, &v5]); // : Vec<&[i32]>
+    }
+    #[test]
+    fn test_on_issue298() {
+        // let mut s = Solver::default();
+        let mut s = Solver::instantiate(&Config::default(), &CNFDescription::default());
+        for _ in 0..3 {
+            s.add_var();
+        }
+        s.state.cnf.num_of_variables = s.state.target.num_of_variables;
+        // assert_eq!(s.state.cnf.num_of_variables, 3);
+        s.add_clause([1, 2]).unwrap();
+        s.add_clause([1, 3]).unwrap();
+        s.add_clause([2, 3]).unwrap();
+        s.add_clause([-1, -2, -3]).unwrap();
+        s.add_clause([2]).unwrap();
+        assert_eq!(s.solve().unwrap(), Certificate::SAT(vec![1, 2, -3]));
     }
 }

--- a/src/solver/mod.rs
+++ b/src/solver/mod.rs
@@ -235,8 +235,7 @@ mod tests {
         for _ in 0..3 {
             s.add_var();
         }
-        s.state.cnf.num_of_variables = s.state.target.num_of_variables;
-        // assert_eq!(s.state.cnf.num_of_variables, 3);
+        assert_eq!(s.state.cnf.num_of_variables, 3);
         s.add_clause([1, 2]).unwrap();
         s.add_clause([1, 3]).unwrap();
         s.add_clause([2, 3]).unwrap();

--- a/src/state.rs
+++ b/src/state.rs
@@ -99,8 +99,6 @@ pub struct State {
     pub stats: [usize; Stat::EndOfStatIndex as usize],
     /// StageManager
     pub span_manager: StageManager,
-    /// problem description
-    pub target: CNFDescription,
     /// strategy adjustment interval in conflict
     pub reflection_interval: usize,
 
@@ -151,7 +149,6 @@ impl Default for State {
             cnf: CNFDescription::default(),
             stats: [0; Stat::EndOfStatIndex as usize],
             span_manager: StageManager::default(),
-            target: CNFDescription::default(),
             reflection_interval: 10_000,
 
             search_mode_ratio: (
@@ -212,7 +209,6 @@ impl Instantiate for State {
             config: config.clone(),
             cnf: cnf.clone(),
             span_manager: StageManager::new(),
-            target: cnf.clone(),
             time_limit: config.c_timeout,
             progress_report_rows: PROGRESS_REPORT_ROWS
                 + CDB_HEATMAP_ROWS * (config.show_cdb_heatmap as usize),
@@ -222,7 +218,7 @@ impl Instantiate for State {
     fn handle(&mut self, e: SolverEvent) {
         match e {
             SolverEvent::NewVar => {
-                self.target.num_of_variables += 1;
+                self.cnf.num_of_variables += 1;
             }
             SolverEvent::Assert(_) => (),
             SolverEvent::Conflict => (),
@@ -858,13 +854,10 @@ impl State {
 impl fmt::Display for State {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let tm: f64 = (self.start.elapsed().as_millis() as f64) / 1_000.0;
-        let vc = format!(
-            "{},{}",
-            self.target.num_of_variables, self.target.num_of_clauses,
-        );
+        let vc = format!("{},{}", self.cnf.num_of_variables, self.cnf.num_of_clauses,);
         let vclen = vc.len();
         let width = 59;
-        let mut fname = match &self.target.pathname {
+        let mut fname = match &self.cnf.pathname {
             CNFIndicator::Void => "(no cnf)".to_string(),
             CNFIndicator::File(f) => f.to_string(),
             CNFIndicator::LitVec(n) => format!("(embedded {n} element vector)"),


### PR DESCRIPTION
See #298 .

Splr-0.18 and Splr-0.19 have two CNF holders in `State`:
- `cnf`, which was used as the storage for the original CNF.
- `target`, which was introduced as the working place.

By using two holders, we can check the answer's correctness by injecting the assignment to the original clauses. But this plan has been suspended and has not implemented. To fix #298 and keep it simple, I drop the extra holder.